### PR TITLE
📮💻 최근 목표 금액 API 연동 + 커스텀 카테고리 etc 아이콘 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		4AC3205F2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */; };
 		4AC320612C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */; };
 		4AC320632C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320622C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift */; };
+		4AC320652C120C0D00DDB4B6 /* TargetAmountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320642C120C0D00DDB4B6 /* TargetAmountModel.swift */; };
 		4AC4FD082BBDCC190027ACD5 /* KakaoOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD072BBDCC190027ACD5 /* KakaoOAuthViewModel.swift */; };
 		4AC4FD0A2BBDCE080027ACD5 /* GoogleOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD092BBDCE080027ACD5 /* GoogleOAuthViewModel.swift */; };
 		4AC4FD0C2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift */; };
@@ -390,6 +391,7 @@
 		4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentMonthTargetAmountResponseDto.swift; sourceTree = "<group>"; };
 		4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForDateResponseDto.swift; sourceTree = "<group>"; };
 		4AC320622C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForPreviousMonthResponseDto.swift; sourceTree = "<group>"; };
+		4AC320642C120C0D00DDB4B6 /* TargetAmountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAmountModel.swift; sourceTree = "<group>"; };
 		4AC4FD072BBDCC190027ACD5 /* KakaoOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC4FD092BBDCE080027ACD5 /* GoogleOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAtuthViewModel.swift; sourceTree = "<group>"; };
@@ -756,7 +758,6 @@
 		4A3701AC2C08F74E00F0AEBA /* Response */ = {
 			isa = PBXGroup;
 			children = (
-
 				4A3701AB2C08F74E00F0AEBA /* GetTotalTargetAmountResponseDto.swift */,
 				4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */,
 				4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */,
@@ -1051,6 +1052,7 @@
 			children = (
 				4ADE80232BF23D10007FFB01 /* ListItem */,
 				4A058F062BD051D9004B6F89 /* Network */,
+				4AC320642C120C0D00DDB4B6 /* TargetAmountModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1676,6 +1678,7 @@
 				4A98BD7C2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift in Sources */,
 				4A57897B2BDC1E5A00AFEB26 /* ConflictErrorCode.swift in Sources */,
 				4AC320612C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift in Sources */,
+				4AC320652C120C0D00DDB4B6 /* TargetAmountModel.swift in Sources */,
 				D851E7202C0273FA00316DB3 /* BackofficeRouter.swift in Sources */,
 				D85927FC2BE9116700653391 /* TermsAndConditionsViewModel.swift in Sources */,
 				4A4D884F2BD81F82009EADB0 /* CryptoHelper.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		4A85713A2BC6FFD30082CE47 /* NumberInputSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571392BC6FFD30082CE47 /* NumberInputSectionView.swift */; };
 		4A8571422BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571412BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift */; };
 		4A8571442BC7C5EB0082CE47 /* OAuthSignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571432BC7C5EB0082CE47 /* OAuthSignUpViewModel.swift */; };
+		4A98BD7C2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */; };
 		4AA52F3F2C05C3AD00B21521 /* RoundedCornerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */; };
 		4AB5AB472BB4A32F00D2C9EA /* AuthAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB462BB4A32F00D2C9EA /* AuthAlamofire.swift */; };
 		4AB5AB4A2BB4A37600D2C9EA /* AuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB492BB4A37600D2C9EA /* AuthRouter.swift */; };
@@ -155,6 +156,10 @@
 		4AC320562C11D5AC00DDB4B6 /* TotalTargetAmountHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3203B2C11D5AC00DDB4B6 /* TotalTargetAmountHeaderView.swift */; };
 		4AC320572C11D5AC00DDB4B6 /* TotalTargetAmountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3203C2C11D5AC00DDB4B6 /* TotalTargetAmountView.swift */; };
 		4AC320592C11D5D500DDB4B6 /* CustomToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320582C11D5D500DDB4B6 /* CustomToastView.swift */; };
+		4AC3205B2C11F31C00DDB4B6 /* GetTotalTargetAmountRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3205A2C11F31C00DDB4B6 /* GetTotalTargetAmountRequestDto.swift */; };
+		4AC3205D2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3205C2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift */; };
+		4AC3205F2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */; };
+		4AC320612C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */; };
 		4AC4FD082BBDCC190027ACD5 /* KakaoOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD072BBDCC190027ACD5 /* KakaoOAuthViewModel.swift */; };
 		4AC4FD0A2BBDCE080027ACD5 /* GoogleOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD092BBDCE080027ACD5 /* GoogleOAuthViewModel.swift */; };
 		4AC4FD0C2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift */; };
@@ -342,6 +347,7 @@
 		4A8571392BC6FFD30082CE47 /* NumberInputSectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberInputSectionView.swift; sourceTree = "<group>"; };
 		4A8571412BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkOAuthToAccountViewModel.swift; sourceTree = "<group>"; };
 		4A8571432BC7C5EB0082CE47 /* OAuthSignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSignUpViewModel.swift; sourceTree = "<group>"; };
+		4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCurrentMonthTargetAmountRequestDto.swift; sourceTree = "<group>"; };
 		4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornerUtil.swift; sourceTree = "<group>"; };
 		4AB5AB462BB4A32F00D2C9EA /* AuthAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAlamofire.swift; sourceTree = "<group>"; };
 		4AB5AB492BB4A37600D2C9EA /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
@@ -378,6 +384,10 @@
 		4AC3203B2C11D5AC00DDB4B6 /* TotalTargetAmountHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TotalTargetAmountHeaderView.swift; sourceTree = "<group>"; };
 		4AC3203C2C11D5AC00DDB4B6 /* TotalTargetAmountView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TotalTargetAmountView.swift; sourceTree = "<group>"; };
 		4AC320582C11D5D500DDB4B6 /* CustomToastView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomToastView.swift; sourceTree = "<group>"; };
+		4AC3205A2C11F31C00DDB4B6 /* GetTotalTargetAmountRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTotalTargetAmountRequestDto.swift; sourceTree = "<group>"; };
+		4AC3205C2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCurrentMonthDummyDataRequestDto.swift; sourceTree = "<group>"; };
+		4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentMonthTargetAmountResponseDto.swift; sourceTree = "<group>"; };
+		4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForDateResponseDto.swift; sourceTree = "<group>"; };
 		4AC4FD072BBDCC190027ACD5 /* KakaoOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC4FD092BBDCE080027ACD5 /* GoogleOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAtuthViewModel.swift; sourceTree = "<group>"; };
@@ -734,6 +744,9 @@
 		4A3701AA2C08F74E00F0AEBA /* Request */ = {
 			isa = PBXGroup;
 			children = (
+				4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */,
+				4AC3205A2C11F31C00DDB4B6 /* GetTotalTargetAmountRequestDto.swift */,
+				4AC3205C2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -742,6 +755,8 @@
 			isa = PBXGroup;
 			children = (
 				4A3701AB2C08F74E00F0AEBA /* GetTotalTargetAmountResponseDto.swift */,
+				4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */,
+				4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1654,7 +1669,9 @@
 				4A1C598A2BC51AEB00EA2B49 /* OAuthRouter.swift in Sources */,
 				4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */,
 				4A57896F2BDBF01500AFEB26 /* BadRequestErrorCode.swift in Sources */,
+				4A98BD7C2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift in Sources */,
 				4A57897B2BDC1E5A00AFEB26 /* ConflictErrorCode.swift in Sources */,
+				4AC320612C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift in Sources */,
 				D851E7202C0273FA00316DB3 /* BackofficeRouter.swift in Sources */,
 				D85927FC2BE9116700653391 /* TermsAndConditionsViewModel.swift in Sources */,
 				4A4D884F2BD81F82009EADB0 /* CryptoHelper.swift in Sources */,
@@ -1664,6 +1681,7 @@
 				4A57898F2BDC298500AFEB26 /* NotFoundError.swift in Sources */,
 				D8180C022BE507FD00F837FB /* FindIdFormView.swift in Sources */,
 				4AC3204E2C11D5AC00DDB4B6 /* SpendingCalendarView.swift in Sources */,
+				4AC3205F2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift in Sources */,
 				4A3701D42C08F7F600F0AEBA /* GetSpendingHistoryResponseDto.swift in Sources */,
 				4A058F032BD048F8004B6F89 /* CheckDuplicateResponseDto.swift in Sources */,
 				4AC948902BC1C563008DBC1F /* OAuthAccountLinkingView.swift in Sources */,
@@ -1711,6 +1729,7 @@
 				4AD70E292BE015970058A52A /* ProfileSettingListView.swift in Sources */,
 				4A3701D02C08F7F600F0AEBA /* GetSpendingHistoryRequestDto.swift in Sources */,
 				4A762AED2B99A16B001C1188 /* pennyway_client_iOSApp.swift in Sources */,
+				4AC3205D2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift in Sources */,
 				4A4703942BCEB21500AEE04E /* StatusError.swift in Sources */,
 				D8880E192BCEBEE700922894 /* DynamicFontSize.swift in Sources */,
 				4A3701CF2C08F7F600F0AEBA /* AddSpendingHistoryRequestDto.swift in Sources */,
@@ -1754,6 +1773,7 @@
 				4A5050332BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift in Sources */,
 				4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */,
 				4A0BC6AA2BF5F5DB0036D900 /* StringAttributeExtensions.swift in Sources */,
+				4AC3205B2C11F31C00DDB4B6 /* GetTotalTargetAmountRequestDto.swift in Sources */,
 				4AC320442C11D5AC00DDB4B6 /* AddSpendingInputFormView.swift in Sources */,
 				D8180C042BE5081F00F837FB /* FindIdContentView.swift in Sources */,
 				4A1C59882BC51AAE00EA2B49 /* OAuthAlamofire.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		4AC3205D2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3205C2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift */; };
 		4AC3205F2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */; };
 		4AC320612C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */; };
+		4AC320632C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320622C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift */; };
 		4AC4FD082BBDCC190027ACD5 /* KakaoOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD072BBDCC190027ACD5 /* KakaoOAuthViewModel.swift */; };
 		4AC4FD0A2BBDCE080027ACD5 /* GoogleOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD092BBDCE080027ACD5 /* GoogleOAuthViewModel.swift */; };
 		4AC4FD0C2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift */; };
@@ -388,6 +389,7 @@
 		4AC3205C2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCurrentMonthDummyDataRequestDto.swift; sourceTree = "<group>"; };
 		4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentMonthTargetAmountResponseDto.swift; sourceTree = "<group>"; };
 		4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForDateResponseDto.swift; sourceTree = "<group>"; };
+		4AC320622C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForPreviousMonthResponseDto.swift; sourceTree = "<group>"; };
 		4AC4FD072BBDCC190027ACD5 /* KakaoOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC4FD092BBDCE080027ACD5 /* GoogleOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAtuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAtuthViewModel.swift; sourceTree = "<group>"; };
@@ -754,9 +756,11 @@
 		4A3701AC2C08F74E00F0AEBA /* Response */ = {
 			isa = PBXGroup;
 			children = (
+
 				4A3701AB2C08F74E00F0AEBA /* GetTotalTargetAmountResponseDto.swift */,
 				4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */,
 				4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */,
+				4AC320622C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1793,6 +1797,7 @@
 				4A57897F2BDC1F4E00AFEB26 /* UnprocessableContentErrorCode.swift in Sources */,
 				4ADBFAF12BE2C4E100C3ECE4 /* GetUserProfileResponseDto.swift in Sources */,
 				D847A78F2BEBB42200899AA3 /* RequestResetPwDto.swift in Sources */,
+				4AC320632C11FE7A00DDB4B6 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */,
 				4A0FFBF52BCDA16B00EFEC56 /* CheckDuplicateRequestDto.swift in Sources */,
 				4AC320472C11D5AC00DDB4B6 /* NoSpendingHistoryView.swift in Sources */,
 				4A69C14A2BE2CF6700A27B82 /* UserDefaultsHelper.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
@@ -50,6 +50,8 @@ class BaseInterceptor: RequestInterceptor {
                     completion(.doNotRetry)
                 }
             }
-        } else {}
+        } else {
+            completion(.doNotRetry)
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Alamofire/TargetAmountAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Alamofire/TargetAmountAlamofire.swift
@@ -14,9 +14,34 @@ class TargetAmountAlamofire {
         session = Session(interceptor: interceptors, eventMonitors: monitors)
     }
     
-    func getTotalTargetAmount(completion: @escaping (Result<Data?, Error>) -> Void) {
+    func getTargetAmountForDate(completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("SpendingAlamofire - getTargetAmountForDate() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.getTargetAmountForDate, completion: completion)
+    }
+    
+    func getTotalTargetAmount(_ dto: GetTotalTargetAmountRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
         Log.info("SpendingAlamofire - getTotalTargetAmount() called")
         
-        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.getTotalTargetAmount, completion: completion)
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.getTotalTargetAmount(dto: dto), completion: completion)
     }
+    
+    func generateCurrentMonthDummyData(_ dto: GenerateCurrentMonthDummyDataRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("SpendingAlamofire - generateCurrentMonthDummyData() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.generateCurrentMonthDummyData(dto: dto), completion: completion)
+    }
+        
+    func deleteCurrentMonthTargetAmount(completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("SpendingAlamofire - deleteCurrentMonthTargetAmount() called")
+    
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.deleteCurrentMonthTargetAmount, completion: completion)
+    }
+    
+    func editCurrentMonthTargetAmount(_ dto: EditCurrentMonthTargetAmountRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("SpendingAlamofire - editCurrentMonthTargetAmount() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.editCurrentMonthTargetAmount(dto: dto), completion: completion)
+    }
+    
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Alamofire/TargetAmountAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Alamofire/TargetAmountAlamofire.swift
@@ -32,16 +32,16 @@ class TargetAmountAlamofire {
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.generateCurrentMonthDummyData(dto: dto), completion: completion)
     }
         
-    func deleteCurrentMonthTargetAmount(completion: @escaping (Result<Data?, Error>) -> Void) {
+    func deleteCurrentMonthTargetAmount(targetAmountId: Int, completion: @escaping (Result<Data?, Error>) -> Void) {
         Log.info("SpendingAlamofire - deleteCurrentMonthTargetAmount() called")
     
-        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.deleteCurrentMonthTargetAmount, completion: completion)
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.deleteCurrentMonthTargetAmount(targetAmountId: targetAmountId), completion: completion)
     }
     
-    func editCurrentMonthTargetAmount(_ dto: EditCurrentMonthTargetAmountRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+    func editCurrentMonthTargetAmount(targetAmountId: Int, dto: EditCurrentMonthTargetAmountRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
         Log.info("SpendingAlamofire - editCurrentMonthTargetAmount() called")
         
-        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.editCurrentMonthTargetAmount(dto: dto), completion: completion)
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.editCurrentMonthTargetAmount(targetAmountId: targetAmountId, dto: dto), completion: completion)
     }
     
     func getTargetAmountForPreviousMonth(completion: @escaping (Result<Data?, Error>) -> Void) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Alamofire/TargetAmountAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Alamofire/TargetAmountAlamofire.swift
@@ -44,4 +44,9 @@ class TargetAmountAlamofire {
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.editCurrentMonthTargetAmount(dto: dto), completion: completion)
     }
     
+    func getTargetAmountForPreviousMonth(completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("SpendingAlamofire - getTargetAmountForPreviousMonth() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: TargetAmountRouter.getTargetAmountForPreviousMonth, completion: completion)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Request/EditCurrentMonthTargetAmountRequestDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Request/EditCurrentMonthTargetAmountRequestDto.swift
@@ -1,0 +1,10 @@
+
+public struct EditCurrentMonthTargetAmountRequestDto: Encodable {
+    let amount: Int
+
+    public init(
+        amount: Int
+    ) {
+        self.amount = amount
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Request/GenerateCurrentMonthDummyDataRequestDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Request/GenerateCurrentMonthDummyDataRequestDto.swift
@@ -1,0 +1,14 @@
+
+public struct GenerateCurrentMonthDummyDataRequestDto: Encodable {
+    let year: Int
+    let month: Int
+  
+    public init(
+        year: Int,
+        month: Int
+     
+    ) {
+        self.year = year
+        self.month = month
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Request/GetTotalTargetAmountRequestDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Request/GetTotalTargetAmountRequestDto.swift
@@ -1,0 +1,11 @@
+
+public struct GetTotalTargetAmountRequestDto: Encodable {
+    let date: String
+  
+    public init(
+        date: String
+     
+    ) {
+        self.date = date
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/CurrentMonthTargetAmountResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/CurrentMonthTargetAmountResponseDto.swift
@@ -1,0 +1,11 @@
+// MARK: - CurrentMonthTargetAmountResponseDto
+
+/// generateCurrentMonthDummyData, editCurrentMonthTargetAmount 응답 포ㅁ
+struct CurrentMonthTargetAmountResponseDto: Codable {
+    let code: String
+    let data: AmountDetailData
+
+    struct AmountDetailData: Codable {
+        let targetAmount: AmountDetail
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/CurrentMonthTargetAmountResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/CurrentMonthTargetAmountResponseDto.swift
@@ -1,6 +1,6 @@
 // MARK: - CurrentMonthTargetAmountResponseDto
 
-/// generateCurrentMonthDummyData, editCurrentMonthTargetAmount 응답 포ㅁ
+/// generateCurrentMonthDummyData, editCurrentMonthTargetAmount 응답 포멧
 struct CurrentMonthTargetAmountResponseDto: Codable {
     let code: String
     let data: AmountDetailData

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GenerateCurrentMonthDummyDataResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GenerateCurrentMonthDummyDataResponseDto.swift
@@ -1,0 +1,12 @@
+
+// MARK: - CurrentMonthTargetAmountResponseDto
+
+/// generateCurrentMonthDummyData, editCurrentMonthTargetAmount 응답 포ㅁ
+struct CurrentMonthTargetAmountResponseDto: Codable {
+    let code: String
+    let data: AmountDetailData
+
+    struct AmountDetailData: Codable {
+        let targetAmount: AmountDetail
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForDateResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForDateResponseDto.swift
@@ -11,21 +11,3 @@ struct GetTargetAmountForDateResponseDto: Codable {
         let targetAmount: TargetAmount
     }
 }
-
-// MARK: - TargetAmount
-
-struct TargetAmount: Codable {
-    let year: Int
-    let month: Int
-    let targetAmountDetail: AmountDetail
-    let totalSpending: Int
-    let diffAmount: Int
-}
-
-// MARK: - AmountDetail
-
-struct AmountDetail: Codable {
-    let id: Int
-    let amount: Int
-    let isRead: Bool
-}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForDateResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForDateResponseDto.swift
@@ -1,0 +1,31 @@
+
+import Foundation
+
+// MARK: - GetTargetAmountForDateResponseDto
+
+struct GetTargetAmountForDateResponseDto: Codable {
+    let code: String
+    let data: targetAmountData
+
+    struct targetAmountData: Codable {
+        let targetAmount: TargetAmount
+    }
+}
+
+// MARK: - TargetAmount
+
+struct TargetAmount: Codable {
+    let year: Int
+    let month: Int
+    let targetAmountDetail: AmountDetail
+    let totalSpending: Int
+    let diffAmount: Int
+}
+
+// MARK: - AmountDetail
+
+struct AmountDetail: Codable {
+    let id: Int
+    let amount: Int
+    let isRead: Bool
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
@@ -1,0 +1,17 @@
+// MARK: - GetTargetAmountForPreviousMonthResponseDto
+
+struct GetTargetAmountForPreviousMonthResponseDto: Codable {
+    let code: String
+    let data: AmountDetailData
+
+    struct AmountDetailData: Codable {
+        let targetAmount: PreviousTargetAmount
+    }
+}
+
+// MARK: - PreviousTargetAmount
+
+struct PreviousTargetAmount: Codable {
+    let isPresent: Bool
+    let amount: Int
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
@@ -6,12 +6,10 @@ struct GetTargetAmountForPreviousMonthResponseDto: Codable {
 
     struct AmountDetailData: Codable {
         let targetAmount: PreviousTargetAmount
-    
+
         struct PreviousTargetAmount: Codable {
             let isPresent: Bool
             let amount: Int
         }
     }
 }
-
-

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
@@ -5,11 +5,6 @@ struct GetTargetAmountForPreviousMonthResponseDto: Codable {
     let data: AmountDetailData
 
     struct AmountDetailData: Codable {
-        let targetAmount: PreviousTargetAmount
-
-        struct PreviousTargetAmount: Codable {
-            let isPresent: Bool
-            let amount: Int
-        }
+        let targetAmount: RecentTargetAmount
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTargetAmountForPreviousMonthResponseDto.swift
@@ -6,12 +6,12 @@ struct GetTargetAmountForPreviousMonthResponseDto: Codable {
 
     struct AmountDetailData: Codable {
         let targetAmount: PreviousTargetAmount
+    
+        struct PreviousTargetAmount: Codable {
+            let isPresent: Bool
+            let amount: Int
+        }
     }
 }
 
-// MARK: - PreviousTargetAmount
 
-struct PreviousTargetAmount: Codable {
-    let isPresent: Bool
-    let amount: Int
-}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTotalTargetAmountResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Dto/Response/GetTotalTargetAmountResponseDto.swift
@@ -1,6 +1,3 @@
-
-import Foundation
-
 // MARK: - GetTotalTargetAmountResponseDto
 
 struct GetTotalTargetAmountResponseDto: Codable {
@@ -8,21 +5,6 @@ struct GetTotalTargetAmountResponseDto: Codable {
     let data: targetAmountData
 
     struct targetAmountData: Codable {
-        let targetAmount: TargetAmount
-    }
-}
-
-// MARK: - TargetAmount
-
-struct TargetAmount: Codable {
-    let year: Int
-    let month: Int
-    let targetAmount: Amount
-    let totalSpending: Int
-    let diffAmount: Int
-
-    struct Amount: Codable {
-        let id: Int
-        let amount: Int
+        let targetAmounts: [TargetAmount]
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
@@ -28,13 +28,13 @@ enum TargetAmountRouter: URLRequestConvertible {
     var path: String {
         switch self {
         case .getTotalTargetAmount, .generateCurrentMonthDummyData:
-            return "v2/targets-amounts"
+            return "v2/target-amounts"
         case .getTargetAmountForDate:
-            return "v2/targets-amounts/\(Date.getBasicformattedDate(from: Date()))"
+            return "v2/target-amounts/\(Date.getBasicformattedDate(from: Date()))"
         case .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount:
-            return "v2/targets-amounts/id값"
+            return "v2/target-amounts/id값"
         case .getTargetAmountForPreviousMonth:
-            return "v2/targets-amounts/recent"
+            return "v2/target-amounts/recent"
         }
     }
     

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
@@ -5,12 +5,12 @@ import Foundation
 enum TargetAmountRouter: URLRequestConvertible {
     case getTotalTargetAmount(dto: GetTotalTargetAmountRequestDto)
     case generateCurrentMonthDummyData(dto: GenerateCurrentMonthDummyDataRequestDto)
-    case getTargetAmountForDate, deleteCurrentMonthTargetAmount
+    case getTargetAmountForDate, deleteCurrentMonthTargetAmount, getTargetAmountForPreviousMonth
     case editCurrentMonthTargetAmount(dto: EditCurrentMonthTargetAmountRequestDto)
  
     var method: HTTPMethod {
         switch self {
-        case .getTotalTargetAmount, .getTargetAmountForDate:
+        case .getTargetAmountForDate, .getTotalTargetAmount, .getTargetAmountForPreviousMonth:
             return .get
         case .generateCurrentMonthDummyData:
             return .post
@@ -27,20 +27,20 @@ enum TargetAmountRouter: URLRequestConvertible {
     
     var path: String {
         switch self {
-        case .getTotalTargetAmount:
-            return "v2/targets/\(Date.getBasicformattedDate(from: Date()))"
         case .getTotalTargetAmount, .generateCurrentMonthDummyData:
             return "v2/targets-amounts"
         case .getTargetAmountForDate:
             return "v2/targets-amounts/\(Date.getBasicformattedDate(from: Date()))"
         case .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount:
             return "v2/targets-amounts/id값"
+        case .getTargetAmountForPreviousMonth:
+            return "v2/targets-amounts/recent"
         }
     }
     
     var bodyParameters: Parameters? {
         switch self {
-        case .getTargetAmountForDate, .getTotalTargetAmount, .generateCurrentMonthDummyData, .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount:
+        case .getTargetAmountForDate, .getTotalTargetAmount, .generateCurrentMonthDummyData, .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount, .getTargetAmountForPreviousMonth:
             return [:]
         }
     }
@@ -53,7 +53,7 @@ enum TargetAmountRouter: URLRequestConvertible {
             return try? dto.asDictionary()
         case let .editCurrentMonthTargetAmount(dto):
             return try? dto.asDictionary()
-        case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount:
+        case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount, .getTargetAmountForPreviousMonth:
             return [:]
         }
     }
@@ -66,7 +66,7 @@ enum TargetAmountRouter: URLRequestConvertible {
         case .getTotalTargetAmount, .generateCurrentMonthDummyData, .editCurrentMonthTargetAmount:
             let queryDatas = queryParameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
             request = URLRequest.createURLRequest(url: url, method: method, queryParameters: queryDatas)
-        case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount:
+        case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount, .getTargetAmountForPreviousMonth:
             request = URLRequest.createURLRequest(url: url, method: method)
         }
         return request

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
@@ -5,8 +5,9 @@ import Foundation
 enum TargetAmountRouter: URLRequestConvertible {
     case getTotalTargetAmount(dto: GetTotalTargetAmountRequestDto)
     case generateCurrentMonthDummyData(dto: GenerateCurrentMonthDummyDataRequestDto)
-    case getTargetAmountForDate, deleteCurrentMonthTargetAmount, getTargetAmountForPreviousMonth
-    case editCurrentMonthTargetAmount(dto: EditCurrentMonthTargetAmountRequestDto)
+    case getTargetAmountForDate, getTargetAmountForPreviousMonth
+    case editCurrentMonthTargetAmount(targetAmountId: Int, dto: EditCurrentMonthTargetAmountRequestDto)
+    case deleteCurrentMonthTargetAmount(targetAmountId: Int)
  
     var method: HTTPMethod {
         switch self {
@@ -31,8 +32,8 @@ enum TargetAmountRouter: URLRequestConvertible {
             return "v2/target-amounts"
         case .getTargetAmountForDate:
             return "v2/target-amounts/\(Date.getBasicformattedDate(from: Date()))"
-        case .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount:
-            return "v2/target-amounts/id값"
+        case let .deleteCurrentMonthTargetAmount(targetAmountId), let .editCurrentMonthTargetAmount(targetAmountId, _):
+            return "v2/target-amounts/\(targetAmountId)"
         case .getTargetAmountForPreviousMonth:
             return "v2/target-amounts/recent"
         }
@@ -51,7 +52,7 @@ enum TargetAmountRouter: URLRequestConvertible {
             return try? dto.asDictionary()
         case let .generateCurrentMonthDummyData(dto):
             return try? dto.asDictionary()
-        case let .editCurrentMonthTargetAmount(dto):
+        case let .editCurrentMonthTargetAmount(_, dto):
             return try? dto.asDictionary()
         case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount, .getTargetAmountForPreviousMonth:
             return [:]

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/TargetAmountDomain/Router/TargetAmountRouter.swift
@@ -3,12 +3,21 @@ import Alamofire
 import Foundation
 
 enum TargetAmountRouter: URLRequestConvertible {
-    case getTotalTargetAmount
+    case getTotalTargetAmount(dto: GetTotalTargetAmountRequestDto)
+    case generateCurrentMonthDummyData(dto: GenerateCurrentMonthDummyDataRequestDto)
+    case getTargetAmountForDate, deleteCurrentMonthTargetAmount
+    case editCurrentMonthTargetAmount(dto: EditCurrentMonthTargetAmountRequestDto)
  
     var method: HTTPMethod {
         switch self {
-        case .getTotalTargetAmount:
+        case .getTotalTargetAmount, .getTargetAmountForDate:
             return .get
+        case .generateCurrentMonthDummyData:
+            return .post
+        case .deleteCurrentMonthTargetAmount:
+            return .delete
+        case .editCurrentMonthTargetAmount:
+            return .patch
         }
     }
     
@@ -20,19 +29,31 @@ enum TargetAmountRouter: URLRequestConvertible {
         switch self {
         case .getTotalTargetAmount:
             return "v2/targets/\(Date.getBasicformattedDate(from: Date()))"
+        case .getTotalTargetAmount, .generateCurrentMonthDummyData:
+            return "v2/targets-amounts"
+        case .getTargetAmountForDate:
+            return "v2/targets-amounts/\(Date.getBasicformattedDate(from: Date()))"
+        case .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount:
+            return "v2/targets-amounts/id값"
         }
     }
     
     var bodyParameters: Parameters? {
         switch self {
-        case .getTotalTargetAmount:
+        case .getTargetAmountForDate, .getTotalTargetAmount, .generateCurrentMonthDummyData, .deleteCurrentMonthTargetAmount, .editCurrentMonthTargetAmount:
             return [:]
         }
     }
     
     var queryParameters: Parameters? {
         switch self {
-        case .getTotalTargetAmount:
+        case let .getTotalTargetAmount(dto):
+            return try? dto.asDictionary()
+        case let .generateCurrentMonthDummyData(dto):
+            return try? dto.asDictionary()
+        case let .editCurrentMonthTargetAmount(dto):
+            return try? dto.asDictionary()
+        case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount:
             return [:]
         }
     }
@@ -42,7 +63,10 @@ enum TargetAmountRouter: URLRequestConvertible {
         var request: URLRequest
         
         switch self {
-        case .getTotalTargetAmount:
+        case .getTotalTargetAmount, .generateCurrentMonthDummyData, .editCurrentMonthTargetAmount:
+            let queryDatas = queryParameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+            request = URLRequest.createURLRequest(url: url, method: method, queryParameters: queryDatas)
+        case .getTargetAmountForDate, .deleteCurrentMonthTargetAmount:
             request = URLRequest.createURLRequest(url: url, method: method)
         }
         return request

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/ListItem/CategoryIconListItem.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/ListItem/CategoryIconListItem.swift
@@ -36,7 +36,7 @@ enum CategoryIconName: String {
     case eventOn = "icon_category_event_on"
     case etcOff = "icon_category_etc_off"
     case etcOn = "icon_category_etc_on"
-    case otherOff = "icon_category_plus_off"
+    case plusOff = "icon_category_plus_off"
 }
 
 // MARK: - SpendingCategoryData
@@ -63,6 +63,7 @@ enum SpendingCategoryIconList: String, CaseIterable {
     case alcoholOrEntertainment = "ALCOHOL_OR_ENTERTAINMENT"
     case membershipOrFamilyEvent = "MEMBERSHIP_OR_FAMILY_EVENT"
     case other = "OTHER"
+    case plus = "PLUS"
 
     var details: SpendingCategoryData {
         switch self {
@@ -89,7 +90,9 @@ enum SpendingCategoryIconList: String, CaseIterable {
         case .membershipOrFamilyEvent:
             return SpendingCategoryData(id: -11, isCustom: false, name: "회비/경조사", icon: .eventOn)
         case .other:
-            return SpendingCategoryData(id: -12, isCustom: false, name: "추가하기", icon: .otherOff)
+            return SpendingCategoryData(id: -12, isCustom: false, name: "기타", icon: .etcOn)
+        case .plus:
+            return SpendingCategoryData(id: -13, isCustom: false, name: "추가하기", icon: .plusOff)
         }
     }
 
@@ -118,7 +121,9 @@ enum SpendingCategoryIconList: String, CaseIterable {
         case .eventOn:
             return .membershipOrFamilyEvent
         case .etcOn:
-            return .other // TODO: 추후 수정 필요
+            return .other
+        case .plusOff:
+            return .plus // TODO: 추후 수정 필요
         default:
             return nil
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
@@ -20,5 +20,5 @@ struct AmountDetail: Codable {
 
 struct RecentTargetAmount: Codable {
     let isPresent: Bool
-    let amount: Int
+    let amount: Int?
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
@@ -1,0 +1,18 @@
+
+// MARK: - TargetAmount
+
+struct TargetAmount: Codable {
+    var year: Int
+    var month: Int
+    var targetAmountDetail: AmountDetail
+    var totalSpending: Int
+    var diffAmount: Int
+}
+
+// MARK: - AmountDetail
+
+struct AmountDetail: Codable {
+    var id: Int
+    var amount: Int
+    var isRead: Bool
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
@@ -15,3 +15,10 @@ struct AmountDetail: Codable {
     var amount: Int
     var isRead: Bool
 }
+
+// MARK: - RecentTargetAmount
+
+struct RecentTargetAmount: Codable {
+    let isPresent: Bool
+    let amount: Int
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
@@ -1,4 +1,3 @@
-
 // MARK: - TargetAmount
 
 struct TargetAmount: Codable {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
@@ -6,6 +6,8 @@ struct InquiryView: View {
     @State private var isSelectedCategory: Bool = false
     @State private var isSelectedAgreeBtn: Bool = false
     @State private var showAgreement: Bool = false
+    
+    @Environment(\.presentationMode) var presentationMode
 
     let placeholder: String = "문의 내용을 입력해주세요"
 
@@ -160,7 +162,11 @@ struct InquiryView: View {
 
     private func continueButtonAction() {
         if viewModel.isFormValid {
-            viewModel.sendInquiryMailApi()
+            viewModel.sendInquiryMailApi { success in
+                if success {
+                    self.presentationMode.wrappedValue.dismiss()
+                }
+            }
         }
     }
     

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -24,9 +24,9 @@ struct ProfileSettingListView: View {
                     ])
 
                     Divider()
-                        .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
-                        .overlay(Color("Gray02"))
-
+                            .overlay(Color("Gray02"))
+                            .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
+                    
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
 
                     ProfileSettingSectionView(showingPopUp: $showingPopUp, title: "앱 설정", itemsWithActions: [
@@ -34,8 +34,8 @@ struct ProfileSettingListView: View {
                     ])
 
                     Divider()
-                        .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
                         .overlay(Color("Gray02"))
+                        .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
 
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
 
@@ -46,8 +46,8 @@ struct ProfileSettingListView: View {
                     ])
 
                     Divider()
-                        .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
                         .overlay(Color("Gray02"))
+                        .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
 
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -24,9 +24,9 @@ struct ProfileSettingListView: View {
                     ])
 
                     Divider()
-                            .overlay(Color("Gray02"))
-                            .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
-                    
+                        .overlay(Color("Gray02"))
+                        .frame(width: 301 * DynamicSizeFactor.factor(), height: 0.43)
+
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
 
                     ProfileSettingSectionView(showingPopUp: $showingPopUp, title: "앱 설정", itemsWithActions: [

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -58,9 +58,10 @@ struct SelectCategoryIconView: View {
             Spacer()
 
             CustomBottomButton(action: {
-                if let selectedCategory = SpendingCategoryIconList.fromIcon(viewModel.selectedCategoryIcon ?? .etcOn) {
+                if let selectedCategory = SpendingCategoryIconList.fromIcon(selectedCategoryIcon) {
                     viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                     viewModel.selectedCategoryIcon = selectedCategoryIcon
+                    Log.debug(viewModel.selectedCategoryIconTitle)
                     isPresented = false
                 }
             }, label: "확인", isFormValid: .constant(true))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/EditSpendingDetailView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/EditSpendingDetailView.swift
@@ -25,7 +25,6 @@ struct EditSpendingDetailView: View {
                     .frame(width: 40, height: 4)
                     .platformTextColor(color: Color("Gray03"))
                     .padding(.top, 12)
-                    .padding(.horizontal, 140)
 
                 HStack(spacing: 0) {
                     Button(action: {
@@ -47,7 +46,7 @@ struct EditSpendingDetailView: View {
                     })
 
                     Button(action: {}, label: {
-                        Image("icon_navigation_add")
+                        Image("icon_navigation_add_black")
                             .scaledToFill()
                             .frame(width: 28 * DynamicSizeFactor.factor(), height: 28 * DynamicSizeFactor.factor())
                             .padding(8)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -30,12 +30,11 @@ struct SpendingDetailSheetView: View {
     ]
     var body: some View {
         ZStack(alignment: .leading) {
-            VStack(alignment: .leading) {
+            VStack {
                 RoundedRectangle(cornerRadius: 10)
                     .frame(width: 40, height: 4)
                     .platformTextColor(color: Color("Gray03"))
                     .padding(.top, 12)
-                    .padding(.horizontal, 140)
                 
                 HStack {
                     Text("6월 4일")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct RecentTargetAmountSuggestionView: View {
+    @ObservedObject var viewModel: TargetAmountViewModel
     @Binding var showToastPopup: Bool
     @Binding var isHidden: Bool
     
@@ -17,6 +18,7 @@ struct RecentTargetAmountSuggestionView: View {
                 
                 Button(action: {
                     isHidden = true
+                    viewModel.deleteCurrentMonthTargetAmountApi()
                 }, label: {
                     Image("icon_close_white")
                         .resizable()
@@ -26,7 +28,7 @@ struct RecentTargetAmountSuggestionView: View {
             .padding(.leading, 18 * DynamicSizeFactor.factor())
             .padding(.trailing, 13 * DynamicSizeFactor.factor())
     
-            Text("6월 목표금액: 500,000원")
+            Text("6월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원") // 백엔드에게 월 데이터 요청
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Mint02"))
                 .padding(.leading, 18 * DynamicSizeFactor.factor())
@@ -44,6 +46,7 @@ struct RecentTargetAmountSuggestionView: View {
                 Button(action: {
                     isHidden = true
                     showToastPopup = true
+                    viewModel.editCurrentMonthTargetAmountApi()
                     
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                         showToastPopup = false

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
@@ -28,7 +28,7 @@ struct RecentTargetAmountSuggestionView: View {
             .padding(.leading, 18 * DynamicSizeFactor.factor())
             .padding(.trailing, 13 * DynamicSizeFactor.factor())
     
-            Text("6월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원") // 백엔드에게 월 데이터 요청
+            Text("5월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원") // 백엔드에게 월 데이터 요청
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Mint02"))
                 .padding(.leading, 18 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -93,17 +93,19 @@ struct SpendingCheckBoxView: View {
                 } else {
                     Spacer()
 
-                    HStack(spacing: 0) {
-                        Text("목표금액 설정하기")
-                            .font(.B1SemiboldeFont())
-                            .platformTextColor(color: Color("Mint03"))
+                    NavigationLink(destination: TotalTargetAmountView()) {
+                        HStack(spacing: 0) {
+                            Text("목표금액 설정하기")
+                                .font(.B1SemiboldeFont())
+                                .platformTextColor(color: Color("Mint03"))
 
-                        Image("icon_arrow_front_small")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                            Image("icon_arrow_front_small")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                        }
+                        .frame(width: 110 * DynamicSizeFactor.factor(), alignment: .trailing)
                     }
-                    .frame(width: 110 * DynamicSizeFactor.factor(), alignment: .trailing)
                 }
             }
             .padding(.leading, 22)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -24,7 +24,7 @@ struct SpendingCheckBoxView: View {
                                                StringAttribute(
                                                    text: "\(formattedTotalSpent)원",
                                                    font: .H3SemiboldFont(),
-                                                   color: CGFloat(viewModel.totalSpent) > viewModel.targetValue ? Color("Red03") : Color("Mint03")
+                                                   color: CGFloat(viewModel.totalSpent) > viewModel.targetAmountValue ? Color("Red03") : Color("Mint03")
                                                ))
                                                .lineSpacing(3)
                 Spacer()
@@ -42,17 +42,17 @@ struct SpendingCheckBoxView: View {
                     .cornerRadius(15)
 
                 let progressWidth: CGFloat = {
-                    if viewModel.targetValue <= 0 {
+                    if viewModel.targetAmountValue <= 0 {
                         return 0
                     }
-                    let ratio = CGFloat(viewModel.totalSpent) / viewModel.targetValue
+                    let ratio = CGFloat(viewModel.totalSpent) / viewModel.targetAmountValue
                     let width = ratio * (UIScreen.main.bounds.width - 76)
                     return min(max(width, 0), UIScreen.main.bounds.width - 76)
                 }()
 
                 Rectangle()
                     .frame(width: progressWidth, height: 24 * DynamicSizeFactor.factor()) // 현재 지출에 따른 프로그래스 바
-                    .platformTextColor(color: CGFloat(viewModel.totalSpent) > viewModel.targetValue ? Color("Red03") : Color("Mint03"))
+                    .platformTextColor(color: CGFloat(viewModel.totalSpent) > viewModel.targetAmountValue ? Color("Red03") : Color("Mint03"))
                     .cornerRadius(15)
             }
 
@@ -61,12 +61,12 @@ struct SpendingCheckBoxView: View {
             HStack {
                 Text("\(viewModel.totalSpent)")
                     .font(.B1SemiboldeFont())
-                    .platformTextColor(color: CGFloat(viewModel.totalSpent) > viewModel.targetValue ? Color("Red03") : Color("Mint03"))
+                    .platformTextColor(color: CGFloat(viewModel.totalSpent) > viewModel.targetAmountValue ? Color("Red03") : Color("Mint03"))
                 Spacer()
 
                 NavigationLink(destination: TotalTargetAmountView()) {
                     HStack(spacing: 0) {
-                        Text("\(Int(viewModel.targetValue))")
+                        Text("\(Int(viewModel.targetAmountValue))")
                             .font(.B1SemiboldeFont())
                             .platformTextColor(color: Color("Gray07"))
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -4,15 +4,26 @@ import SwiftUI
 struct SpendingCheckBoxView: View {
     @ObservedObject var viewModel: TargetAmountViewModel
 
-    /// 프로그래스 바에 사용될 최대 값
     let baseAttribute = BaseAttribute(font: .H3SemiboldFont(), color: Color("Gray07"))
 
     var formattedTotalSpent: String {
-        NumberFormatterUtil.formatIntToDecimalString(viewModel.totalSpent)
+        if let targetAmountData = viewModel.targetAmountData {
+            return NumberFormatterUtil.formatIntToDecimalString(targetAmountData.totalSpending)
+        } else {
+            return "0"
+        }
     }
 
     var spentInfoText: String {
         "반가워요 \(String(describing: getUserData()?.username ?? ""))님! \n이번 달에 \(formattedTotalSpent)원 썼어요"
+    }
+
+    var totalSpending: Int {
+        viewModel.targetAmountData?.totalSpending ?? 0
+    }
+
+    var targetAmount: Int {
+        viewModel.targetAmountData?.targetAmountDetail.amount ?? 0
     }
 
     var body: some View {
@@ -24,7 +35,7 @@ struct SpendingCheckBoxView: View {
                                                StringAttribute(
                                                    text: "\(formattedTotalSpent)원",
                                                    font: .H3SemiboldFont(),
-                                                   color: CGFloat(viewModel.totalSpent) > viewModel.targetAmountValue ? Color("Red03") : Color("Mint03")
+                                                   color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03")
                                                ))
                                                .lineSpacing(3)
                 Spacer()
@@ -42,40 +53,54 @@ struct SpendingCheckBoxView: View {
                     .cornerRadius(15)
 
                 let progressWidth: CGFloat = {
-                    if viewModel.targetAmountValue <= 0 {
+                    if targetAmount <= 0 {
                         return 0
                     }
-                    let ratio = CGFloat(viewModel.totalSpent) / viewModel.targetAmountValue
+                    let ratio = CGFloat(totalSpending) / CGFloat(targetAmount)
                     let width = ratio * (UIScreen.main.bounds.width - 76)
                     return min(max(width, 0), UIScreen.main.bounds.width - 76)
                 }()
 
                 Rectangle()
                     .frame(width: progressWidth, height: 24 * DynamicSizeFactor.factor()) // 현재 지출에 따른 프로그래스 바
-                    .platformTextColor(color: CGFloat(viewModel.totalSpent) > viewModel.targetAmountValue ? Color("Red03") : Color("Mint03"))
+                    .platformTextColor(color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
                     .cornerRadius(15)
             }
 
             Spacer().frame(height: 2)
 
             HStack {
-                Text("\(viewModel.totalSpent)")
+                Text("\(totalSpending)")
                     .font(.B1SemiboldeFont())
-                    .platformTextColor(color: CGFloat(viewModel.totalSpent) > viewModel.targetAmountValue ? Color("Red03") : Color("Mint03"))
+                    .platformTextColor(color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
                 Spacer()
 
-                NavigationLink(destination: TotalTargetAmountView()) {
+                if viewModel.isPresentTargetAmount == true {
+                    NavigationLink(destination: TotalTargetAmountView()) {
+                        HStack(spacing: 0) {
+                            Text("\(targetAmount)")
+                                .font(.B1SemiboldeFont())
+                                .platformTextColor(color: Color("Gray07"))
+
+                            Image("icon_arrow_front_small")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                        }
+                        .frame(width: 79 * DynamicSizeFactor.factor(), alignment: .trailing)
+                    }
+                } else {
                     HStack(spacing: 0) {
-                        Text("\(Int(viewModel.targetAmountValue))")
+                        Text("목표금액 설정하기")
                             .font(.B1SemiboldeFont())
-                            .platformTextColor(color: Color("Gray07"))
+                            .platformTextColor(color: Color("Mint03"))
 
                         Image("icon_arrow_front_small")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                     }
-                    .frame(width: 79 * DynamicSizeFactor.factor(), alignment: .trailing)
+                    .frame(width: 110 * DynamicSizeFactor.factor(), alignment: .trailing)
                 }
             }
             .padding(.leading, 22)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -35,7 +35,7 @@ struct SpendingCheckBoxView: View {
                                                StringAttribute(
                                                    text: "\(formattedTotalSpent)원",
                                                    font: .H3SemiboldFont(),
-                                                   color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03")
+                                                   color: targetAmount != -1 && totalSpending > targetAmount ? Color("Red03") : Color("Mint03")
                                                ))
                                                .lineSpacing(3)
                 Spacer()
@@ -70,12 +70,13 @@ struct SpendingCheckBoxView: View {
             Spacer().frame(height: 2)
 
             HStack {
-                Text("\(totalSpending)")
-                    .font(.B1SemiboldeFont())
-                    .platformTextColor(color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
-                Spacer()
-
                 if viewModel.isPresentTargetAmount == true {
+                    Text("\(totalSpending)")
+                        .font(.B1SemiboldeFont())
+                        .platformTextColor(color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
+
+                    Spacer()
+
                     NavigationLink(destination: TotalTargetAmountView()) {
                         HStack(spacing: 0) {
                             Text("\(targetAmount)")
@@ -90,6 +91,8 @@ struct SpendingCheckBoxView: View {
                         .frame(width: 79 * DynamicSizeFactor.factor(), alignment: .trailing)
                     }
                 } else {
+                    Spacer()
+
                     HStack(spacing: 0) {
                         Text("목표금액 설정하기")
                             .font(.B1SemiboldeFont())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -122,7 +122,7 @@ struct SpendingManagementMainView: View {
                     if showToastPopup {
                         CustomToastView(message: "\(Date.month(from: Date()))월의 새로운 목표금액을 설정했어요")
                             .transition(.move(edge: .bottom))
-                            .animation(.easeInOut(duration: 0.5))
+                            .animation(.easeInOut(duration: 0.2)) // 애니메이션 시간
                             .padding(.bottom, 10)
                     }
                 }, alignment: .bottom

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -20,7 +20,7 @@ struct SpendingManagementMainView: View {
                     Spacer().frame(height: 16 * DynamicSizeFactor.factor())
 
                     if !targetAmountViewModel.isHiddenSuggestionView {
-                        RecentTargetAmountSuggestionView(showToastPopup: $showToastPopup, isHidden: $targetAmountViewModel.isHiddenSuggestionView)
+                        RecentTargetAmountSuggestionView(viewModel: targetAmountViewModel, showToastPopup: $showToastPopup, isHidden: $targetAmountViewModel.isHiddenSuggestionView)
 
                         Spacer().frame(height: 13 * DynamicSizeFactor.factor())
                     }
@@ -118,7 +118,7 @@ struct SpendingManagementMainView: View {
             .overlay(
                 Group {
                     if showToastPopup {
-                        CustomToastView(message: "7월의 새로운 목표금액을 설정했어요")
+                        CustomToastView(message: "\(Date.month(from: Date()))월의 새로운 목표금액을 설정했어요")
                             .transition(.move(edge: .bottom))
                             .animation(.easeInOut(duration: 0.5))
                             .padding(.bottom, 10)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -76,7 +76,7 @@ struct SpendingManagementMainView: View {
             .setTabBarVisibility(isHidden: ishidden)
             .onAppear {
                 spendingHistoryViewModel.checkSpendingHistoryApi { _ in }
-                targetAmountViewModel.getTotalTargetAmountApi { _ in }
+                targetAmountViewModel.getTargetAmountForDateApi { _ in }
             }
             .navigationBarColor(UIColor(named: "Gray01"), title: "")
             .background(Color("Gray01"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -9,10 +9,9 @@ struct SpendingManagementMainView: View {
     @State private var showSpendingDetailView = false
     @State private var showEditSpendingDetailView: Bool = false
 
-    @State private var ishidden = false
+    @State private var ishidden = false // 변수명 바꿀 필요
 
     @State private var showToastPopup = false
-    @State private var isHiddenSuggestionView = false
 
     var body: some View {
         NavigationAvailable {
@@ -20,8 +19,8 @@ struct SpendingManagementMainView: View {
                 VStack {
                     Spacer().frame(height: 16 * DynamicSizeFactor.factor())
 
-                    if !isHiddenSuggestionView {
-                        RecentTargetAmountSuggestionView(showToastPopup: $showToastPopup, isHidden: $isHiddenSuggestionView)
+                    if !targetAmountViewModel.isHiddenSuggestionView {
+                        RecentTargetAmountSuggestionView(showToastPopup: $showToastPopup, isHidden: $targetAmountViewModel.isHiddenSuggestionView)
 
                         Spacer().frame(height: 13 * DynamicSizeFactor.factor())
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/InquiryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/InquiryViewModel.swift
@@ -32,7 +32,7 @@ class InquiryViewModel: ObservableObject {
         }
     }
 
-    func sendInquiryMailApi() {
+    func sendInquiryMailApi(completion: @escaping (Bool) -> Void) {
         let categoryCode = getCategoryCode(for: category)
 
         let inquiryRequestDto = BackofficeRequestDto(email: email, content: content, category: categoryCode)
@@ -43,9 +43,9 @@ class InquiryViewModel: ObservableObject {
                 do {
                     if let responseData = data {
                         let response = try JSONDecoder().decode(SmsResponseDto.self, from: responseData)
-                        NavigationUtil.popToRootView()
 
                         Log.debug("문의하기 api 응답 성공 : \(response)")
+                        completion(true)
                     }
                 } catch {
                     Log.fault("Error decoding JSON: \(error)")
@@ -56,6 +56,7 @@ class InquiryViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
+                completion(false)
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/AddSpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/AddSpendingHistoryViewModel.swift
@@ -45,10 +45,10 @@ class AddSpendingHistoryViewModel: ObservableObject {
                             Log.debug("사용자 정의 카테고리 조회 완료 \(jsonString)")
                         }
                         let staticCategories = SpendingCategoryIconList.allCases
-                            .filter { $0 != .other }
+                            .filter { $0 != .other && $0 != .plus }
                             .map { $0.details }
 
-                        let otherCategory = SpendingCategoryIconList.other.details
+                        let otherCategory = SpendingCategoryIconList.plus.details
                         let dynamicCategories = response.data.spendingCategories.compactMap { self.convertToSpendingCategoryData(from: $0) }
                         self.spendingCategories = staticCategories + dynamicCategories + [otherCategory]
                     } catch {
@@ -121,7 +121,7 @@ class AddSpendingHistoryViewModel: ObservableObject {
                 categoryId = -1
             }
         } else { // 사용자 정의 카테고리
-            selectedCategoryIconTitle = "OTHER"
+            selectedCategoryIconTitle = "CUSTOM"
             categoryId = selectedCategory?.id ?? 0
         }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -24,7 +24,12 @@ class TargetAmountViewModel: ObservableObject {
                             // 추천 금액 보여주기 x + 목표 금액 데이터 적용
                             self.isHiddenSuggestionView = true
                             self.isPresentTargetAmount = true
-                        } else {                            
+                        } else if validTargetAmount.targetAmountDetail.amount == -1 {
+                            self.isHiddenSuggestionView = true
+                            self.isPresentTargetAmount = false
+                            
+                            self.getTargetAmountForPreviousMonthApi()
+                        } else {
                             self.getTargetAmountForPreviousMonthApi()
                         }
 
@@ -75,7 +80,6 @@ class TargetAmountViewModel: ObservableObject {
                             self.isHiddenSuggestionView = false
                             self.isPresentTargetAmount = false
                             // 추천 금액 보여주기 + 목표 금액 설정하기 UI
-         
                         } else {
                             self.deleteCurrentMonthTargetAmountApi()
                         }
@@ -137,7 +141,7 @@ class TargetAmountViewModel: ObservableObject {
     }
     
     func editCurrentMonthTargetAmountApi() {
-        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: recentTargetAmountData!.amount)
+        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: recentTargetAmountData!.amount ?? 0)
         
         TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(targetAmountId: targetAmountData?.targetAmountDetail.id ?? -1, dto: editCurrentMonthTargetAmountRequestDto) { result in
             switch result {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -6,39 +6,98 @@ class TargetAmountViewModel: ObservableObject {
     @Published var totalSpent = 0
     @Published var targetValue: CGFloat = 0
 
-    func getTotalTargetAmountApi(completion: @escaping (Bool) -> Void) {
-//        TargetAmountAlamofire.shared.getTotalTargetAmount { result in
-//            switch result {
-//            case let .success(data):
-//                if let responseData = data {
-//                    do {
-//                        let response = try JSONDecoder().decode(GetTotalTargetAmountResponseDto.self, from: responseData)
-//
-//                        let validTotalSpending = response.data.targetAmount // 현재 달의 총 지출 금액 찾기
-//                        self.totalSpent = validTotalSpending.totalSpending
-//
+    func getTotalTargetAmountApi(completion : @escaping (Bool) -> Void) {
+        
+        TargetAmountAlamofire.shared.getTargetAmountForDate { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    do {
+                        let response = try JSONDecoder().decode(GetTargetAmountForDateResponseDto.self, from: responseData)
+
+                        let validTargetAmount = response.data.targetAmount
+                       
+                        if validTargetAmount.targetAmountDetail.isRead == true{
+                            self.totalSpent = validTargetAmount.totalSpending
+                            self.targetValue = CGFloat(validTargetAmount.targetAmountDetail.amount)
+                            //TODO: 화면 안나오도록
+                        }else{
+                            
+                            //TODO: getTargetAmountForPreviousMonth 요청
+                        }
+                        
+                       
+                        
+                        
+
 //                        if validTotalSpending.targetAmount.id != -1 && validTotalSpending.targetAmount.amount != -1 {
 //                            self.targetValue = CGFloat(validTotalSpending.targetAmount.amount)
 //                            // TODO: -1인 경우 목표 금액이 없으므로, 목표 금액 설정하기 화면 보여주기
 //                        }
-//
-//                        if let jsonString = String(data: responseData, encoding: .utf8) {
-//                            Log.debug("지출 내역 조회 완료 \(jsonString)")
-//                        }
-//                        completion(true)
-//                    } catch {
-//                        Log.fault("Error decoding JSON: \(error)")
-//                        completion(false)
-//                    }
-//                }
-//            case let .failure(error):
-//                if let StatusSpecificError = error as? StatusSpecificError {
-//                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
-//                } else {
-//                    Log.error("Network request failed: \(error)")
-//                }
-//                completion(false)
-//            }
-//        }
+
+                        if let jsonString = String(data: responseData, encoding: .utf8) {
+                            Log.debug("지출 내역 조회 완료 \(jsonString)")
+                        }
+                        completion(true)
+                    } catch {
+                        Log.fault("Error decoding JSON: \(error)")
+                        completion(false)
+                    }
+                }
+            case let .failure(error):
+                
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                    
+                    //TODO: 404 오류 처리
+                    if StatusSpecificError.domainError == .notFound{
+                        //TODO: deleteCurrentMonthTargetAmount 요청
+                    } else {
+                       
+                    }
+                    
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
+    }
+    
+    
+    func getTargetAmountForPreviousMonthApi(completion : @escaping (Bool) -> Void) {
+        TargetAmountAlamofire.shared.getTargetAmountForPreviousMonth { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    do {
+                        let response = try JSONDecoder().decode(GetTargetAmountForPreviousMonthResponseDto.self, from: responseData)
+                        
+                        let isPresent = response.data.targetAmount.isPresent
+                        
+                        if isPresent == true{
+                            //TODO: 추천 금액 보여주기
+                        }else{
+                            //TODO: deleteCurrentMonthTargetAmount 요청
+                        }
+
+                        if let jsonString = String(data: responseData, encoding: .utf8) {
+                            Log.debug("지출 내역 조회 완료 \(jsonString)")
+                        }
+                        completion(true)
+                    } catch {
+                        Log.fault("Error decoding JSON: \(error)")
+                        completion(false)
+                    }
+                }
+            case let .failure(error):
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -29,8 +29,6 @@ class TargetAmountViewModel: ObservableObject {
                             self.isPresentTargetAmount = false
                             
                             self.getTargetAmountForPreviousMonthApi()
-                        } else {
-                            self.getTargetAmountForPreviousMonthApi()
                         }
 
                         if let jsonString = String(data: responseData, encoding: .utf8) {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -7,38 +7,38 @@ class TargetAmountViewModel: ObservableObject {
     @Published var targetValue: CGFloat = 0
 
     func getTotalTargetAmountApi(completion: @escaping (Bool) -> Void) {
-        TargetAmountAlamofire.shared.getTotalTargetAmount { result in
-            switch result {
-            case let .success(data):
-                if let responseData = data {
-                    do {
-                        let response = try JSONDecoder().decode(GetTotalTargetAmountResponseDto.self, from: responseData)
-
-                        let validTotalSpending = response.data.targetAmount // 현재 달의 총 지출 금액 찾기
-                        self.totalSpent = validTotalSpending.totalSpending
-
-                        if validTotalSpending.targetAmount.id != -1 && validTotalSpending.targetAmount.amount != -1 {
-                            self.targetValue = CGFloat(validTotalSpending.targetAmount.amount)
-                            // TODO: -1인 경우 목표 금액이 없으므로, 목표 금액 설정하기 화면 보여주기
-                        }
-
-                        if let jsonString = String(data: responseData, encoding: .utf8) {
-                            Log.debug("지출 내역 조회 완료 \(jsonString)")
-                        }
-                        completion(true)
-                    } catch {
-                        Log.fault("Error decoding JSON: \(error)")
-                        completion(false)
-                    }
-                }
-            case let .failure(error):
-                if let StatusSpecificError = error as? StatusSpecificError {
-                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
-                } else {
-                    Log.error("Network request failed: \(error)")
-                }
-                completion(false)
-            }
-        }
+//        TargetAmountAlamofire.shared.getTotalTargetAmount { result in
+//            switch result {
+//            case let .success(data):
+//                if let responseData = data {
+//                    do {
+//                        let response = try JSONDecoder().decode(GetTotalTargetAmountResponseDto.self, from: responseData)
+//
+//                        let validTotalSpending = response.data.targetAmount // 현재 달의 총 지출 금액 찾기
+//                        self.totalSpent = validTotalSpending.totalSpending
+//
+//                        if validTotalSpending.targetAmount.id != -1 && validTotalSpending.targetAmount.amount != -1 {
+//                            self.targetValue = CGFloat(validTotalSpending.targetAmount.amount)
+//                            // TODO: -1인 경우 목표 금액이 없으므로, 목표 금액 설정하기 화면 보여주기
+//                        }
+//
+//                        if let jsonString = String(data: responseData, encoding: .utf8) {
+//                            Log.debug("지출 내역 조회 완료 \(jsonString)")
+//                        }
+//                        completion(true)
+//                    } catch {
+//                        Log.fault("Error decoding JSON: \(error)")
+//                        completion(false)
+//                    }
+//                }
+//            case let .failure(error):
+//                if let StatusSpecificError = error as? StatusSpecificError {
+//                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+//                } else {
+//                    Log.error("Network request failed: \(error)")
+//                }
+//                completion(false)
+//            }
+//        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -101,6 +101,30 @@ class TargetAmountViewModel: ObservableObject {
         }
     }
     
+    func generateCurrentMonthDummyDataApi(completion: @escaping (Bool) -> Void) {
+        
+        let generateCurrentMonthDummyDataRequestDto = GenerateCurrentMonthDummyDataRequestDto(year: Date.year(from: Date()), month: Date.month(from: Date()))
+        
+        TargetAmountAlamofire.shared.generateCurrentMonthDummyData(generateCurrentMonthDummyDataRequestDto) { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    if let jsonString = String(data: responseData, encoding: .utf8) {
+                        Log.debug("당월 목표 금액 더미값 생성 \(jsonString)")
+                    }
+                    completion(true)
+                }
+            case let .failure(error):
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
+    }
+    
     func deleteCurrentMonthTargetAmountApi(completion: @escaping (Bool) -> Void) {
         TargetAmountAlamofire.shared.deleteCurrentMonthTargetAmount { result in
             switch result {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -4,8 +4,10 @@ import SwiftUI
 
 class TargetAmountViewModel: ObservableObject {
     @Published var targetAmountData: TargetAmount? = nil
-    @Published var isHiddenSuggestionView = true//추천 금액 뷰
-    @Published var isPresentTargetAmount = true//당월 목표 금액 존재 여부
+    @Published var isHiddenSuggestionView = true // 추천 금액 뷰
+    @Published var isPresentTargetAmount = true // 당월 목표 금액 존재 여부
+    
+    @Published var recentTargetAmountData: RecentTargetAmount? = nil // 당월 이전 사용자의 최신 목표 금액
 
     func getTargetAmountForDateApi(completion: @escaping (Bool) -> Void) {
         TargetAmountAlamofire.shared.getTargetAmountForDate { result in
@@ -16,23 +18,14 @@ class TargetAmountViewModel: ObservableObject {
                         let response = try JSONDecoder().decode(GetTargetAmountForDateResponseDto.self, from: responseData)
 
                         let validTargetAmount = response.data.targetAmount
+                        self.targetAmountData = validTargetAmount
                        
                         if validTargetAmount.targetAmountDetail.isRead == true {
-                            self.targetAmountData = validTargetAmount
+                            // 추천 금액 보여주기 x + 목표 금액 데이터 적용
                             self.isHiddenSuggestionView = true
-                            self.isPresentTargetAmount = false
-                        } else {
-                            
-                            self.getTargetAmountForPreviousMonthApi{ isPresent in
-                                if isPresent{
-                                    self.targetAmountData = validTargetAmount
-                                    self.isHiddenSuggestionView = false
-                                    self.isPresentTargetAmount = false
-                                }else{
-                                    self.deleteCurrentMonthTargetAmountApi{ _ in}
-                                }
-                            }
-                            // TODO: getTargetAmountForPreviousMonth 요청
+                            self.isPresentTargetAmount = true
+                        } else {                            
+                            self.getTargetAmountForPreviousMonthApi()
                         }
 
                         if let jsonString = String(data: responseData, encoding: .utf8) {
@@ -50,9 +43,10 @@ class TargetAmountViewModel: ObservableObject {
                     Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
                     
                     if StatusSpecificError.domainError == .notFound {
+                        // 추천 금액 보여주기 x + 목표 금액 설정하기 UI
                         self.isHiddenSuggestionView = true
                         self.isPresentTargetAmount = false
-                        // TODO: generateCurrentMonthDummyData 요청 + 추천 금액 보여주기 x + 목표 금액 설정하기 UI
+                        self.generateCurrentMonthDummyDataApi()
                     }
                 } else {
                     Log.error("Network request failed: \(error)")
@@ -62,7 +56,7 @@ class TargetAmountViewModel: ObservableObject {
         }
     }
     
-    func getTargetAmountForPreviousMonthApi(completion: @escaping (Bool) -> Void) {
+    func getTargetAmountForPreviousMonthApi() {
         TargetAmountAlamofire.shared.getTargetAmountForPreviousMonth { result in
             switch result {
             case let .success(data):
@@ -74,20 +68,20 @@ class TargetAmountViewModel: ObservableObject {
                             Log.debug("당월 이전 사용자 최신 목표 금액 조회 완료 \(jsonString)")
                         }
                         
+                        self.recentTargetAmountData = response.data.targetAmount
                         let isPresent = response.data.targetAmount.isPresent
                         
                         if isPresent == true {
-                            // TODO: 추천 금액 보여주기 + 목표 금액 설정하기 UI
-                            completion(true)
+                            self.isHiddenSuggestionView = false
+                            self.isPresentTargetAmount = false
+                            // 추천 금액 보여주기 + 목표 금액 설정하기 UI
+         
                         } else {
-                            // TODO: deleteCurrentMonthTargetAmount 요청
-                            completion(false)
+                            self.deleteCurrentMonthTargetAmountApi()
                         }
-
-                        
+               
                     } catch {
                         Log.fault("Error decoding JSON: \(error)")
-                        completion(false)
                     }
                 }
             case let .failure(error):
@@ -96,13 +90,11 @@ class TargetAmountViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
-                completion(false)
             }
         }
     }
     
-    func generateCurrentMonthDummyDataApi(completion: @escaping (Bool) -> Void) {
-        
+    func generateCurrentMonthDummyDataApi() {
         let generateCurrentMonthDummyDataRequestDto = GenerateCurrentMonthDummyDataRequestDto(year: Date.year(from: Date()), month: Date.month(from: Date()))
         
         TargetAmountAlamofire.shared.generateCurrentMonthDummyData(generateCurrentMonthDummyDataRequestDto) { result in
@@ -112,7 +104,6 @@ class TargetAmountViewModel: ObservableObject {
                     if let jsonString = String(data: responseData, encoding: .utf8) {
                         Log.debug("당월 목표 금액 더미값 생성 \(jsonString)")
                     }
-                    completion(true)
                 }
             case let .failure(error):
                 if let StatusSpecificError = error as? StatusSpecificError {
@@ -120,20 +111,20 @@ class TargetAmountViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
-                completion(false)
             }
         }
     }
     
-    func deleteCurrentMonthTargetAmountApi(completion: @escaping (Bool) -> Void) {
-        TargetAmountAlamofire.shared.deleteCurrentMonthTargetAmount { result in
+    func deleteCurrentMonthTargetAmountApi() {
+        TargetAmountAlamofire.shared.deleteCurrentMonthTargetAmount(targetAmountId: (targetAmountData?.targetAmountDetail.id)!) { result in
             switch result {
             case let .success(data):
                 if let responseData = data {
                     if let jsonString = String(data: responseData, encoding: .utf8) {
                         Log.debug("당월 목표 금액 삭제 완료 \(jsonString)")
                     }
-                    completion(true)
+                    self.isHiddenSuggestionView = true
+                    self.isPresentTargetAmount = false
                 }
             case let .failure(error):
                 if let StatusSpecificError = error as? StatusSpecificError {
@@ -141,22 +132,22 @@ class TargetAmountViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
-                completion(false)
             }
         }
     }
     
-    func editCurrentMonthTargetAmountApi(completion: @escaping (Bool) -> Void) {
-        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: 0)
+    func editCurrentMonthTargetAmountApi() {
+        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: recentTargetAmountData!.amount)
         
-        TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(editCurrentMonthTargetAmountRequestDto) { result in
+        TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(targetAmountId: targetAmountData?.targetAmountDetail.id ?? -1, dto: editCurrentMonthTargetAmountRequestDto) { result in
             switch result {
             case let .success(data):
                 if let responseData = data {
                     if let jsonString = String(data: responseData, encoding: .utf8) {
                         Log.debug("당월 목표 금액 수정 완료 \(jsonString)")
                     }
-                    completion(true)
+                    // 당월 목표 금액 조회 재요청
+                    self.getTargetAmountForDateApi { _ in }
                 }
             case let .failure(error):
                 if let StatusSpecificError = error as? StatusSpecificError {
@@ -164,7 +155,6 @@ class TargetAmountViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
-                completion(false)
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -4,9 +4,10 @@ import SwiftUI
 
 class TargetAmountViewModel: ObservableObject {
     @Published var totalSpent = 0
-    @Published var targetValue: CGFloat = 0
+    @Published var targetAmountValue: CGFloat = 0
+    
 
-    func getTotalTargetAmountApi(completion : @escaping (Bool) -> Void) {
+    func getTargetAmountForDateApi(completion : @escaping (Bool) -> Void) {
         
         TargetAmountAlamofire.shared.getTargetAmountForDate { result in
             switch result {
@@ -19,24 +20,15 @@ class TargetAmountViewModel: ObservableObject {
                        
                         if validTargetAmount.targetAmountDetail.isRead == true{
                             self.totalSpent = validTargetAmount.totalSpending
-                            self.targetValue = CGFloat(validTargetAmount.targetAmountDetail.amount)
+                            self.targetAmountValue = CGFloat(validTargetAmount.targetAmountDetail.amount)
                             //TODO: 화면 안나오도록
                         }else{
                             
                             //TODO: getTargetAmountForPreviousMonth 요청
                         }
-                        
-                       
-                        
-                        
-
-//                        if validTotalSpending.targetAmount.id != -1 && validTotalSpending.targetAmount.amount != -1 {
-//                            self.targetValue = CGFloat(validTotalSpending.targetAmount.amount)
-//                            // TODO: -1인 경우 목표 금액이 없으므로, 목표 금액 설정하기 화면 보여주기
-//                        }
 
                         if let jsonString = String(data: responseData, encoding: .utf8) {
-                            Log.debug("지출 내역 조회 완료 \(jsonString)")
+                            Log.debug("당월 목표 금액 조회 \(jsonString)")
                         }
                         completion(true)
                     } catch {
@@ -76,13 +68,13 @@ class TargetAmountViewModel: ObservableObject {
                         let isPresent = response.data.targetAmount.isPresent
                         
                         if isPresent == true{
-                            //TODO: 추천 금액 보여주기
+                            //TODO: 추천 금액 보여주기 + 목표 금액 설정하기 UI
                         }else{
                             //TODO: deleteCurrentMonthTargetAmount 요청
                         }
 
                         if let jsonString = String(data: responseData, encoding: .utf8) {
-                            Log.debug("지출 내역 조회 완료 \(jsonString)")
+                            Log.debug("당월 이전 사용자 최신 목표 금액 조회 완료 \(jsonString)")
                         }
                         completion(true)
                     } catch {
@@ -100,4 +92,53 @@ class TargetAmountViewModel: ObservableObject {
             }
         }
     }
+    
+    func deleteCurrentMonthTargetAmountApi(completion : @escaping (Bool) -> Void) {
+        TargetAmountAlamofire.shared.deleteCurrentMonthTargetAmount { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+           
+                    if let jsonString = String(data: responseData, encoding: .utf8) {
+                        Log.debug("당월 목표 금액 삭제 완료 \(jsonString)")
+                    }
+                    completion(true)
+                }
+            case let .failure(error):
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
+    }
+    
+    func editCurrentMonthTargetAmountApi(completion : @escaping (Bool) -> Void) {
+         
+        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: 0)
+        
+        TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(editCurrentMonthTargetAmountRequestDto) { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+           
+                    if let jsonString = String(data: responseData, encoding: .utf8) {
+                        Log.debug("당월 목표 금액 수정 완료 \(jsonString)")
+                    }
+                    completion(true)
+                }
+            case let .failure(error):
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
+    }
+    
+    
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -4,8 +4,7 @@ import SwiftUI
 
 class TargetAmountViewModel: ObservableObject {
     @Published var totalSpent = 0
-    @Published var targetAmountValue: CGFloat = 0
-    
+    @Published var targetAmountData: TargetAmount? = nil
 
     func getTargetAmountForDateApi(completion : @escaping (Bool) -> Void) {
         
@@ -19,11 +18,9 @@ class TargetAmountViewModel: ObservableObject {
                         let validTargetAmount = response.data.targetAmount
                        
                         if validTargetAmount.targetAmountDetail.isRead == true{
-                            self.totalSpent = validTargetAmount.totalSpending
-                            self.targetAmountValue = CGFloat(validTargetAmount.targetAmountDetail.amount)
-                            //TODO: 화면 안나오도록
+                            self.targetAmountData = validTargetAmount
+                            //TODO: targetAmountData가 nil이 아니면 화면 안 나오도록
                         }else{
-                            
                             //TODO: getTargetAmountForPreviousMonth 요청
                         }
 
@@ -44,10 +41,8 @@ class TargetAmountViewModel: ObservableObject {
                     //TODO: 404 오류 처리
                     if StatusSpecificError.domainError == .notFound{
                         //TODO: deleteCurrentMonthTargetAmount 요청
-                    } else {
-                       
+                        self.deleteCurrentMonthTargetAmountApi{_ in }
                     }
-                    
                 } else {
                     Log.error("Network request failed: \(error)")
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -3,11 +3,11 @@
 import SwiftUI
 
 class TargetAmountViewModel: ObservableObject {
-    @Published var totalSpent = 0
     @Published var targetAmountData: TargetAmount? = nil
+    @Published var isHiddenSuggestionView = true
+    @Published var isPresentTargetAmount = true // 당월 목표 금액 존재 여부
 
-    func getTargetAmountForDateApi(completion : @escaping (Bool) -> Void) {
-        
+    func getTargetAmountForDateApi(completion: @escaping (Bool) -> Void) {
         TargetAmountAlamofire.shared.getTargetAmountForDate { result in
             switch result {
             case let .success(data):
@@ -17,11 +17,12 @@ class TargetAmountViewModel: ObservableObject {
 
                         let validTargetAmount = response.data.targetAmount
                        
-                        if validTargetAmount.targetAmountDetail.isRead == true{
+                        if validTargetAmount.targetAmountDetail.isRead == true {
                             self.targetAmountData = validTargetAmount
-                            //TODO: targetAmountData가 nil이 아니면 화면 안 나오도록
-                        }else{
-                            //TODO: getTargetAmountForPreviousMonth 요청
+                            self.isHiddenSuggestionView = true
+                            // TODO: targetAmountData가 nil이 아니면 화면 안 나오도록
+                        } else {
+                            // TODO: getTargetAmountForPreviousMonth 요청
                         }
 
                         if let jsonString = String(data: responseData, encoding: .utf8) {
@@ -34,14 +35,15 @@ class TargetAmountViewModel: ObservableObject {
                     }
                 }
             case let .failure(error):
-                
+    
                 if let StatusSpecificError = error as? StatusSpecificError {
                     Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
                     
-                    //TODO: 404 오류 처리
-                    if StatusSpecificError.domainError == .notFound{
-                        //TODO: deleteCurrentMonthTargetAmount 요청
-                        self.deleteCurrentMonthTargetAmountApi{_ in }
+                    // TODO: 404 오류 처리
+                    if StatusSpecificError.domainError == .notFound {
+                        self.isHiddenSuggestionView = true
+                        self.isPresentTargetAmount = false
+                        // TODO: generateCurrentMonthDummyData 요청 + 추천 금액 보여주기 x + 목표 금액 설정하기 UI
                     }
                 } else {
                     Log.error("Network request failed: \(error)")
@@ -51,8 +53,7 @@ class TargetAmountViewModel: ObservableObject {
         }
     }
     
-    
-    func getTargetAmountForPreviousMonthApi(completion : @escaping (Bool) -> Void) {
+    func getTargetAmountForPreviousMonthApi(completion: @escaping (Bool) -> Void) {
         TargetAmountAlamofire.shared.getTargetAmountForPreviousMonth { result in
             switch result {
             case let .success(data):
@@ -62,10 +63,10 @@ class TargetAmountViewModel: ObservableObject {
                         
                         let isPresent = response.data.targetAmount.isPresent
                         
-                        if isPresent == true{
-                            //TODO: 추천 금액 보여주기 + 목표 금액 설정하기 UI
-                        }else{
-                            //TODO: deleteCurrentMonthTargetAmount 요청
+                        if isPresent == true {
+                            // TODO: 추천 금액 보여주기 + 목표 금액 설정하기 UI
+                        } else {
+                            // TODO: deleteCurrentMonthTargetAmount 요청
                         }
 
                         if let jsonString = String(data: responseData, encoding: .utf8) {
@@ -88,12 +89,11 @@ class TargetAmountViewModel: ObservableObject {
         }
     }
     
-    func deleteCurrentMonthTargetAmountApi(completion : @escaping (Bool) -> Void) {
+    func deleteCurrentMonthTargetAmountApi(completion: @escaping (Bool) -> Void) {
         TargetAmountAlamofire.shared.deleteCurrentMonthTargetAmount { result in
             switch result {
             case let .success(data):
                 if let responseData = data {
-           
                     if let jsonString = String(data: responseData, encoding: .utf8) {
                         Log.debug("당월 목표 금액 삭제 완료 \(jsonString)")
                     }
@@ -110,15 +110,13 @@ class TargetAmountViewModel: ObservableObject {
         }
     }
     
-    func editCurrentMonthTargetAmountApi(completion : @escaping (Bool) -> Void) {
-         
+    func editCurrentMonthTargetAmountApi(completion: @escaping (Bool) -> Void) {
         let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: 0)
         
         TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(editCurrentMonthTargetAmountRequestDto) { result in
             switch result {
             case let .success(data):
                 if let responseData = data {
-           
                     if let jsonString = String(data: responseData, encoding: .utf8) {
                         Log.debug("당월 목표 금액 수정 완료 \(jsonString)")
                     }
@@ -134,6 +132,4 @@ class TargetAmountViewModel: ObservableObject {
             }
         }
     }
-    
-    
 }


### PR DESCRIPTION
## 작업 이유

- 최근 목표 금액 API 연동
- custom 카테고리 etc 아이콘 반영
- 마이프로필 구분선 수정


<br/>

## 작업 사항

### 1️⃣ 최근 목표 금액 API 연동

필요한 API는 총 5개로,,, 플로우 이해하는데 어려움이 있었다..ㅎㅎㅎ

플로우에 따라서 정리해보겠다.

<br/>

1. 임의의 년/월에 대한 목표 금액 및 총 사용 금액 조회

(1) 응답코드 200인 경우(해당 월에 목표 금액이 있는 경우)
isRead와 amount의 값에 따라 처리한다.

- `isRead == true` -> [추천 뷰 x, 목표 금액 데이터 적용]하고 더이상 api 요청없이 끝!
- `isRead == false, amount != -1` -> 3번 api 호출
- `isRead == false, amount == -1` -> [추천 뷰 x, 목표 금액 데이터 적용 x]하고 3번 api 호출 

> amount == -1이라는 것은 목표 금액을 등록한 적 없는 사용자라는 것을 의미한다.

(2) 응답코드 404인 경우(해당 월에 목표 금액이 없는 경우)

[추천 뷰 x, 목표 금액 데이터 적용 x]하고 2번 api 호출

<img src = "https://github.com/CollaBu/pennyway-client-ios/assets/103185302/ddf14aa7-cc2e-47b4-b74f-46947d42973d"
width = "700" height = "450"/> 

<br/>

2. 당월 목표 금액 더미값 생성 

사용자가 당월 첫 로그인 시 목표 금액이 없으므로 더미값을 생성한다.
무조건 `amount`는 -1로 생성된다. 

<br/>

3. 당월 이전 사용자가 입력한 목표 금액 중 최신 데이터 단일 조회

`isPresent`값을 사용하고 최근 목표 금액 설정값 존재 여부를 의미한다.

- `isPresent == true `-> [추천 뷰, 목표 금액 데이터 적용 x]하고 더이상 api 요청없이 끝!
- `isPresent == false` -> 4번 api 요청

<img src = "https://github.com/CollaBu/pennyway-client-ios/assets/103185302/f1078431-40f2-456a-bf14-ef3e67e6db77"
width = "600" /> 

<br/>

4. 당월 목표 금액 삭제

- `isPresent == false`라면, isRead를 true로 바꾸기 위해 삭제 요청을 호출한다.
- `isRead가 true`가 되었으면 더이상 api 요청없이 끝!

> 사용자가 x버튼을 클릭한 경우에도 요청한다

![스크린샷 2024-06-25 오전 1 19 11](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/d092bd4e-7c21-40bc-a159-4c1217620ef5)

<br/>

5. 당월 목표 금액 수정

사용자가 사용하기 버튼을 클릭한 경우 요청한다.
당월 목표 금액을 최근 목표 금액으로 수정한다.

<br/>

### 2️⃣ custom 카테고리 etc 아이콘 반영

- custom 카테고리 중 `...` 아이콘 백엔드에서 반영 완료했다고 해서 수정하였다.

`enum SpendingCategoryIconList`에서 `case other = "OTHER"`로 관리하면서 기타로 처리하였다.

![스크린샷 2024-06-25 오전 1 21 55](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/5719fe56-4224-4c1b-80a1-0553fdc6950a)

<br/>

### 3️⃣ 마이프로필 구분선 수정

마이프로필의 리스트 중 구분선이 진하게 나오는 부분이 있어서 수정하였다.
![스크린샷 2024-06-25 오전 1 24 43](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/0dbeb778-4f2e-45c0-a7fc-b7269382cc1c)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

1️⃣번 플로우가 좀 복잡해요 ㅎㅎ,,, 최대한 설명했긴 했는데 이해안가시는 부분 말씀해주세요! 
노션에 최근 목표 금액 api 설계한거 사진 첨부해놓았고, 백엔드에서 정리해준 다이어그램도 있어서 읽어보시면 흐름 이해갈거에요!

2️⃣번 `...` 아이콘 반영 안했던거 이번에 수정했습니다! 그리고 3️⃣ 구분선 문제있던 것도 같이 수정했습니다~

<br/>

## 발견한 이슈
없음
