### PR TITLE
📍 TermsAndConditionsView 동의 버튼 오류 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4A762B092B99A26C001C1188 /* TextExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B082B99A26C001C1188 /* TextExtensions.swift */; };
 		4A762B0B2B99A27A001C1188 /* NavigationAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */; };
 		D80E6A0D2BB1D549009F2DFE /* SignUpFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E6A0C2BB1D549009F2DFE /* SignUpFormViewModel.swift */; };
+		D80E6A0F2BB2A7F5009F2DFE /* AgreementSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */; };
 		D850DF8B2BA9E3AA004FBF67 /* SignUpFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */; };
 		D850DF8D2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift */; };
 		D850DF8F2BAAD70E004FBF67 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */; };
@@ -78,6 +79,7 @@
 		4A762B082B99A26C001C1188 /* TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExtensions.swift; sourceTree = "<group>"; };
 		4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationAvailable.swift; sourceTree = "<group>"; };
 		D80E6A0C2BB1D549009F2DFE /* SignUpFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignUpFormViewModel.swift; path = ../View/SignUpView/SignUpView/SignUpFormViewModel.swift; sourceTree = "<group>"; };
+		D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementSectionView.swift; sourceTree = "<group>"; };
 		D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpFormView.swift; sourceTree = "<group>"; };
 		D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsContentView.swift; sourceTree = "<group>"; };
 		D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 			children = (
 				4A4A56772BACADBF0071D00E /* TermsAndConditionsView.swift */,
 				D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift */,
+				D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */,
 			);
 			path = TermsAndConditionsView;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				4A6E62D62BA5F7FC00111246 /* NumberVerificationContentView.swift in Sources */,
 				4A762B012B99A239001C1188 /* SplashView.swift in Sources */,
 				4A4A56722BACA2250071D00E /* NumberVerificationView.swift in Sources */,
+				D80E6A0F2BB2A7F5009F2DFE /* AgreementSectionView.swift in Sources */,
 				4A4A567A2BADEFF90071D00E /* NavigationBackButton.swift in Sources */,
 				4A1179802BA86AF400A9CF4C /* CustomInputView.swift in Sources */,
 			);

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		4A762B072B99A262001C1188 /* api_ex_file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B062B99A262001C1188 /* api_ex_file.swift */; };
 		4A762B092B99A26C001C1188 /* TextExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B082B99A26C001C1188 /* TextExtensions.swift */; };
 		4A762B0B2B99A27A001C1188 /* NavigationAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */; };
+		D80E6A0D2BB1D549009F2DFE /* SignUpFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E6A0C2BB1D549009F2DFE /* SignUpFormViewModel.swift */; };
 		D850DF8B2BA9E3AA004FBF67 /* SignUpFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */; };
 		D850DF8D2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift */; };
 		D850DF8F2BAAD70E004FBF67 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */; };
@@ -76,6 +77,7 @@
 		4A762B062B99A262001C1188 /* api_ex_file.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = api_ex_file.swift; sourceTree = "<group>"; };
 		4A762B082B99A26C001C1188 /* TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExtensions.swift; sourceTree = "<group>"; };
 		4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationAvailable.swift; sourceTree = "<group>"; };
+		D80E6A0C2BB1D549009F2DFE /* SignUpFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignUpFormViewModel.swift; path = ../View/SignUpView/SignUpView/SignUpFormViewModel.swift; sourceTree = "<group>"; };
 		D850DF8A2BA9E3AA004FBF67 /* SignUpFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpFormView.swift; sourceTree = "<group>"; };
 		D850DF8C2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsContentView.swift; sourceTree = "<group>"; };
 		D850DF8E2BAAD70D004FBF67 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 		4A762AFC2B99A1CB001C1188 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				D80E6A0C2BB1D549009F2DFE /* SignUpFormViewModel.swift */,
 				4A762B042B99A259001C1188 /* NumberVerificationViewModel.swift */,
 				4A51D2AD2BB18EBC0080083D /* SignUpNavigationViewModel.swift */,
 			);
@@ -366,6 +369,7 @@
 				D850DF8D2BA9F1F1004FBF67 /* TermsAndConditionsContentView.swift in Sources */,
 				4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */,
 				4A4A56782BACADBF0071D00E /* TermsAndConditionsView.swift in Sources */,
+				D80E6A0D2BB1D549009F2DFE /* SignUpFormViewModel.swift in Sources */,
 				4A6E62D62BA5F7FC00111246 /* NumberVerificationContentView.swift in Sources */,
 				4A762B012B99A239001C1188 /* SplashView.swift in Sources */,
 				4A4A56722BACA2250071D00E /* NumberVerificationView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct CustomInputView: View {
     @Binding var inputText: String
     @State var titleText: String?
+    var onCommit: (() -> Void)?
     
     var body: some View {
         VStack(alignment: .leading, spacing: 13) {
@@ -20,7 +21,9 @@ struct CustomInputView: View {
                         .fill(Color("Gray01"))
                         .frame(height: 46)
                     
-                    TextField("", text: $inputText)
+                    TextField("", text: $inputText, onCommit: {
+                        onCommit?()
+                    })
                         .padding(.leading, 13)
                         .padding(.vertical, 16)
                         .font(.pretendard(.medium, size: 14))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormView.swift
@@ -1,12 +1,13 @@
 import SwiftUI
 
 struct SignUpFormView: View {
-    @Binding var name: String
-    @Binding var id: String
-    @Binding var password: String
-    @Binding var confirmPw: String
-    @State var showErrorName = false
+//    @Binding var name: String
+//    @Binding var id: String
+//    @Binding var password: String
+//    @Binding var confirmPw: String
+//    @State var showErrorName = false
     
+    @StateObject private var viewModel = SignUpFormViewModel()
     
     var body: some View {
         VStack(alignment: .leading){
@@ -19,16 +20,58 @@ struct SignUpFormView: View {
             ScrollView() {
                 VStack(alignment: .leading) {
                     VStack(alignment: .leading, spacing: 21){
-                        CustomInputView(inputText: $name, titleText: "이름")
-                        if showErrorName{
-                            Text("입력 포멧 관련 문구")
-                            .padding(.horizontal, 20)
-                            .font(.pretendard(.medium, size: 12))
-                            .platformTextColor(color: Color("Red03"))
+                        VStack(alignment:.leading, spacing: 9) {
+                            CustomInputView(inputText: $viewModel.name, titleText: "이름", onCommit: {
+                                viewModel.validateName()
+                            })
+
+                                if viewModel.showErrorName{
+                                    Text("입력 포멧 관련 문구")
+                                    .padding(.leading, 20)
+                                    .font(.pretendard(.medium, size: 12))
+                                    .platformTextColor(color: Color("Red03"))
+                                }
                         }
-                        CustomInputView(inputText: $id, titleText: "아이디")
-                        CustomInputView(inputText: $password, titleText: "비밀번호")
-                        CustomInputView(inputText: $confirmPw, titleText: "비밀번호 확인")
+                        
+                        VStack(alignment:.leading, spacing: 9) {
+                            CustomInputView(inputText: $viewModel.id, titleText: "아이디", onCommit: {
+                                viewModel.validateID()
+                            })
+
+                            if viewModel.showErrorID{
+                                Text("입력 포멧 관련 문구")
+                                .padding(.leading, 20)
+                                .font(.pretendard(.medium, size: 12))
+                                .platformTextColor(color: Color("Red03"))
+                            }
+                        }
+                        
+                        VStack(alignment:.leading, spacing:9) {
+                            CustomInputView(inputText: $viewModel.password, titleText: "비밀번호", onCommit: {
+                                viewModel.validatePassword()
+                            })
+
+                            if viewModel.showErrorPassword{
+                                Text("입력 포멧 관련 문구")
+                                .padding(.leading, 20)
+                                
+                                .font(.pretendard(.medium, size: 12))
+                                .platformTextColor(color: Color("Red03"))
+                            }
+                        }
+                        
+                        VStack(alignment:.leading, spacing:9) {
+                            CustomInputView(inputText: $viewModel.confirmPw, titleText: "비밀번호 확인", onCommit: {
+                                viewModel.validateConfirmPw()
+                            })
+
+                            if viewModel.showErrorConfirmPw{
+                                Text("입력 포멧 관련 문구")
+                                .padding(.leading, 20)
+                                .font(.pretendard(.medium, size: 12))
+                                .platformTextColor(color: Color("Red03"))
+                            }
+                        }
                     }
                 }
             }
@@ -37,5 +80,5 @@ struct SignUpFormView: View {
 }
 
 #Preview {
-    SignUpFormView(name: .constant("01097740978"), id: .constant("2weeksone"), password: .constant("* * * * * *"), confirmPw: .constant("* * * * * *"))
+    SignUpFormView()
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormView.swift
@@ -1,12 +1,7 @@
 import SwiftUI
 
 struct SignUpFormView: View {
-//    @Binding var name: String
-//    @Binding var id: String
-//    @Binding var password: String
-//    @Binding var confirmPw: String
-//    @State var showErrorName = false
-    
+
     @StateObject private var viewModel = SignUpFormViewModel()
     
     var body: some View {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormView.swift
@@ -1,43 +1,44 @@
 import SwiftUI
 
 struct SignUpFormView: View {
-
+    
     @StateObject private var viewModel = SignUpFormViewModel()
     
     var body: some View {
-        VStack(alignment: .leading){
-            Text("회원가입")
-                .font(.pretendard(.semibold, size: 24))
-                .padding(.horizontal,20)
-            
-            Spacer().frame(height: 32)
-            
-            ScrollView() {
+        ScrollView() {
+            VStack(alignment: .leading){
+                Text("회원가입")
+                    .font(.pretendard(.semibold, size: 24))
+                    .padding(.horizontal,20)
+                
+                Spacer().frame(height: 32)
+                
+                
                 VStack(alignment: .leading) {
                     VStack(alignment: .leading, spacing: 21){
                         VStack(alignment:.leading, spacing: 9) {
                             CustomInputView(inputText: $viewModel.name, titleText: "이름", onCommit: {
                                 viewModel.validateName()
                             })
-
-                                if viewModel.showErrorName{
-                                    Text("입력 포멧 관련 문구")
+                            
+                            if viewModel.showErrorName{
+                                Text("입력 포멧 관련 문구")
                                     .padding(.leading, 20)
                                     .font(.pretendard(.medium, size: 12))
                                     .platformTextColor(color: Color("Red03"))
-                                }
+                            }
                         }
                         
                         VStack(alignment:.leading, spacing: 9) {
                             CustomInputView(inputText: $viewModel.id, titleText: "아이디", onCommit: {
                                 viewModel.validateID()
                             })
-
+                            
                             if viewModel.showErrorID{
                                 Text("입력 포멧 관련 문구")
-                                .padding(.leading, 20)
-                                .font(.pretendard(.medium, size: 12))
-                                .platformTextColor(color: Color("Red03"))
+                                    .padding(.leading, 20)
+                                    .font(.pretendard(.medium, size: 12))
+                                    .platformTextColor(color: Color("Red03"))
                             }
                         }
                         
@@ -45,13 +46,13 @@ struct SignUpFormView: View {
                             CustomInputView(inputText: $viewModel.password, titleText: "비밀번호", onCommit: {
                                 viewModel.validatePassword()
                             })
-
+                            
                             if viewModel.showErrorPassword{
                                 Text("입력 포멧 관련 문구")
-                                .padding(.leading, 20)
+                                    .padding(.leading, 20)
                                 
-                                .font(.pretendard(.medium, size: 12))
-                                .platformTextColor(color: Color("Red03"))
+                                    .font(.pretendard(.medium, size: 12))
+                                    .platformTextColor(color: Color("Red03"))
                             }
                         }
                         
@@ -59,12 +60,12 @@ struct SignUpFormView: View {
                             CustomInputView(inputText: $viewModel.confirmPw, titleText: "비밀번호 확인", onCommit: {
                                 viewModel.validateConfirmPw()
                             })
-
+                            
                             if viewModel.showErrorConfirmPw{
                                 Text("입력 포멧 관련 문구")
-                                .padding(.leading, 20)
-                                .font(.pretendard(.medium, size: 12))
-                                .platformTextColor(color: Color("Red03"))
+                                    .padding(.leading, 20)
+                                    .font(.pretendard(.medium, size: 12))
+                                    .platformTextColor(color: Color("Red03"))
                             }
                         }
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  SignUpForm.swift
-//  pennyway-client-iOS
-//
-//  Created by 아우신얀 on 3/26/24.
-//
-
 import SwiftUI
 import Combine
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpFormViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  SignUpForm.swift
+//  pennyway-client-iOS
+//
+//  Created by 아우신얀 on 3/26/24.
+//
+
+import SwiftUI
+import Combine
+
+class SignUpFormViewModel: ObservableObject {
+    
+    @Published var name: String = ""
+    @Published var id: String = ""
+    @Published var password: String = ""
+    @Published var confirmPw: String = ""
+    @Published var showErrorName = false
+    @Published var showErrorID = false
+    @Published var showErrorPassword = false
+    @Published var showErrorConfirmPw = false
+
+    func validateName() {
+        let nameRegex = "^[가-힣a-zA-Z]+$"
+        showErrorName = !NSPredicate(format: "SELF MATCHES %@", nameRegex).evaluate(with: name)
+        print(showErrorName)
+    }
+
+    func validateID() {
+        let idRegex = "^[a-z0-9._-]{5,20}$"
+        showErrorID = !NSPredicate(format: "SELF MATCHES %@", idRegex).evaluate(with: id)
+    }
+
+    func validatePassword() {
+        let passwordRegex = "^(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~]).{8,16}$"
+        showErrorPassword = !NSPredicate(format: "SELF MATCHES %@", passwordRegex).evaluate(with: password)
+    }
+
+    func validateConfirmPw() {
+        showErrorConfirmPw = password != confirmPw
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
@@ -1,4 +1,3 @@
-
 import SwiftUI
 
 struct SignUpView: View {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/SignUpView/SignUpView.swift
@@ -24,7 +24,7 @@ struct SignUpView: View {
                 
                 Spacer().frame(height: 14)
                 
-                SignUpFormView(name: $name, id: $id, password: $password, confirmPw: $confirmPw)
+                SignUpFormView()
                 
                 Spacer()
                 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/AgreementSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/AgreementSectionView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct AgreementSectionView: View {
+    @Binding var isSelected: Bool
+    var title: String
+    var contentText: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            ZStack{
+                HStack{
+                    Button(action: {
+                        isSelected.toggle()
+                    }, label: {
+                        let selected = isSelected == true ? Image("icon_checkone_on_small") : Image("icon_checkone_off_small")
+                        
+                        selected
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                            .padding(.leading, 4)
+                    })
+                    
+                    Text(title)
+                        .font(.pretendard(.medium, size: 11))
+                        .multilineTextAlignment(.leading)
+                        .platformTextColor(color: Color("Gray04"))
+                }
+            }
+            
+            ZStack() {
+                Rectangle()
+                    .platformTextColor(color: .clear)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .cornerRadius(4)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .inset(by: 0.5)
+                            .stroke(.gray04.opacity(0.5),lineWidth: 1)
+                    )
+                
+                Text(contentText)
+                    .font(.pretendard(.medium, size: 12))
+                    .minimumScaleFactor(0.001)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .platformTextColor(color: Color("Gray04"))
+                    .padding(12)
+            }
+            
+            Spacer().frame(height: 0)
+        }
+    }
+}
+
+#Preview {
+    AgreementSectionView(isSelected: .constant(true), title: "", contentText: "")
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
@@ -7,18 +7,19 @@ struct TermsAndConditionsContentView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            
-            HStack{
-                Text("이용 약관 동의")
-                    .font(.pretendard(.semibold, size: 24))
-                Spacer()
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.leading, 20)
-            
-            Spacer().frame(height: 49)
-            
-            ScrollView(){
+            ScrollView(){ //스크롤 뷰 위치 수정
+                
+                HStack{
+                    Text("이용 약관 동의")
+                        .font(.pretendard(.semibold, size: 24))
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.leading, 20)
+                
+                Spacer().frame(height: 49)
+                
+                
                 VStack(alignment: .leading) {
                     VStack(alignment: .leading, spacing: 28){
                         
@@ -49,91 +50,11 @@ struct TermsAndConditionsContentView: View {
                         })
                         
                         VStack(alignment: .leading, spacing: 7) {
-                            ZStack{
-                                HStack{
-                                    
-                                    Button(action: {
-                                        isSelectedUseBtn.toggle()
-                                    }, label: {
-                                        let selected = isSelectedUseBtn == true ? Image("icon_checkone_on_small") : Image("icon_checkone_off_small")
-                                        
-                                        selected
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fit)
-                                            .frame(width: 24, height: 24)
-                                            .padding(.leading, 4)
-                                    })
-                                    
-                                    
-                                    Text("이용약관 (필수)")
-                                        .font(.pretendard(.medium, size: 11))
-                                        .multilineTextAlignment(.leading)
-                                        .platformTextColor(color: Color("Gray04"))
-                                }
-                            }
+                            //수정
+                            AgreementSectionView(isSelected:  $isSelectedUseBtn, title: "이용약관 (필수)", contentText: "Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas sit")
                             
-                            ZStack() {
-                                Rectangle()
-                                    .platformTextColor(color: .clear)
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                    .cornerRadius(4)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .inset(by: 0.5)
-                                            .stroke(.gray04.opacity(0.5),lineWidth: 1)
-                                    )
-                                
-                                Text("Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas sit")
-                                    .font(.pretendard(.medium, size: 12))
-                                    .minimumScaleFactor(0.001)
-                                    .multilineTextAlignment(.leading)
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                                    .platformTextColor(color: Color("Gray04"))
-                                    .padding(12)
-                            }
-                            
-                            Spacer().frame(height: 0)
-                            
-                            VStack(alignment: .leading) {
-                                
-                                HStack {
-                                    Button(action: {
-                                        isSelectedInfoBtn.toggle()
-                                    }, label: {
-                                        let selectedInfo = isSelectedInfoBtn == true ? Image("icon_checkone_on_small") : Image("icon_checkone_off_small")
-                                        
-                                        selectedInfo
-                                            .resizable()
-                                            .frame(width: 24, height: 24)
-                                            .padding(.leading, 4)
-                                    })
-                                    Text("개인정보 처리방침 (필수)")
-                                        .font(.pretendard(.medium, size: 11))
-                                        .multilineTextAlignment(.leading)
-                                        .platformTextColor(color: Color("Gray04"))
-                                }
-                                
-                                ZStack{
-                                    Rectangle()
-                                        .platformTextColor(color: .clear)
-                                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                        .cornerRadius(4)
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .inset(by: 0.5)
-                                                .stroke(.gray04.opacity(0.5),lineWidth: 1)
-                                        )
-                                    
-                                    Text("Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas sit")
-                                        .font(.pretendard(.medium, size: 12))
-                                        .minimumScaleFactor(0.001)
-                                        .multilineTextAlignment(.leading)
-                                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                                        .platformTextColor(color: Color("Gray04"))
-                                        .padding(12)
-                                    
-                                }
-                            }
+                            //수정
+                            AgreementSectionView(isSelected: $isSelectedInfoBtn, title: "개인정보 처리방침 (필수)", contentText: "Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas sit")
                         }
                     }
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/SignUpView/TermsAndConditionsView/TermsAndConditionsContentView.swift
@@ -23,9 +23,10 @@ struct TermsAndConditionsContentView: View {
                     VStack(alignment: .leading, spacing: 28){
                         
                         Button(action: {
-                            isSelectedAllBtn.toggle()
-                            isSelectedUseBtn.toggle()
-                            isSelectedInfoBtn.toggle()
+                            let newSelection = !isSelectedAllBtn
+                            isSelectedAllBtn = newSelection
+                            isSelectedUseBtn = newSelection
+                            isSelectedInfoBtn = newSelection
                         }, label: {
                             ZStack(alignment: .leading){
                                 Rectangle()
@@ -33,7 +34,7 @@ struct TermsAndConditionsContentView: View {
                                     .platformTextColor(color: isSelectedAllBtn ? Color("Gray05") : Color("Gray02"))
                                     .cornerRadius(4)
                                 
-                                Image("icon_check") //버튼 눌렀을 때 색 안바뀜
+                                Image("icon_check")
                                     .renderingMode(.template)
                                     .resizable()
                                     .frame(width: 24, height: 24)
@@ -137,6 +138,8 @@ struct TermsAndConditionsContentView: View {
                     }
                 }
                 .padding(.horizontal, 20)
+                .onChange(of: isSelectedUseBtn) { _ in isSelectedAllBtn = isSelectedUseBtn && isSelectedInfoBtn }
+                .onChange(of: isSelectedInfoBtn) { _ in isSelectedAllBtn = isSelectedUseBtn && isSelectedInfoBtn }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## 작업 이유
- 기존에 이용약관 동의 화면 오류 해결
- 모두 동의할게요 처리시 두 버튼 모두 활성화
- 모두 동의 버튼 누르고 하나 취소시 모두 동의버튼 비활성화


<br/>

## 작업 사항
### 1️⃣ **TermsAndConditionsContentView** 
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-03-26 at 03 16 04](https://github.com/CollaBu/pennyway-client-ios/assets/122153297/97952ace-2bad-4d2d-805a-ce3d13f2e2d1)

이용약관 동의 화면에서 '모두 동의할게요' 버튼을 누르고 나머지 활성화된 버튼을 눌렀을 때 모두동의 버튼이 해제 되며 두 버튼 중 하나 취소해도 모두 동의버튼이 활성화 되는 버그가 존재했다.

기존 방식은 button을 눌렀을 때 action 안에 `isSelectedAllBtn, isSelectedUseBtn, isSelectedInfoBtn `모두 toggle 되도록 하여 예외처리 없이 모두 동의하면 두 버튼이 활성화 되도록 처리되어 있었다.

**해결 방법**
```swift
Button(action: {
                            let newSelection = !isSelectedAllBtn
                            isSelectedAllBtn = newSelection
                            isSelectedUseBtn = newSelection
                            isSelectedInfoBtn = newSelection
                        }, label: {
``` 
모두 동의 버튼을 눌렀을 경우 newSelection 변수를 생성한 후 '모두 동의할게요' 버튼을 클릭했을 경우 `isSelectedAllBtn` 값을 반전시키고 나머지 버튼을 모두 업데이트 시켜준다.

```swift
.onChange(of: isSelectedUseBtn) { _ in isSelectedAllBtn = isSelectedUseBtn && isSelectedInfoBtn }
.onChange(of: isSelectedInfoBtn) { _ in isSelectedAllBtn = isSelectedUseBtn && isSelectedInfoBtn }
``` 
isSelectedUseBtn과 isSelectedInfoBtn 상태 변경시 isSelectedAllBtn 상태 업데이트되도록 onChange함수를 통해 변경사항을 감지해주었다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

이 부분도 계속하기 버튼 활성화 하는 로직 처리는 구현하지 않았습니다!

<br/>

## 발견한 이슈
1️⃣ TermsAndConditionsContentView 버튼 오류 해결