### PR TITLE
🛠️🎨 번호인증 + 팝업 + 계정 연동 + 네비게이션 카운트 뷰 동적 UI 반영과 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/Font/DynamicFontSize.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/Font/DynamicFontSize.swift
@@ -17,6 +17,10 @@ extension Font {
         return Font.custom("Pretendard-SemiBold", size: 16 * DynamicSizeFactor.factor())
     }
 
+    static func H3BoldFont() -> Font {
+        return Font.custom("Pretendard-Bold", size: 16 * DynamicSizeFactor.factor())
+    }
+
     static func H4MediumFont() -> Font {
         return Font.custom("Pretendard-Medium", size: 14 * DynamicSizeFactor.factor())
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
@@ -18,10 +18,19 @@ struct FindIdPhoneVerificationView: View {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Color("Gray01"))
                             .frame(height: 46 * DynamicSizeFactor.factor())
-                        TextField("'-' 제외 입력", text: $viewModel.phoneNumber)
+
+                        if viewModel.phoneNumber.isEmpty {
+                            Text("01012345678")
+                                .platformTextColor(color: Color("Gray03"))
+                                .padding(.leading, 13 * DynamicSizeFactor.factor())
+                                .font(.H4MediumFont())
+                        }
+
+                        TextField("", text: $viewModel.phoneNumber)
                             .padding(.leading, 13 * DynamicSizeFactor.factor())
                             .font(.H4MediumFont())
                             .keyboardType(.numberPad)
+                            .platformTextColor(color: Color("Gray07"))
 
                             .onChange(of: viewModel.phoneNumber) { newValue in
                                 if Int(newValue) != nil {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
@@ -11,17 +11,25 @@ struct FindPwPhoneVerificationView: View {
             VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
                 Text("휴대폰 번호")
                     .padding(.horizontal, 20)
-                    .font(.pretendard(.regular, size: 12))
+                    .font(.B1RegularFont())
                     .platformTextColor(color: Color("Gray04"))
                 HStack(spacing: 11 * DynamicSizeFactor.factor()) {
                     ZStack {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Color("Gray01"))
                             .frame(height: 46 * DynamicSizeFactor.factor())
-                        TextField("'-' 제외 입력", text: $viewModel.phoneNumber)
+                        if viewModel.phoneNumber.isEmpty {
+                            Text("01012345678")
+                                .platformTextColor(color: Color("Gray03"))
+                                .padding(.leading, 13 * DynamicSizeFactor.factor())
+                                .font(.H4MediumFont())
+                        }
+
+                        TextField("", text: $viewModel.phoneNumber)
                             .padding(.leading, 13 * DynamicSizeFactor.factor())
                             .font(.H4MediumFont())
                             .keyboardType(.numberPad)
+                            .platformTextColor(color: Color("Gray07"))
 
                             .onChange(of: viewModel.phoneNumber) { newValue in
                                 if Int(newValue) != nil {
@@ -40,7 +48,7 @@ struct FindPwPhoneVerificationView: View {
                         }
                     }, label: {
                         Text("인증번호 받기")
-                            .font(.pretendard(.medium, size: 13))
+                            .font(.pretendard(.medium, size: 13)) // 폰트 리스트에 없는 예외
                             .platformTextColor(color: !viewModel.isDisabledButton && viewModel.phoneNumber.count >= 11 ? Color("White01") : Color("Gray04"))
                     })
                     .padding(.horizontal, 13 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -14,8 +14,7 @@ struct FindPwView: View {
                     FindPwContentView(phoneVerificationViewModel: phoneVerificationViewModel)
                 }
             }
-            Spacer().frame(height: 203 * DynamicSizeFactor.factor())
-
+            
             Spacer()
                 
             CustomBottomButton(action: {
@@ -28,26 +27,6 @@ struct FindPwView: View {
                 EmptyView()
             }.hidden()
                 
-            if showingPopUp == true {
-                Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingPopUp, label: "사용자 정보를 찾을 수 없어요")
-            }
-            Spacer().frame(height: 203 * DynamicSizeFactor.factor())
-            
-            Spacer()
-            
-            VStack {
-                Spacer()
-                CustomBottomButton(action: {
-                    continueButtonAction()
-                }, label: "확인", isFormValid: $phoneVerificationViewModel.isFormValid)
-            }
-            .padding(.bottom, 34)
-            
-            NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel()), isActive: $isNavigateToFindPwView) {
-                EmptyView()
-            }.hidden()
-            
             if showingPopUp == true {
                 Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
                 ErrorCodePopUpView(showingPopUp: $showingPopUp, label: "사용자 정보를 찾을 수 없어요")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/ErrorCodeContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/ErrorCodeContentView.swift
@@ -7,7 +7,7 @@ struct ErrorCodeContentView: View {
         ZStack(alignment: .leading) {
             if isCloseErrorPopUpView {
                 Rectangle()
-                    .frame(maxWidth: .infinity, maxHeight: 28 * DynamicSizeFactor.factor())
+                    .frame(height: 28 * DynamicSizeFactor.factor())
                     .platformTextColor(color: Color("Red01"))
                     .cornerRadius(17)
 
@@ -16,9 +16,10 @@ struct ErrorCodeContentView: View {
 
                 }, label: {
                     Image("icon_close_filled_red")
-                        .aspectRatio(contentMode: .fit)
+                        .aspectRatio(contentMode: .fill)
                         .foregroundColor(Color("Red03"))
                         .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                        .padding(.leading, 9)
                 })
 
                 Text("아이디 또는 비밀번호가 잘못 입력되었어요")
@@ -27,6 +28,7 @@ struct ErrorCodeContentView: View {
                     .padding(.leading, 34 * DynamicSizeFactor.factor())
             }
         }
+        .frame(maxWidth: .infinity)
         .padding(.horizontal, 20 * DynamicSizeFactor.factor())
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
@@ -21,7 +21,7 @@ struct InputFormView: View {
             if loginViewModel.showErrorCodeContent {
                 Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                 ErrorCodeContentView(isCloseErrorPopUpView: $loginViewModel.isLoginSuccessful)
-                Spacer().frame(height: 35 * DynamicSizeFactor.factor())
+                Spacer().frame(height: 35)
 
             } else {
                 Spacer().frame(height: 49 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/OAuthAccountLinkingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/OAuthAccountLinkingView.swift
@@ -9,26 +9,26 @@ struct OAuthAccountLinkingView: View {
     var body: some View {
         ZStack {
             VStack(alignment: .center) {
-                Spacer().frame(height: 110)
+                Spacer().frame(height: 110 * DynamicSizeFactor.factor())
                 
                 Image("icon_illust_completion")
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(width: 68, height: 68)
+                    .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
                 
-                Spacer().frame(height: 16)
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
                 
                 Text("현재 사용 중인 계정이 있어요\n이 아이디와 연동할까요?")
                     .multilineTextAlignment(.center)
-                    .font(.pretendard(.semibold, size: 16))
+                    .font(.H3SemiboldFont())
                 
-                Spacer().frame(height: 30)
+                Spacer().frame(height: 30 * DynamicSizeFactor.factor())
                 
                 ZStack {
                     Text("\(OAuthRegistrationManager.shared.username)")
-                        .font(.pretendard(.medium, size: 16))
+                        .font(.H3SemiboldFont())
                         .platformTextColor(color: Color("Gray07"))
-                        .padding(.vertical, 20)
+                        .padding(.vertical, 20 * DynamicSizeFactor.factor())
                         .frame(maxWidth: .infinity)
                 }
                 .background(Color("Gray01"))
@@ -40,12 +40,13 @@ struct OAuthAccountLinkingView: View {
                     isActiveButton = true
                     
                 }, label: "연동하기", isFormValid: .constant(true))
-                    .padding(.bottom, 34)
+                    .padding(.bottom, 34 * DynamicSizeFactor.factor())
                 NavigationLink(destination: SignUpView(viewModel: signUpViewModel), isActive: $isActiveButton) {
                     EmptyView()
                 }
             }
         }
+        .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/ErrorCodePopUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/ErrorCodePopUpView.swift
@@ -8,11 +8,7 @@ struct ErrorCodePopUpView: View {
     let label: String
 
     var body: some View {
-        if UIScreen.main.bounds.width <= 375 { // iPhone SE/iPhone mini
-            PopupContent(imageSize: CGSize(width: 44, height: 44), frameHeight: 150, contentHeight: 70, titleFontSize: 16, subtitleFontSize: 12, label: label, showingPopUp: $showingPopUp)
-        } else {
-            PopupContent(imageSize: CGSize(width: 55, height: 55), frameHeight: 180, contentHeight: 90, titleFontSize: 20, subtitleFontSize: 15, label: label, showingPopUp: $showingPopUp)
-        }
+        PopupContent(imageSize: CGSize(width: 44 * DynamicSizeFactor.factor(), height: 44 * DynamicSizeFactor.factor()), frameHeight: 145 * DynamicSizeFactor.factor(), contentHeight: 70 * DynamicSizeFactor.factor(), label: label, showingPopUp: $showingPopUp)
     }
 }
 
@@ -23,8 +19,6 @@ extension ErrorCodePopUpView {
         var imageSize: CGSize
         var frameHeight: CGFloat
         var contentHeight: CGFloat
-        var titleFontSize: CGFloat
-        var subtitleFontSize: CGFloat
         let label: String
 
         @Binding var showingPopUp: Bool
@@ -43,10 +37,10 @@ extension ErrorCodePopUpView {
                                 }) {
                                     Image("icon_close")
                                         .resizable()
-                                        .aspectRatio(contentMode: .fill)
-                                        .frame(width: 24, height: 24)
-                                        .padding(10)
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                                 }
+                                .frame(width: 44, height: 44)
                             }
                             .alignmentGuide(.top, computeValue: { _ in
                                 geometry.frame(in: .global).midY
@@ -57,29 +51,31 @@ extension ErrorCodePopUpView {
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: imageSize.width, height: imageSize.height)
-                            .offset(y: 10)
+                            .offset(y: 10 * DynamicSizeFactor.factor())
 
                         Spacer()
                     }
                     .frame(height: contentHeight)
 
-                    Spacer().frame(height: 9)
+                    Spacer().frame(height: 9 * DynamicSizeFactor.factor())
 
-                    VStack(spacing: 2) {
+                    VStack(spacing: 2 * DynamicSizeFactor.factor()) {
                         Text(label)
                             .platformTextColor(color: Color("Gray07"))
-                            .font(.pretendard(.semibold, size: titleFontSize))
+                            .font(.H3SemiboldFont())
                         Text("다시 한 번 확인해주세요")
                             .platformTextColor(color: Color("Gray04"))
-                            .font(.pretendard(.medium, size: subtitleFontSize))
+                            .font(.B1MediumFont())
                     }
                     Spacer()
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(height: frameHeight)
+                .border(Color.black)
             }
-            .frame(width: UIScreen.main.bounds.width - 120, height: frameHeight)
+            .frame(maxWidth: .infinity)
             .background(Color("White01"))
             .cornerRadius(10)
+            .padding(.horizontal, 40)
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/NumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/NumberInputSectionView.swift
@@ -16,7 +16,7 @@ struct NumberInputSectionView: View {
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Gray04"))
 
-            HStack(spacing: 11) {
+            HStack(spacing: 11 * DynamicSizeFactor.factor()) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 4)
                         .fill(Color("Gray01"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/NumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/NumberInputSectionView.swift
@@ -13,7 +13,7 @@ struct NumberInputSectionView: View {
         VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
             Text("인증 번호")
                 .padding(.horizontal, 20)
-                .font(.B1MediumFont())
+                .font(.B1RegularFont())
                 .platformTextColor(color: Color("Gray04"))
 
             HStack(spacing: 11 * DynamicSizeFactor.factor()) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -13,14 +13,23 @@ struct PhoneNumberInputSectionView: View {
                     .font(.pretendard(.regular, size: 12))
                     .platformTextColor(color: Color("Gray04"))
                 HStack(spacing: 11) {
-                    ZStack {
+                    ZStack(alignment: .leading) {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Color("Gray01"))
-                            .frame(height: 46)
-                        TextField("'-' 제외 입력", text: $viewModel.phoneNumber)
-                            .padding(.leading, 13)
-                            .font(.pretendard(.medium, size: 14))
+                            .frame(height: 46 * DynamicSizeFactor.factor())
+
+                        if viewModel.phoneNumber.isEmpty {
+                            Text("01012345678")
+                                .platformTextColor(color: Color("Gray03"))
+                                .padding(.leading, 13 * DynamicSizeFactor.factor())
+                                .font(.H4MediumFont())
+                        }
+
+                        TextField("", text: $viewModel.phoneNumber)
+                            .padding(.leading, 13 * DynamicSizeFactor.factor())
+                            .font(.H4MediumFont())
                             .keyboardType(.numberPad)
+                            .platformTextColor(color: Color("Gray07"))
 
                             .onChange(of: viewModel.phoneNumber) { newValue in
                                 if Int(newValue) != nil {
@@ -33,6 +42,7 @@ struct PhoneNumberInputSectionView: View {
                                 viewModel.validateForm()
                             }
                     }
+
                     Button(action: {
                         if isOAuthRegistration {
                             viewModel.requestOAuthVerificationCodeApi { viewModel.judgeTimerRunning() }
@@ -41,11 +51,11 @@ struct PhoneNumberInputSectionView: View {
                         }
                     }, label: {
                         Text("인증번호 받기")
-                            .font(.pretendard(.medium, size: 13))
+                            .font(.pretendard(.medium, size: 13)) // 폰트 리스트에 없는 예외
                             .platformTextColor(color: !viewModel.isDisabledButton && viewModel.phoneNumber.count >= 11 ? Color("White01") : Color("Gray04"))
                     })
-                    .padding(.horizontal, 13)
-                    .frame(height: 46)
+                    .padding(.horizontal, 13 * DynamicSizeFactor.factor())
+                    .frame(height: 46 * DynamicSizeFactor.factor())
                     .background(!viewModel.isDisabledButton && viewModel.phoneNumber.count == 11 ? Color("Gray05") : Color("Gray03"))
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                     .disabled(viewModel.isDisabledButton)
@@ -55,14 +65,14 @@ struct PhoneNumberInputSectionView: View {
             if viewModel.showErrorPhoneNumberFormat {
                 Text("올바른 전화번호 형식이 아니에요")
                     .padding(.horizontal, 20)
-                    .font(.pretendard(.medium, size: 12))
+                    .font(.B1MediumFont())
                     .platformTextColor(color: Color("Red03"))
             }
 
             if viewModel.showErrorExistingUser {
                 Text("이미 가입된 전화번호예요")
                     .padding(.horizontal, 20)
-                    .font(.pretendard(.medium, size: 12))
+                    .font(.B1MediumFont())
                     .platformTextColor(color: Color("Red03"))
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -6,13 +6,13 @@ struct PhoneNumberInputSectionView: View {
     @State private var isOAuthRegistration = OAuthRegistrationManager.shared.isOAuthRegistration
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 11) {
-            VStack(alignment: .leading, spacing: 13) {
+        VStack(alignment: .leading, spacing: 11 * DynamicSizeFactor.factor()) {
+            VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
                 Text("휴대폰 번호")
                     .padding(.horizontal, 20)
-                    .font(.pretendard(.regular, size: 12))
+                    .font(.B1RegularFont())
                     .platformTextColor(color: Color("Gray04"))
-                HStack(spacing: 11) {
+                HStack(spacing: 11 * DynamicSizeFactor.factor()) {
                     ZStack(alignment: .leading) {
                         RoundedRectangle(cornerRadius: 4)
                             .fill(Color("Gray01"))
@@ -54,7 +54,7 @@ struct PhoneNumberInputSectionView: View {
                             .font(.pretendard(.medium, size: 13)) // 폰트 리스트에 없는 예외
                             .platformTextColor(color: !viewModel.isDisabledButton && viewModel.phoneNumber.count >= 11 ? Color("White01") : Color("Gray04"))
                     })
-                    .padding(.horizontal, 13 * DynamicSizeFactor.factor())
+                    .padding(.horizontal, 13)
                     .frame(height: 46 * DynamicSizeFactor.factor())
                     .background(!viewModel.isDisabledButton && viewModel.phoneNumber.count == 11 ? Color("Gray05") : Color("Gray03"))
                     .clipShape(RoundedRectangle(cornerRadius: 4))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
@@ -9,14 +9,14 @@ struct PhoneVerificationContentView: View {
     var body: some View {
         VStack(alignment: .leading) {
             Text("번호인증")
-                .font(.pretendard(.semibold, size: 24))
+                .font(.H1SemiboldFont())
                 .padding(.horizontal, 20)
 
-            Spacer().frame(height: 32)
+            Spacer().frame(height: 32 * DynamicSizeFactor.factor())
 
             PhoneNumberInputSectionView(viewModel: phoneVerificationViewModel) 
 
-            Spacer().frame(height: 21)
+            Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 
             NumberInputSectionView(viewModel: phoneVerificationViewModel)
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -11,14 +11,14 @@ struct PhoneVerificationView: View {
     var body: some View {
         ZStack {
             VStack {
-                Spacer().frame(height: 15)
+                Spacer().frame(height: 15 * DynamicSizeFactor.factor())
                 
                 NavigationCountView(selectedText: $viewModel.selectedText)
                     .onAppear {
                         viewModel.selectedText = 1
                     }
                 
-                Spacer().frame(height: 14)
+                Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                 
                 PhoneVerificationContentView(phoneVerificationViewModel: phoneVerificationViewModel)
                 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -9,10 +9,10 @@ struct CustomInputView: View {
     var isSecureText: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 13) {
+        VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
             Text(titleText!)
                 .padding(.horizontal, 20)
-                .font(.pretendard(.regular, size: 12))
+                .font(.B1RegularFont())
                 .platformTextColor(color: Color("Gray04"))
 
             HStack(spacing: 11 * DynamicSizeFactor.factor()) {
@@ -29,7 +29,7 @@ struct CustomInputView: View {
                         .disableAutocorrection(true)
                         .padding(.leading, 13 * DynamicSizeFactor.factor())
                         .padding(.vertical, 16 * DynamicSizeFactor.factor())
-                        .font(.pretendard(.medium, size: 14))
+                        .font(.H4MediumFont())
 
                     } else {
                         TextField("", text: $inputText, onCommit: {
@@ -39,7 +39,7 @@ struct CustomInputView: View {
                         .disableAutocorrection(true)
                         .padding(.leading, 13 * DynamicSizeFactor.factor())
                         .padding(.vertical, 16 * DynamicSizeFactor.factor())
-                        .font(.pretendard(.medium, size: 14))
+                        .font(.H4MediumFont())
                     }
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
@@ -6,32 +6,32 @@ struct NavigationCountView: View {
     @Binding var selectedText: Int?
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 8 * DynamicSizeFactor.factor()) {
             LazyHGrid(rows: [GridItem(.flexible())]) {
                 Text("1")
                     .padding(6)
                     .background(selectedText ?? 0 >= 1 ? Color("Gray06") : Color("Gray03"))
                     .platformTextColor(color: selectedText ?? 0 >= 1 ? Color("White01") : Color("Gray04"))
                     .clipShape(Circle())
-                    .font(.pretendard(.medium, size: 12))
+                    .font(.B2MediumFont())
 
                 Text("2")
                     .padding(6)
                     .background(selectedText ?? 0 >= 2 ? Color("Gray06") : Color("Gray03"))
                     .platformTextColor(color: selectedText ?? 0 >= 2 ? Color("White01") : Color("Gray04"))
                     .clipShape(Circle())
-                    .font(.pretendard(.medium, size: 12))
+                    .font(.B2MediumFont())
 
                 Text("3")
                     .padding(6)
                     .background(selectedText ?? 0 >= 3 ? Color("Gray06") : Color("Gray03"))
                     .platformTextColor(color: selectedText ?? 0 >= 3 ? Color("White01") : Color("Gray04"))
                     .clipShape(Circle())
-                    .font(.pretendard(.medium, size: 12))
+                    .font(.B2MediumFont())
             }
             Spacer()
         }
         .padding(.horizontal, 20)
-        .frame(height: 20)
+        .frame(height: 18 * DynamicSizeFactor.factor())
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
@@ -32,6 +32,6 @@ struct NavigationCountView: View {
             Spacer()
         }
         .padding(.horizontal, 20)
-        .frame(height: 18 * DynamicSizeFactor.factor())
+        .frame(height: 18)
     }
 }


### PR DESCRIPTION
## 작업 이유

- 번호인증 뷰 (인증번호 받기 ui)
- 오류 팝업 뷰
- 계정 연동 뷰
- 네비게이션 카운트 뷰

<br/>

## 작업 사항

### 1️⃣ 인증번호 받기 ui

- 동적 UI 적용
- placeholder color와 문구 수정 ('-'제외 입력 -> 01012345678으로 변경)
- "인증번호 받기" 버튼 text size는 정리된 폰트 리스트에 없는 size여서 디자인팀에 질문 남겨놓음
- 인증번호 받기 ui를 사용하는 아이디 찾기, 비밀번호 찾기, 번호인증 화면에 모두 적용함

![스크린샷 2024-05-17 오전 2 45 13](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/ab676514-1012-46f1-afd3-566628dc5661)


### 2️⃣ 오류 팝업 뷰

- 동적 ui 적용
- 코드 리팩토링


### 3️⃣ 계정 연동 뷰

- 동적 UI 적용


### 4️⃣ 로그인 뷰

- x 박스와 textfield간의 간격 수정

![스크린샷 2024-05-17 오전 2 49 27](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/51009355-b598-4693-a68b-953d13fd81ca)

### 5️⃣ 네비게이션 카운트 뷰

- 동적 ui 적용

![스크린샷 2024-05-17 오전 2 52 27](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/21c7e8ea-f559-4e3a-a4e8-f803bd80232d)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

동적 UI 적용 안 한 뷰에 모두 반영했고요! 그리고 font 리스트에 없는 사이즈가 있어서 디자인팀에게 질문 남겼습니다

<br/>

## 발견한 이슈
없음
