### PR TITLE
💻📍 Button/Navigation 로직 모듈화 + UI 오류 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		4A4A56742BACA4000071D00E /* NavigationCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A56732BACA4000071D00E /* NavigationCountView.swift */; };
 		4A4A56782BACADBF0071D00E /* TermsAndConditionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A56772BACADBF0071D00E /* TermsAndConditionsView.swift */; };
 		4A4A567A2BADEFF90071D00E /* NavigationBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A56792BADEFF90071D00E /* NavigationBackButton.swift */; };
+		4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */; };
 		4A6E62D62BA5F7FC00111246 /* NumberVerificationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D52BA5F7FC00111246 /* NumberVerificationContentView.swift */; };
 		4A6E62D82BA6082100111246 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D72BA6082100111246 /* SignUpView.swift */; };
 		4A762AED2B99A16B001C1188 /* pennyway_client_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762AEC2B99A16B001C1188 /* pennyway_client_iOSApp.swift */; };
@@ -58,6 +59,7 @@
 		4A4A56732BACA4000071D00E /* NavigationCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCountView.swift; sourceTree = "<group>"; };
 		4A4A56772BACADBF0071D00E /* TermsAndConditionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsView.swift; sourceTree = "<group>"; };
 		4A4A56792BADEFF90071D00E /* NavigationBackButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBackButton.swift; sourceTree = "<group>"; };
+		4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomButton.swift; sourceTree = "<group>"; };
 		4A6E62D32BA18F9B00111246 /* pennyway-client-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "pennyway-client-iOS.entitlements"; sourceTree = "<group>"; };
 		4A6E62D52BA5F7FC00111246 /* NumberVerificationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberVerificationContentView.swift; sourceTree = "<group>"; };
 		4A6E62D72BA6082100111246 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				4A11797F2BA86AF400A9CF4C /* CustomInputView.swift */,
+				4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */,
 			);
 			path = CustomView;
 			sourceTree = "<group>";
@@ -357,6 +360,7 @@
 				4A1179B52BA9C20900A9CF4C /* ErrorCodePopUpView.swift in Sources */,
 				D850DF8F2BAAD70E004FBF67 /* WelcomeView.swift in Sources */,
 				D850DF8D2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift in Sources */,
+				4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */,
 				4A4A56782BACADBF0071D00E /* TermsAndConditionsView.swift in Sources */,
 				4A6E62D62BA5F7FC00111246 /* NumberVerificationContentView.swift in Sources */,
 				4A762B012B99A239001C1188 /* SplashView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		4A4A56782BACADBF0071D00E /* TermsAndConditionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A56772BACADBF0071D00E /* TermsAndConditionsView.swift */; };
 		4A4A567A2BADEFF90071D00E /* NavigationBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A56792BADEFF90071D00E /* NavigationBackButton.swift */; };
 		4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */; };
+		4A51D2AE2BB18EBC0080083D /* SignUpNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A51D2AD2BB18EBC0080083D /* SignUpNavigationViewModel.swift */; };
 		4A6E62D62BA5F7FC00111246 /* NumberVerificationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D52BA5F7FC00111246 /* NumberVerificationContentView.swift */; };
 		4A6E62D82BA6082100111246 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D72BA6082100111246 /* SignUpView.swift */; };
 		4A762AED2B99A16B001C1188 /* pennyway_client_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762AEC2B99A16B001C1188 /* pennyway_client_iOSApp.swift */; };
@@ -60,6 +61,7 @@
 		4A4A56772BACADBF0071D00E /* TermsAndConditionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsView.swift; sourceTree = "<group>"; };
 		4A4A56792BADEFF90071D00E /* NavigationBackButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBackButton.swift; sourceTree = "<group>"; };
 		4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomButton.swift; sourceTree = "<group>"; };
+		4A51D2AD2BB18EBC0080083D /* SignUpNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpNavigationViewModel.swift; sourceTree = "<group>"; };
 		4A6E62D32BA18F9B00111246 /* pennyway-client-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "pennyway-client-iOS.entitlements"; sourceTree = "<group>"; };
 		4A6E62D52BA5F7FC00111246 /* NumberVerificationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberVerificationContentView.swift; sourceTree = "<group>"; };
 		4A6E62D72BA6082100111246 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 			isa = PBXGroup;
 			children = (
 				4A762B042B99A259001C1188 /* NumberVerificationViewModel.swift */,
+				4A51D2AD2BB18EBC0080083D /* SignUpNavigationViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -348,6 +351,7 @@
 			files = (
 				4A4A56742BACA4000071D00E /* NavigationCountView.swift in Sources */,
 				4A762B032B99A246001C1188 /* model_ex_file.swift in Sources */,
+				4A51D2AE2BB18EBC0080083D /* SignUpNavigationViewModel.swift in Sources */,
 				4A762AEF2B99A16B001C1188 /* LoginView.swift in Sources */,
 				4A1179A02BA9533D00A9CF4C /* FontExtensions.swift in Sources */,
 				4A762B072B99A262001C1188 /* api_ex_file.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomBottomButton.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomBottomButton.swift
@@ -1,0 +1,22 @@
+
+import SwiftUI
+
+struct CustomBottomButton: View {
+    let action: () -> Void
+    let label: String
+    
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.pretendard(.semibold, size: 14))
+                .platformTextColor(color: Color("Gray04"))
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 17)
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color("Gray03"))
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .padding(.horizontal, 20)
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
@@ -10,22 +10,22 @@ struct NavigationCountView: View {
             LazyHGrid(rows: [GridItem(.flexible())]) {
                 Text("1")
                     .padding(6)
-                    .background(selectedText == 1 ? Color("Gray06") : Color("Gray03"))
-                    .platformTextColor(color: selectedText == 1 ? Color("White") : Color("Gray04"))
+                    .background(selectedText! >= 1 ? Color("Gray06") : Color("Gray03"))
+                    .platformTextColor(color: selectedText! >= 1 ? Color("White") : Color("Gray04"))
                     .clipShape(Circle())
                     .font(.pretendard(.medium, size: 12))
                 
                 Text("2")
                     .padding(6)
-                    .background(selectedText == 2 ? Color("Gray06") : Color("Gray03"))
-                    .platformTextColor(color: selectedText == 2 ? Color("White") : Color("Gray04"))
+                    .background(selectedText! >= 2 ? Color("Gray06") : Color("Gray03"))
+                    .platformTextColor(color: selectedText! >= 2 ? Color("White") : Color("Gray04"))
                     .clipShape(Circle())
                     .font(.pretendard(.medium, size: 12))
                 
                 Text("3")
                     .padding(6)
-                    .background(selectedText == 3 ? Color("Gray06") : Color("Gray03"))
-                    .platformTextColor(color: selectedText == 3 ? Color("White") : Color("Gray04"))
+                    .background(selectedText! >= 3 ? Color("Gray06") : Color("Gray03"))
+                    .platformTextColor(color: selectedText! >= 3 ? Color("White") : Color("Gray04"))
                     .clipShape(Circle())
                     .font(.pretendard(.medium, size: 12))
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView/NumberVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView/NumberVerificationView.swift
@@ -7,7 +7,7 @@ struct NumberVerificationView: View {
     @State private var verificationCode: String = ""
     @State private var showingPopUp = false
     @State var showErrorVerificationCode = true
-    @State private var selectedText: Int? = 1
+    @StateObject var viewModel = SignUpNavigationViewModel()
     
     var body: some View {
         NavigationAvailable {
@@ -15,9 +15,9 @@ struct NumberVerificationView: View {
                 VStack{
                     Spacer().frame(height: 15)
                     
-                    NavigationCountView(selectedText: $selectedText) 
+                    NavigationCountView(selectedText: $viewModel.selectedText)
                         .onAppear {
-                            selectedText = 1
+                            viewModel.selectedText = 1
                         }
                     
                     Spacer().frame(height: 14)
@@ -29,20 +29,17 @@ struct NumberVerificationView: View {
                     CustomBottomButton(action: {
                         if !showErrorVerificationCode {
                             showingPopUp = false
-                            selectedText = 2
+                            viewModel.continueButtonTapped()
                         } else {
                             showingPopUp = true
                         }
                     }, label: "계속하기")
                     .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
-                    .border(Color.black)
                     
-                    
-                    NavigationLink(destination: SignUpView(), tag: 2, selection: $selectedText) {
+                    NavigationLink(destination: SignUpView(viewModel: viewModel), tag: 2, selection: $viewModel.selectedText) {
                         EmptyView()
                     }
                 }
-               
                 
                 if showingPopUp {
                     Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
@@ -50,7 +47,6 @@ struct NumberVerificationView: View {
                 }
                     
             }
-            .border(.red)
             .navigationBarBackButtonHidden(true)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView/NumberVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView/NumberVerificationView.swift
@@ -12,13 +12,15 @@ struct NumberVerificationView: View {
     var body: some View {
         NavigationAvailable {
             ZStack{
-                VStack(spacing: 14) {
-                    Spacer().frame(height: 10)
+                VStack{
+                    Spacer().frame(height: 15)
                     
                     NavigationCountView(selectedText: $selectedText) 
                         .onAppear {
                             selectedText = 1
                         }
+                    
+                    Spacer().frame(height: 14)
                     
                     NumberVerificationContentView(showErrorVerificationCode: $showErrorVerificationCode)
                     

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView/NumberVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/NumberVerificationView/NumberVerificationView.swift
@@ -24,37 +24,31 @@ struct NumberVerificationView: View {
                     
                     Spacer()
                     
-                    Button(action: {
+                    CustomBottomButton(action: {
                         if !showErrorVerificationCode {
                             showingPopUp = false
                             selectedText = 2
                         } else {
                             showingPopUp = true
                         }
-                    }, label: {
-                        Text("계속하기")
-                            .font(.pretendard(.semibold, size: 14))
-                            .platformTextColor(color: Color("Gray04"))
-                            .frame(maxWidth: .infinity)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 17)
-                    })
-                    .frame(maxWidth: .infinity)
-                    .background(Color("Gray02"))
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-                    .padding(.horizontal, 20)
+                    }, label: "계속하기")
                     .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
+                    .border(Color.black)
+                    
                     
                     NavigationLink(destination: SignUpView(), tag: 2, selection: $selectedText) {
                         EmptyView()
                     }
                 }
+               
                 
                 if showingPopUp {
                     Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
                     ErrorCodePopUpView(showingPopUp: $showingPopUp)
                 }
+                    
             }
+            .border(.red)
             .navigationBarBackButtonHidden(true)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
@@ -14,13 +14,15 @@ struct SignUpView: View {
     
     var body: some View {
         ZStack{
-            VStack(spacing: 14) {
-                Spacer().frame(height: 10)
+            VStack {
+                Spacer().frame(height: 15)
                 
                 NavigationCountView(selectedText: $selectedText)
                     .onAppear {
                         selectedText = 2
                     }
+                
+                Spacer().frame(height: 14)
                 
                 SignUpFormView(name: $name, id: $id, password: $password, confirmPw: $confirmPw)
                 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
@@ -26,20 +26,9 @@ struct SignUpView: View {
                 
                 Spacer()
                 
-                Button(action: {
+                CustomBottomButton(action: {
                     selectedText = 3
-                }, label: {
-                    Text("계속하기")
-                        .font(.pretendard(.semibold, size: 14))
-                        .platformTextColor(color: Color("Gray04"))
-                        .frame(maxWidth: .infinity)
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 17)
-                })
-                .frame(maxWidth: .infinity)
-                .background(Color("Gray02"))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .padding(.horizontal, 20)
+                }, label: "계속하기")
                 .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
                 
                 NavigationLink(destination: TermsAndConditionsView(), tag: 3, selection: $selectedText) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
@@ -9,17 +9,17 @@ struct SignUpView: View {
     @State private var id: String = ""
     @State private var password: String = ""
     @State private var confirmPw: String = ""
-    
-    @State private var selectedText: Int? = 2
+
+    @ObservedObject var viewModel: SignUpNavigationViewModel
     
     var body: some View {
         ZStack{
             VStack {
                 Spacer().frame(height: 15)
                 
-                NavigationCountView(selectedText: $selectedText)
+                NavigationCountView(selectedText: $viewModel.selectedText)
                     .onAppear {
-                        selectedText = 2
+                        viewModel.selectedText = 2
                     }
                 
                 Spacer().frame(height: 14)
@@ -29,11 +29,11 @@ struct SignUpView: View {
                 Spacer()
                 
                 CustomBottomButton(action: {
-                    selectedText = 3
+                    viewModel.continueButtonTapped()
                 }, label: "계속하기")
                 .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
                 
-                NavigationLink(destination: TermsAndConditionsView(), tag: 3, selection: $selectedText) {
+                NavigationLink(destination: TermsAndConditionsView(viewModel: viewModel), tag: 3, selection: $viewModel.selectedText) {
                     EmptyView()
                 }
             }
@@ -55,5 +55,5 @@ struct SignUpView: View {
 }
 
 #Preview {
-    SignUpView()
+    SignUpView(viewModel: SignUpNavigationViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
@@ -38,11 +38,11 @@ struct TermsAndConditionsContentView: View {
                                     .renderingMode(.template)
                                     .resizable()
                                     .frame(width: 24, height: 24)
-                                    .platformTextColor(color: isSelectedAllBtn ? Color.white : Color("Gray04"))
+                                    .platformTextColor(color: isSelectedAllBtn ? Color("White"): Color("Gray04"))
                                     .padding(.horizontal,10)
                                 Text("모두 동의할게요")
                                     .font(.pretendard(.medium, size: 14))
-                                    .platformTextColor(color: isSelectedAllBtn ? Color.white : Color("Gray04"))
+                                    .platformTextColor(color: isSelectedAllBtn ? Color("White") : Color("Gray04"))
                                     .padding(.horizontal,36)
                                 
                             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
@@ -5,7 +5,6 @@ struct TermsAndConditionsContentView: View {
     @State private var isSelectedUseBtn: Bool = false
     @State private var isSelectedInfoBtn: Bool = false
     
-    
     var body: some View {
         VStack(alignment: .leading) {
             
@@ -148,5 +147,5 @@ struct TermsAndConditionsContentView: View {
 
 
 #Preview {
-    TermsAndConditionsView()
+    TermsAndConditionsView(viewModel: SignUpNavigationViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsView.swift
@@ -22,27 +22,18 @@ struct TermsAndConditionsView: View {
                 
                 Spacer()
                 
-                Button(action: {
+                CustomBottomButton(action: {
                     selectedText = 4
-                }, label: {
-                    Text("계속하기")
-                        .font(.pretendard(.semibold, size: 14))
-                        .platformTextColor(color: Color("Gray04"))
-                        .frame(maxWidth: .infinity)
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 17)
-                })
-                .frame(maxWidth: .infinity)
-                .background(Color("Gray02"))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .padding(.horizontal, 20)
+                }, label: "계속하기")
                 .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
-                
+                .border(Color.black)
+
                 NavigationLink(destination: WelcomeView(), tag: 4, selection: $selectedText) {
                     EmptyView()
                 }
                 
             }
+            .border(Color.black)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsView.swift
@@ -10,13 +10,15 @@ struct TermsAndConditionsView: View {
    
     var body: some View {
         ZStack{
-            VStack(spacing: 14) {
-                Spacer().frame(height: 10)
+            VStack {
+                Spacer().frame(height: 15)
                 
                 NavigationCountView(selectedText: $selectedText)
                     .onAppear {
                         selectedText = 3
                     }
+                
+                Spacer().frame(height: 14)
                 
                 TermsAndConditionsContentView()
                 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsView.swift
@@ -6,16 +6,16 @@ struct TermsAndConditionsView: View {
     
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     
-    @State private var selectedText: Int? = 3
+    @ObservedObject var viewModel: SignUpNavigationViewModel
    
     var body: some View {
         ZStack{
             VStack {
                 Spacer().frame(height: 15)
                 
-                NavigationCountView(selectedText: $selectedText)
+                NavigationCountView(selectedText: $viewModel.selectedText)
                     .onAppear {
-                        selectedText = 3
+                        viewModel.selectedText = 3
                     }
                 
                 Spacer().frame(height: 14)
@@ -25,17 +25,15 @@ struct TermsAndConditionsView: View {
                 Spacer()
                 
                 CustomBottomButton(action: {
-                    selectedText = 4
+                    viewModel.continueButtonTapped()
                 }, label: "계속하기")
                 .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
-                .border(Color.black)
 
-                NavigationLink(destination: WelcomeView(), tag: 4, selection: $selectedText) {
+                NavigationLink(destination: WelcomeView(), tag: 4, selection: $viewModel.selectedText) {
                     EmptyView()
                 }
                 
             }
-            .border(Color.black)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -53,5 +51,5 @@ struct TermsAndConditionsView: View {
 }
 
 #Preview {
-    TermsAndConditionsView()
+    TermsAndConditionsView(viewModel: SignUpNavigationViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/WelcomeView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/WelcomeView.swift
@@ -8,7 +8,7 @@ struct WelcomeView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity, maxHeight: 160)
-                    .padding(.top, 71)//수정
+                    .padding(.top, 71)
                     .padding(.horizontal, 80)
                     .padding(.bottom, 20)
                 
@@ -21,25 +21,15 @@ struct WelcomeView: View {
                     .font(.pretendard(.medium, size: 14))
                     .platformTextColor(color: Color("Gray04"))
                 
-                Spacer()//수정
+                Spacer()
                 
-                Button(action: {
+                CustomBottomButton(action: {
                     
-                }, label: {
-                    ZStack{
-                        Rectangle()
-                            .frame(maxWidth: .infinity, maxHeight: 47)
-                            .platformTextColor(color: Color("Mint03"))
-                            .cornerRadius(4)
-                            .padding(.horizontal, 20)
-                        
-                        Text("확인")
-                            .font(.pretendard(.semibold, size: 14))
-                            .platformTextColor(color: .white)
-                    }
-                })
+                }, label: "확인")
                 .padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
+                .border(Color.black)
             }
+            .border(Color.black)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SignUpNavigationViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SignUpNavigationViewModel.swift
@@ -1,0 +1,12 @@
+
+import Foundation
+
+class SignUpNavigationViewModel: ObservableObject {
+    @Published var selectedText: Int? = 1 // 초기 값은 1으로 설정
+    
+    func continueButtonTapped() {
+        if let selectedText = selectedText {
+            self.selectedText = selectedText + 1
+        }
+    }
+}


### PR DESCRIPTION
## 작업 이유

- bottom button 모듈화
- View padding 오류 해결
- SignUp Navigation ViewModel로 인스턴스 공유
- 화면 이동에 따른 NavigationCountView Color오류 수정

<br/>

## 작업 사항

### 1️⃣  bottom button 모듈화
- CustomBottomButton으로 모듈화

```swift
struct CustomBottomButton: View {
    let action: () -> Void
    let label: String
    
    var body: some View {
        Button(action: action) {
            Text(label)
                .font(.pretendard(.semibold, size: 14))
                .platformTextColor(color: Color("Gray04"))
                .frame(maxWidth: .infinity)
                .padding(.horizontal, 20)
                .padding(.vertical, 17)
        }
        .frame(maxWidth: .infinity)
        .background(Color("Gray03"))
        .clipShape(RoundedRectangle(cornerRadius: 4))
        .padding(.horizontal, 20)
    }
}

```
<br/>

-사용방법
: CustomBottomButton으로 작성하고 일반 버튼처럼 action, label 적어주면 된다.

```swift
 CustomBottomButton(action: {
    if !showErrorVerificationCode {
        showingPopUp = false
        viewModel.continueButtonTapped()
    } else {
        showingPopUp = true
    }
}, label: "계속하기")
.padding(.bottom, (UIApplication.shared.windows.first?.safeAreaInsets.bottom)! + 34)
```
<br/>

### 2️⃣ View padding 오류 해결
- bottom button 하단에 padding 값이 남는 오류

<img src = "https://github.com/CollaBu/pennyway-client-ios/assets/103185302/049f0a2a-4c14-4fe0-88f7-fa8254f4ca09" width = "350" />

<br/>

- VStack안의 요소들에 14 간격을 주려고 했는데 이게 하단 버튼의 아래에도 간격을 넣어준 문제가 있었다.

``` swift
ZStack{
    VStack(spacing: 14){
      ...
    }                 
}
```
<br/>

- 그래서 `spacing: 14`를 삭제하고 `Spacer().frame(height: 14)`로 변경하니 해결

<img src = "https://github.com/CollaBu/pennyway-client-ios/assets/103185302/e38f9d0c-2306-43ed-8124-1d09c461db79" width = "350" />

<br/>

### 3️⃣ SignUp Navigation ViewModel로 인스턴스 공유

- SignUpNavigationViewModel로 selectedText를 공유

<br/>

-  첫 번째 View인 NumberVerificationView에서 ViewModel을 생성하고 @StateObject로 ViewModel을 유지하도록 설정한다.
`@StateObject var viewModel = SignUpNavigationViewModel()`

<br/>

- 그 다음 SignUpView에 viewModel을 직접 전달한다.

``` swift
NavigationLink(destination: SignUpView(viewModel: viewModel), tag: 2, selection: $viewModel.selectedText) {
    EmptyView()
}
```

<br/>

- SignUpView에서는 ObservedObject로 viewModel 값 관찰/변경 처리

`@ObservedObject var viewModel: SignUpNavigationViewModel`

- 다음 화면에서도 같은 로직 적용

<br/>

### 4️⃣ 화면 이동에 따른 NavigationCountView Color오류 수정

- 아래와 같이 화면 이동에 따른 Color 오류 수정
<img width="78" alt="스크린샷 2024-03-25 오후 9 00 54" src="https://github.com/CollaBu/pennyway-client-ios/assets/103185302/c3973551-d376-4973-8eea-bad0654c8a96">

<br/>

- selectedText값이 2인 경우 Text("1")도` >= `1 로 Color 변경되도록 함

```swift
Text("1")
      .padding(6)
      .background(selectedText! >= 1 ? Color("Gray06") : Color("Gray03"))
      .platformTextColor(color: selectedText! >= 1 ? Color("White") : Color("Gray04"))
      .clipShape(Circle())
      .font(.pretendard(.medium, size: 12))
```


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

저번에 말씀해주셨던 모듈화 부분 1️⃣, 3️⃣ 확인해주시면 됩니다.
그리고 2️⃣는 이번에 하위 버튼 모듈화하다가 간격 오류가 있어서 고쳤고 확인해주시면 됩니다.

<br/>

## 발견한 이슈
2️⃣ View padding 오류 해결
