### PR TITLE
💻 번호인증 화면 예외처리(전화번호, 인증번호)

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -18,9 +18,7 @@
 		4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4A1179A72BA9572F00A9CF4C /* Pretendard-Bold.otf */; };
 		4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4A1179A82BA9572F00A9CF4C /* Pretendard-Medium.otf */; };
 		4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4A1179A92BA9572F00A9CF4C /* Pretendard-Light.otf */; };
-
 		4A1179B52BA9C20900A9CF4C /* ErrorCodePopUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1179B42BA9C20900A9CF4C /* ErrorCodePopUpView.swift */; };
-
 		4A6E62D62BA5F7FC00111246 /* NumberVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D52BA5F7FC00111246 /* NumberVerificationView.swift */; };
 		4A6E62D82BA6082100111246 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D72BA6082100111246 /* SignUpView.swift */; };
 		4A762AED2B99A16B001C1188 /* pennyway_client_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762AEC2B99A16B001C1188 /* pennyway_client_iOSApp.swift */; };
@@ -29,15 +27,13 @@
 		4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A762AF32B99A16D001C1188 /* Preview Assets.xcassets */; };
 		4A762B012B99A239001C1188 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B002B99A239001C1188 /* SplashView.swift */; };
 		4A762B032B99A246001C1188 /* model_ex_file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B022B99A246001C1188 /* model_ex_file.swift */; };
-		4A762B052B99A259001C1188 /* viewmodel_ex_file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B042B99A259001C1188 /* viewmodel_ex_file.swift */; };
+		4A762B052B99A259001C1188 /* PhoneNumberVerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B042B99A259001C1188 /* PhoneNumberVerificationViewModel.swift */; };
 		4A762B072B99A262001C1188 /* api_ex_file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B062B99A262001C1188 /* api_ex_file.swift */; };
 		4A762B092B99A26C001C1188 /* TextExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B082B99A26C001C1188 /* TextExtensions.swift */; };
 		4A762B0B2B99A27A001C1188 /* NavigationAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */; };
-
 		D850DF8B2BA9E3AA004FBF67 /* SignUpFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */; };
 		D850DF8D2BA9F1F1004FBF67 /* TermsAndConditionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsView.swift */; };
 		D850DF8F2BAAD70E004FBF67 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */; };
-
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -53,9 +49,7 @@
 		4A1179A82BA9572F00A9CF4C /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		4A1179A92BA9572F00A9CF4C /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		4A1179B32BA958ED00A9CF4C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-
 		4A1179B42BA9C20900A9CF4C /* ErrorCodePopUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodePopUpView.swift; sourceTree = "<group>"; };
-
 		4A6E62D32BA18F9B00111246 /* pennyway-client-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "pennyway-client-iOS.entitlements"; sourceTree = "<group>"; };
 		4A6E62D52BA5F7FC00111246 /* NumberVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberVerificationView.swift; sourceTree = "<group>"; };
 		4A6E62D72BA6082100111246 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -66,15 +60,13 @@
 		4A762AF32B99A16D001C1188 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		4A762B002B99A239001C1188 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		4A762B022B99A246001C1188 /* model_ex_file.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = model_ex_file.swift; sourceTree = "<group>"; };
-		4A762B042B99A259001C1188 /* viewmodel_ex_file.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = viewmodel_ex_file.swift; sourceTree = "<group>"; };
+		4A762B042B99A259001C1188 /* PhoneNumberVerificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberVerificationViewModel.swift; sourceTree = "<group>"; };
 		4A762B062B99A262001C1188 /* api_ex_file.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = api_ex_file.swift; sourceTree = "<group>"; };
 		4A762B082B99A26C001C1188 /* TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExtensions.swift; sourceTree = "<group>"; };
 		4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationAvailable.swift; sourceTree = "<group>"; };
-
 		D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpFormView.swift; sourceTree = "<group>"; };
 		D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsView.swift; sourceTree = "<group>"; };
 		D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
-
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,13 +117,10 @@
 			children = (
 				4A6E62D52BA5F7FC00111246 /* NumberVerificationView.swift */,
 				4A6E62D72BA6082100111246 /* SignUpView.swift */,
-
 				4A1179B42BA9C20900A9CF4C /* ErrorCodePopUpView.swift */,
-
 				D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */,
 				D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsView.swift */,
 				D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */,
-
 			);
 			path = SignUpView;
 			sourceTree = "<group>";
@@ -201,7 +190,7 @@
 		4A762AFC2B99A1CB001C1188 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				4A762B042B99A259001C1188 /* viewmodel_ex_file.swift */,
+				4A762B042B99A259001C1188 /* PhoneNumberVerificationViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -314,15 +303,12 @@
 				4A762AEF2B99A16B001C1188 /* LoginView.swift in Sources */,
 				4A1179A02BA9533D00A9CF4C /* FontExtensions.swift in Sources */,
 				4A762B072B99A262001C1188 /* api_ex_file.swift in Sources */,
-
 				D850DF8B2BA9E3AA004FBF67 /* SignUpFormView.swift in Sources */,
-
 				4A762B092B99A26C001C1188 /* TextExtensions.swift in Sources */,
 				4A762B0B2B99A27A001C1188 /* NavigationAvailable.swift in Sources */,
 				4A762AED2B99A16B001C1188 /* pennyway_client_iOSApp.swift in Sources */,
 				4A6E62D82BA6082100111246 /* SignUpView.swift in Sources */,
-				4A762B052B99A259001C1188 /* viewmodel_ex_file.swift in Sources */,
-	
+				4A762B052B99A259001C1188 /* PhoneNumberVerificationViewModel.swift in Sources */,
 				4A1179B52BA9C20900A9CF4C /* ErrorCodePopUpView.swift in Sources */,
 				D850DF8F2BAAD70E004FBF67 /* WelcomeView.swift in Sources */,
 				D850DF8D2BA9F1F1004FBF67 /* TermsAndConditionsView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView.swift
@@ -1,73 +1,85 @@
 import SwiftUI
 
 struct NumberVerificationView: View {
-    @State private var phoneNumber: String = ""
     @State private var verificationCode: String = ""
-    @State var showErrorPhoneNumber = false
-    @State var showErrorVerificationCode = false
+    @Binding var showErrorVerificationCode: Bool
+    @State var showErrorPhoneNumberFormat = false
+    @State var phoneNumber: String = ""
     
     var body: some View {
         VStack(alignment: .leading) {
-
             Text("번호인증")
                 .font(.pretendard(.semibold, size: 24))
                 .padding(.horizontal,20)
             
             Spacer().frame(height: 32)
             
-            VStack(alignment: .leading, spacing: 11){
-                VStack(alignment: .leading, spacing: 13){
-                    Text("휴대폰 번호")
-                        .padding(.horizontal, 20)
-                        .font(.pretendard(.regular, size: 12))
-                        .platformTextColor(color: Color("Gray04"))
-                    HStack(spacing: 11){
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(Color("Gray01"))
-                                .frame(height: 46)
-                            
-                            TextField("'-' 제외 입력", text: $phoneNumber)
-                                .padding(.leading, 13)
-                                .font(.pretendard(.medium, size: 14))
-                        }
-                        Button(action: {
-                            
-                            showErrorPhoneNumber.toggle()
-                            showErrorVerificationCode.toggle()
-                            
-                        }, label: {
-                            Text("인증번호 받기")
-                                .font(.pretendard(.medium, size: 13))
-                                .platformTextColor(color: phoneNumber.count >= 11 ? Color("White") : Color("Gray04"))
-                        })
-                        .padding(.horizontal, 13)
-                        .frame(height: 46)
-                        .background(phoneNumber.count == 11 ? Color("Gray05"): Color("Gray03"))
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                    }
-                    .padding(.horizontal, 20)
-                }
-                if showErrorPhoneNumber{
-                    Text("존재하지 않는 전화번호예요")
-                        .padding(.horizontal, 20)
-                        .font(.pretendard(.medium, size: 12))
-                        .platformTextColor(color: Color("Red03"))
-                }
-            }
-            
+            phoneNumberInputSection()
+       
             Spacer().frame(height: 21)
             
             VStack(alignment: .leading, spacing: 11){
                 CustomInputView(inputText: $verificationCode, titleText: "인증 번호")
-                if showErrorVerificationCode{
-
+            }
+        }
+    }
+    
+    private func phoneNumberInputSection() -> some View {
+        VStack(alignment: .leading, spacing: 11){
+            VStack(alignment: .leading, spacing: 13){
+                Text("휴대폰 번호")
+                    .padding(.horizontal, 20)
+                    .font(.pretendard(.regular, size: 12))
+                    .platformTextColor(color: Color("Gray04"))
+                HStack(spacing: 11){
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color("Gray01"))
+                            .frame(height: 46)
+                        TextField("'-' 제외 입력", text: $phoneNumber)
+                            .padding(.leading, 13)
+                            .font(.pretendard(.medium, size: 14))
+                            .keyboardType(.numberPad)
+                        
+                            .onChange(of: phoneNumber) { newValue in
+                                if Int(newValue) != nil {
+                                    if newValue.count > 11 {
+                                        phoneNumber = String(newValue.prefix(11))
+                                    }
+                                } else {
+                                    phoneNumber = ""
+                                }
+                            }
+                    }
+                    Button(action: {
+                 
+                        if phoneNumber.prefix(3) != "010" && phoneNumber.prefix(3) != "011" {
+                            showErrorPhoneNumberFormat = true
+                        }
+                        
+                                 
+                    }, label: {
+                        Text("인증번호 받기")
+                            .font(.pretendard(.medium, size: 13))
+                            .platformTextColor(color: phoneNumber.count >= 11 ? Color("White") : Color("Gray04"))
+                    })
+                    .padding(.horizontal, 13)
+                    .frame(height: 46)
+                    .background(phoneNumber.count == 11 ? Color("Gray05"): Color("Gray03"))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
+                .padding(.horizontal, 20)
+            }
+            if showErrorPhoneNumberFormat {
+                Text("존재하지 않는 전화번호예요")
+                    .padding(.horizontal, 20)
+                    .font(.pretendard(.medium, size: 12))
+                    .platformTextColor(color: Color("Red03"))
             }
         }
     }
 }
 
 #Preview {
-    NumberVerificationView()
+    NumberVerificationView(showErrorVerificationCode: .constant(false))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView.swift
@@ -1,11 +1,9 @@
 import SwiftUI
 
 struct NumberVerificationView: View {
+    @StateObject var viewModel = PhoneNumberVerificationViewModel()
     @State private var verificationCode: String = ""
     @Binding var showErrorVerificationCode: Bool
-    @State var showErrorPhoneNumberFormat = false
-    @State var randomVerificationCode = ""
-    @State var phoneNumber: String = ""
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -24,7 +22,7 @@ struct NumberVerificationView: View {
             }
         }
         .onChange(of: verificationCode) { newValue in
-            if newValue == randomVerificationCode {
+            if newValue == viewModel.randomVerificationCode {
                 showErrorVerificationCode = false
             } else {
                 showErrorVerificationCode = true
@@ -44,44 +42,37 @@ struct NumberVerificationView: View {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Color("Gray01"))
                             .frame(height: 46)
-                        TextField("'-' 제외 입력", text: $phoneNumber)
+                        TextField("'-' 제외 입력", text: $viewModel.phoneNumber)
                             .padding(.leading, 13)
                             .font(.pretendard(.medium, size: 14))
                             .keyboardType(.numberPad)
                         
-                            .onChange(of: phoneNumber) { newValue in
+                            .onChange(of: viewModel.phoneNumber) { newValue in
                                 if Int(newValue) != nil {
                                     if newValue.count > 11 {
-                                        phoneNumber = String(newValue.prefix(11))
+                                        viewModel.phoneNumber = String(newValue.prefix(11))
                                     }
                                 } else {
-                                    phoneNumber = ""
+                                    viewModel.phoneNumber = ""
                                 }
                             }
                     }
                     Button(action: {
-                 
-                        if phoneNumber.prefix(3) != "010" && phoneNumber.prefix(3) != "011" {
-                            showErrorPhoneNumberFormat = true
-                        }else{
-                            randomVerificationCode = String(Int.random(in: 100000...999999))
-                            print(randomVerificationCode)
-                        }
-                        
-                                 
+                        viewModel.validatePhoneNumber()
+                        viewModel.generateRandomVerificationCode()
                     }, label: {
                         Text("인증번호 받기")
                             .font(.pretendard(.medium, size: 13))
-                            .platformTextColor(color: phoneNumber.count >= 11 ? Color("White") : Color("Gray04"))
+                            .platformTextColor(color: viewModel.phoneNumber.count >= 11 ? Color("White") : Color("Gray04"))
                     })
                     .padding(.horizontal, 13)
                     .frame(height: 46)
-                    .background(phoneNumber.count == 11 ? Color("Gray05"): Color("Gray03"))
+                    .background(viewModel.phoneNumber.count == 11 ? Color("Gray05"): Color("Gray03"))
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
                 .padding(.horizontal, 20)
             }
-            if showErrorPhoneNumberFormat {
+            if viewModel.showErrorPhoneNumberFormat {
                 Text("존재하지 않는 전화번호예요")
                     .padding(.horizontal, 20)
                     .font(.pretendard(.medium, size: 12))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView.swift
@@ -4,6 +4,7 @@ struct NumberVerificationView: View {
     @State private var verificationCode: String = ""
     @Binding var showErrorVerificationCode: Bool
     @State var showErrorPhoneNumberFormat = false
+    @State var randomVerificationCode = ""
     @State var phoneNumber: String = ""
     
     var body: some View {
@@ -20,6 +21,13 @@ struct NumberVerificationView: View {
             
             VStack(alignment: .leading, spacing: 11){
                 CustomInputView(inputText: $verificationCode, titleText: "인증 번호")
+            }
+        }
+        .onChange(of: verificationCode) { newValue in
+            if newValue == randomVerificationCode {
+                showErrorVerificationCode = false
+            } else {
+                showErrorVerificationCode = true
             }
         }
     }
@@ -55,6 +63,9 @@ struct NumberVerificationView: View {
                  
                         if phoneNumber.prefix(3) != "010" && phoneNumber.prefix(3) != "011" {
                             showErrorPhoneNumberFormat = true
+                        }else{
+                            randomVerificationCode = String(Int.random(in: 100000...999999))
+                            print(randomVerificationCode)
                         }
                         
                                  

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView.swift
@@ -12,6 +12,8 @@ struct SignUpView: View {
     @State private var password: String = ""
     @State private var confirmPw: String = ""
     
+    @State var showErrorVerificationCode = false
+    
     var backButton: some View{
         Button(action: {
             self.presentationMode.wrappedValue.dismiss()
@@ -26,7 +28,7 @@ struct SignUpView: View {
     }
     
     var body: some View {
-
+        
         NavigationAvailable{
             ZStack{
                 VStack(spacing: 14) {
@@ -57,9 +59,9 @@ struct SignUpView: View {
                     }
                     .padding(.horizontal, 20)
                     .frame(height: 20)
-
-                    NumberVerificationView()                 
-
+                    
+                    NumberVerificationView(showErrorVerificationCode: $showErrorVerificationCode)
+                    
                     Spacer()
                     
                     Button(action: {
@@ -78,12 +80,12 @@ struct SignUpView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                     .padding(.horizontal, 20)
                     .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
-                
+                    
                 }
                 
                 if showingPopUp {
                     Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
-                   ErrorCodePopUpView(showingPopUp: $showingPopUp)
+                    ErrorCodePopUpView(showingPopUp: $showingPopUp)
                 }
             }
             
@@ -96,10 +98,11 @@ struct SignUpView: View {
                         .padding(.leading, 5)
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
-                       
+                    
                 }.offset(x: -10)
             }
         }
+    }
 }
 
 #Preview {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/PhoneNumberVerificationViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/PhoneNumberVerificationViewModel.swift
@@ -1,0 +1,23 @@
+
+import SwiftUI
+
+class PhoneNumberVerificationViewModel: ObservableObject {
+    @Published var phoneNumber: String = ""
+    @Published var showErrorPhoneNumberFormat = false
+    @Published var randomVerificationCode = ""
+    
+    func generateRandomVerificationCode() {
+        if !showErrorPhoneNumberFormat{
+            randomVerificationCode = String(Int.random(in: 100000...999999))
+            print(randomVerificationCode)
+        }
+    }
+    
+    func validatePhoneNumber() {
+        if phoneNumber.prefix(3) != "010" && phoneNumber.prefix(3) != "011" {
+            showErrorPhoneNumberFormat = true
+        }else{
+            showErrorPhoneNumberFormat = false
+        }
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/viewmodel_ex_file.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/viewmodel_ex_file.swift
@@ -1,8 +1,0 @@
-//
-//  ex_file.swift
-//  pennyway-client-iOS
-//
-//  Created by 최희진 on 3/7/24.
-//
-
-import Foundation


### PR DESCRIPTION
## 작업 이유

- 전화번호 포맷 확인
- 인증번호 확인
- 로직 ViewModel로 처리 + View 섹션 분리
- View 섹션 분리

<br/>

## 작업 사항

### 1️⃣ 전화번호 포맷 확인

- PhoneNumberVerificationViewModel로 로직을 분리해서 사용하였다.
- 11자리 정수 문자열 + 앞 3자리 ["010", "011"]으로 제한
- `showErrorPhoneNumberFormat: Bool`으로 포맷 오류 문구 표시 여부 결정

<img width="345" alt="스크린샷 2024-03-22 오후 11 19 14" src="https://github.com/CollaBu/pennyway-client-ios/assets/103185302/54cd9f2a-4817-4672-bf4d-b19fde6cc549">


<br/>

<br/>

- 앞 3자리 포맷 확인

 ```swift
func validatePhoneNumber() {
    if phoneNumber.prefix(3) != "010" && phoneNumber.prefix(3) != "011" {
        showErrorPhoneNumberFormat = true
    }else{
        showErrorPhoneNumberFormat = false
    }
}
```

### 2️⃣ 인증번호 확인
- `randomVerificationCode` 임시 랜덤 인증코드 생성
- `showErrorVerificationCode: Bool `으로 인증번호 확인 여부 판단

<br/>

- 랜덤 인증번호 생성

```swift
func generateRandomVerificationCode() {
    if !showErrorPhoneNumberFormat{
        randomVerificationCode = String(Int.random(in: 100000...999999))
        print(randomVerificationCode)
    }
}
```

- 입력한 인증번호가 randomVerificationCode와 같은 지 판단

``` swift
.onChange(of: verificationCode) { newValue in
    if newValue == viewModel.randomVerificationCode {
        showErrorVerificationCode = false
    } else {
        showErrorVerificationCode = true
    }
}
```

### 3️⃣ 로직 ViewModel로 처리 + View 섹션 분리

- 이전에는 NumberVerificationView body안에 모든 ui 관련 코드와 상태 관리 로직이 있어서 가독성이 너무 안 좋았다. 그래서 다음과 같이 해결했다.
- 상태 관리 로직은 => ViewModel
- ui 관련 코드 => 섹션 분리

<br/>

<br/>

- 폰 번호 입력 화면을 phoneNumberInputSection으로 나누어서 가독성 향상과 유지보수에 유리하도록 함

```swift
struct NumberVerificationView: View {
    ...
    
    var body: some View {
        VStack(alignment: .leading) {
            Text("번호인증")
                .font(.pretendard(.semibold, size: 24))
                .padding(.horizontal,20)
            
            Spacer().frame(height: 32)
            
            phoneNumberInputSection()
       
            Spacer().frame(height: 21)
            
            VStack(alignment: .leading, spacing: 11){
                CustomInputView(inputText: $verificationCode, titleText: "인증 번호")
            }
        }
       ...
    }
    
    private func phoneNumberInputSection() -> some View {
        ...
    }
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

예외처리한 부분은 1️⃣, 2️⃣ 번 읽어보시면 됩니다.
3️⃣처럼 추후 예외처리할 때 상태관리에 대한 로직은 ViewModel에서 관리하고, ui 로직은 최대한 가독성 좋도록 섹션별로 분리해서 작성하시면 좋을 것 같습니다.


<br/>

## 발견한 이슈
- 번호 인증번호 받기 횟수 제한
- 번호 인증번호 받기 버튼 비활성화
- 인증번호 입력 패드 숫자로

처리 필요