### PR TITLE
📮 목표 금액 기록 조회 API 연동 + 최근 목표 금액 조회 API 응답 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		4AB5AB552BB4AAF200D2C9EA /* BaseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB542BB4AAF200D2C9EA /* BaseInterceptor.swift */; };
 		4AB5AB572BB5E88C00D2C9EA /* RegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB562BB5E88C00D2C9EA /* RegistrationManager.swift */; };
 		4AB5AB592BB5E93900D2C9EA /* SignUpFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB582BB5E93900D2C9EA /* SignUpFormView.swift */; };
+		4AC289FC2C2C0405001A6393 /* GetTotalTargetAmountResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC289FB2C2C0405001A6393 /* GetTotalTargetAmountResponseDto.swift */; };
 		4AC3203F2C11D5AC00DDB4B6 /* AddSpendingCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3201E2C11D5AC00DDB4B6 /* AddSpendingCategoryView.swift */; };
 		4AC320402C11D5AC00DDB4B6 /* SelectCategoryIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC3201F2C11D5AC00DDB4B6 /* SelectCategoryIconView.swift */; };
 		4AC320412C11D5AC00DDB4B6 /* SpendingCategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC320202C11D5AC00DDB4B6 /* SpendingCategoryListView.swift */; };
@@ -361,6 +362,7 @@
 		4AB5AB542BB4AAF200D2C9EA /* BaseInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseInterceptor.swift; sourceTree = "<group>"; };
 		4AB5AB562BB5E88C00D2C9EA /* RegistrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationManager.swift; sourceTree = "<group>"; };
 		4AB5AB582BB5E93900D2C9EA /* SignUpFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUpFormView.swift; sourceTree = "<group>"; };
+		4AC289FB2C2C0405001A6393 /* GetTotalTargetAmountResponseDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetTotalTargetAmountResponseDto.swift; sourceTree = "<group>"; };
 		4AC3201E2C11D5AC00DDB4B6 /* AddSpendingCategoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddSpendingCategoryView.swift; sourceTree = "<group>"; };
 		4AC3201F2C11D5AC00DDB4B6 /* SelectCategoryIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectCategoryIconView.swift; sourceTree = "<group>"; };
 		4AC320202C11D5AC00DDB4B6 /* SpendingCategoryListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpendingCategoryListView.swift; sourceTree = "<group>"; };
@@ -761,6 +763,7 @@
 		4A3701AC2C08F74E00F0AEBA /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				4AC289FB2C2C0405001A6393 /* GetTotalTargetAmountResponseDto.swift */,
 				4A3701AB2C08F74E00F0AEBA /* GetTargetAmountForDateResponseDto.swift */,
 				4AC3205E2C11F35700DDB4B6 /* CurrentMonthTargetAmountResponseDto.swift */,
 				4AC320602C11F39300DDB4B6 /* GetTargetAmountForDateResponseDto.swift */,
@@ -1787,6 +1790,7 @@
 				4AC320442C11D5AC00DDB4B6 /* AddSpendingInputFormView.swift in Sources */,
 				D8180C042BE5081F00F837FB /* FindIdContentView.swift in Sources */,
 				4A1C59882BC51AAE00EA2B49 /* OAuthAlamofire.swift in Sources */,
+				4AC289FC2C2C0405001A6393 /* GetTotalTargetAmountResponseDto.swift in Sources */,
 				4AD70E222BE013C10058A52A /* ProfileMainView.swift in Sources */,
 				4A4703922BCEA55500AEE04E /* OAuthSignUpRequestDto.swift in Sources */,
 				4A0BC6AF2BF6459B0036D900 /* DateExtensions.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/TargetAmountModel.swift
@@ -20,5 +20,7 @@ struct AmountDetail: Codable {
 
 struct RecentTargetAmount: Codable {
     let isPresent: Bool
+    let year: Int?
+    let month: Int?
     let amount: Int?
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
@@ -28,7 +28,7 @@ struct RecentTargetAmountSuggestionView: View {
             .padding(.leading, 18 * DynamicSizeFactor.factor())
             .padding(.trailing, 13 * DynamicSizeFactor.factor())
     
-            Text("5월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원") // 백엔드에게 월 데이터 요청
+            Text("\(viewModel.recentTargetAmountData?.month ?? 0)월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원")
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Mint02"))
                 .padding(.leading, 18 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountContentView.swift
@@ -59,7 +59,7 @@ struct TotalTargetAmountContentView: View {
                 
                 Spacer().frame(height: 36 * DynamicSizeFactor.factor())
                 
-                ForEach(viewModel.targetAmounts) { content in
+                ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
                     VStack(alignment: .leading) {
                         Text("\(String(content.year))년 \(content.month)월")
                             .font(.B2MediumFont())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountContentView.swift
@@ -21,7 +21,7 @@ struct TotalTargetAmountContentView: View {
                 
                 Spacer()
                 
-                Text("\(viewModel.currentData.diffAmount)원")
+                Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.diffAmount)원" : "-원")
                     .font(.B1SemiboldeFont())
                     .platformTextColor(color: determineDiffAmountColor(for: viewModel.currentData.diffAmount))
                     .padding(.trailing, 16)
@@ -98,7 +98,11 @@ struct TotalTargetAmountContentView: View {
     // Color 설정
     
     func determineDiffAmountColor(for diffAmount: Int) -> Color {
-        return diffAmount <= 0 ? Color("Red03") : Color("Gray07")
+        if viewModel.currentData.targetAmountDetail.amount != -1 {
+            return diffAmount <= 0 ? Color("Red03") : Color("Gray07")
+        } else {
+            return Color("Gray07")
+        }
     }
     
     func determineBackgroundColor(for diffAmount: Int) -> Color {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountGraphView.swift
@@ -5,7 +5,8 @@ struct TotalTargetAmountGraphView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     var body: some View {
         HStack(spacing: 24 * DynamicSizeFactor.factor()) {
-            ForEach(viewModel.sortTargetAmounts.prefix(6)) { content in
+            ForEach(Array(viewModel.targetAmounts.prefix(6).enumerated()), id: \.offset) { _, content in
+
                 VStack {
                     Text("\(content.totalSpending / 10000)")
                         .font(.B3MediumFont())
@@ -25,7 +26,7 @@ struct TotalTargetAmountGraphView: View {
         .frame(height: 140 * DynamicSizeFactor.factor(), alignment: .center)
     }
 
-    func determineColorGray03(for content: TargetAmountData) -> Color {
+    func determineColorGray03(for content: TargetAmount) -> Color {
         if content.month == Date.month(from: Date()) {
             return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
         } else {
@@ -33,7 +34,7 @@ struct TotalTargetAmountGraphView: View {
         }
     }
 
-    func determineColorGray04(for content: TargetAmountData) -> Color {
+    func determineColorGray04(for content: TargetAmount) -> Color {
         if content.month == Date.month(from: Date()) {
             return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
         } else {
@@ -41,7 +42,7 @@ struct TotalTargetAmountGraphView: View {
         }
     }
 
-    func determineColorGray06(for content: TargetAmountData) -> Color {
+    func determineColorGray06(for content: TargetAmount) -> Color {
         if content.month == Date.month(from: Date()) {
             return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
         } else {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountGraphView.swift
@@ -5,21 +5,36 @@ struct TotalTargetAmountGraphView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     var body: some View {
         HStack(spacing: 24 * DynamicSizeFactor.factor()) {
-            ForEach(Array(viewModel.targetAmounts.prefix(6).enumerated()), id: \.offset) { _, content in
-
-                VStack {
-                    Text("\(content.totalSpending / 10000)")
-                        .font(.B3MediumFont())
-                        .platformTextColor(color: determineColorGray04(for: content))
-                    Rectangle()
-                        .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: CGFloat(content.totalSpending / 10000) * DynamicSizeFactor.factor())
-                        .platformTextColor(color: determineColorGray03(for: content))
-                        .clipShape(RoundedCornerUtil(radius: 15, corners: [.topLeft, .topRight]))
-                    Text("\(content.month)월")
-                        .font(.B3MediumFont())
-                        .platformTextColor(color: determineColorGray06(for: content))
+            ForEach(0 ..< 6) { index in
+                if index >= 6 - viewModel.sortTargetAmounts.count {
+                    let content = viewModel.sortTargetAmounts[index - (6 - viewModel.sortTargetAmounts.count)]
+                    VStack {
+                        Text("\(content.totalSpending / 10000)")
+                            .font(.B3MediumFont())
+                            .platformTextColor(color: determineColorGray04(for: content))
+                        Rectangle()
+                            .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: CGFloat(content.totalSpending / 10000) * DynamicSizeFactor.factor())
+                            .platformTextColor(color: determineColorGray03(for: content))
+                            .clipShape(RoundedCornerUtil(radius: 15, corners: [.topLeft, .topRight]))
+                        Text("\(content.month)월")
+                            .font(.B3MediumFont())
+                            .platformTextColor(color: determineColorGray06(for: content))
+                    }
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+                } else {
+                    VStack {
+                        Text("0")
+                            .font(.B3MediumFont())
+                            .platformTextColor(color: Color("Gray03"))
+                        Rectangle()
+                            .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: 0)
+                            .foregroundColor(.clear)
+                        Text("\(viewModel.currentData.month - (6 - (index + 1)))월")
+                            .font(.B3MediumFont())
+                            .platformTextColor(color: Color("Gray03")) 
+                    }
+                    .frame(maxHeight: .infinity, alignment: .bottom)
                 }
-                .frame(maxHeight: .infinity, alignment: .bottom)
             }
         }
         .frame(maxWidth: .infinity)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountGraphView.swift
@@ -16,6 +16,9 @@ struct TotalTargetAmountGraphView: View {
                             .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: CGFloat(content.totalSpending / 10000) * DynamicSizeFactor.factor())
                             .platformTextColor(color: determineColorGray03(for: content))
                             .clipShape(RoundedCornerUtil(radius: 15, corners: [.topLeft, .topRight]))
+
+                        Spacer().frame(height: 8 * DynamicSizeFactor.factor())
+
                         Text("\(content.month)월")
                             .font(.B3MediumFont())
                             .platformTextColor(color: determineColorGray06(for: content))
@@ -25,13 +28,12 @@ struct TotalTargetAmountGraphView: View {
                     VStack {
                         Text("0")
                             .font(.B3MediumFont())
-                            .platformTextColor(color: Color("Gray03"))
+                            .platformTextColor(color: Color("Gray04"))
                         Rectangle()
                             .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: 0)
-                            .foregroundColor(.clear)
                         Text("\(viewModel.currentData.month - (6 - (index + 1)))월")
                             .font(.B3MediumFont())
-                            .platformTextColor(color: Color("Gray03")) 
+                            .platformTextColor(color: Color("Gray06"))
                     }
                     .frame(maxHeight: .infinity, alignment: .bottom)
                 }
@@ -42,26 +44,38 @@ struct TotalTargetAmountGraphView: View {
     }
 
     func determineColorGray03(for content: TargetAmount) -> Color {
-        if content.month == Date.month(from: Date()) {
-            return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+        if content.targetAmountDetail.amount != -1 {
+            if content.month == Date.month(from: Date()) {
+                return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+            } else {
+                return Color("Gray03")
+            }
         } else {
-            return Color("Gray03")
+            return Color("Mint03")
         }
     }
 
     func determineColorGray04(for content: TargetAmount) -> Color {
-        if content.month == Date.month(from: Date()) {
-            return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+        if content.targetAmountDetail.amount != -1 {
+            if content.month == Date.month(from: Date()) {
+                return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+            } else {
+                return Color("Gray04")
+            }
         } else {
-            return Color("Gray04")
+            return Color("Mint03")
         }
     }
 
     func determineColorGray06(for content: TargetAmount) -> Color {
-        if content.month == Date.month(from: Date()) {
-            return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+        if content.targetAmountDetail.amount != -1 {
+            if content.month == Date.month(from: Date()) {
+                return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+            } else {
+                return Color("Gray06")
+            }
         } else {
-            return Color("Gray06")
+            return Color("Mint03")
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountHeaderView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountHeaderView.swift
@@ -14,10 +14,10 @@ struct TotalTargetAmountHeaderView: View {
                     .platformTextColor(color: Color("White01"))
                         
                 HStack(spacing: 0) {
-                    Text("\(viewModel.currentData.targetAmountDetail.amount)")
+                    Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.targetAmountDetail.amount)" : "-")
                         .font(.H1BoldFont())
                         .platformTextColor(color: Color("White01"))
-                    Text("원")
+                    Text(" 원")
                         .font(.H3SemiboldFont())
                         .platformTextColor(color: Color("White01"))
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountHeaderView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountHeaderView.swift
@@ -14,7 +14,7 @@ struct TotalTargetAmountHeaderView: View {
                     .platformTextColor(color: Color("White01"))
                         
                 HStack(spacing: 0) {
-                    Text("\(viewModel.currentData.targetAmount.amount)")
+                    Text("\(viewModel.currentData.targetAmountDetail.amount)")
                         .font(.H1BoldFont())
                         .platformTextColor(color: Color("White01"))
                     Text("원")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView.swift
@@ -54,6 +54,10 @@ struct TotalTargetAmountView: View {
                 .offset(x: 10)
             }
         }
+        .onAppear {
+            viewModel.getTotalTargetAmountApi { _ in 
+            }
+        }
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
@@ -2,43 +2,79 @@
 
 import SwiftUI
 
-// MARK: - TargetAmountData
-
-/// 임시 데이터 모델 설정
-struct TargetAmountData: Identifiable {
-    let id = UUID()
-    let year: Int
-    let month: Int
-    let targetAmount: Amount
-    let totalSpending: Int
-    let diffAmount: Int
-
-    struct Amount: Codable {
-        let id: Int
-        let amount: Int
-    }
-}
+//// MARK: - TargetAmountData
+//
+///// 임시 데이터 모델 설정
+// struct TargetAmountData: Identifiable {
+//    let id = UUID()
+//    let year: Int
+//    let month: Int
+//    let targetAmount: Amount
+//    let totalSpending: Int
+//    let diffAmount: Int
+//
+//    struct Amount: Codable {
+//        let id: Int
+//        let amount: Int
+//    }
+// }
 
 // MARK: - TotalTargetAmountViewModel
 
 class TotalTargetAmountViewModel: ObservableObject {
-    @Published var targetAmounts: [TargetAmountData] = []
-    @Published var sortTargetAmounts: [TargetAmountData] = []
-    @Published var currentData: TargetAmountData
+    @Published var targetAmounts: [TargetAmount] = []
+    @Published var sortTargetAmounts: [TargetAmount] = []
+    @Published var currentData: TargetAmount = TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0)
 
-    init() {
-        let initialTargetAmounts = [
-            TargetAmountData(year: 2024, month: 6, targetAmount: TargetAmountData.Amount(id: 1, amount: 100_000), totalSpending: 0, diffAmount: 100_000),
-            TargetAmountData(year: 2024, month: 5, targetAmount: TargetAmountData.Amount(id: 2, amount: 800_000), totalSpending: 900_000, diffAmount: -100_000),
-            TargetAmountData(year: 2024, month: 4, targetAmount: TargetAmountData.Amount(id: 3, amount: 700_000), totalSpending: 700_000, diffAmount: 0),
-            TargetAmountData(year: 2024, month: 3, targetAmount: TargetAmountData.Amount(id: 4, amount: 100_000), totalSpending: 50000, diffAmount: 50000),
-            TargetAmountData(year: 2024, month: 2, targetAmount: TargetAmountData.Amount(id: 5, amount: 120_000), totalSpending: 60000, diffAmount: 60000),
-            TargetAmountData(year: 2024, month: 1, targetAmount: TargetAmountData.Amount(id: 6, amount: 1_000_000), totalSpending: 5_000_000, diffAmount: -4_000_000),
-            TargetAmountData(year: 2023, month: 12, targetAmount: TargetAmountData.Amount(id: 6, amount: 800_000), totalSpending: 1_000_000, diffAmount: -200_000)
-        ]
+    func getTotalTargetAmountApi(completion: @escaping (Bool) -> Void) {
+        let getTotalTargetAmountRequestDto = GetTotalTargetAmountRequestDto(date: Date.getBasicformattedDate(from: Date()))
 
-        targetAmounts = initialTargetAmounts
-        sortTargetAmounts = initialTargetAmounts.sorted(by: { $0.month < $1.month })
-        currentData = initialTargetAmounts.first ?? TargetAmountData(year: 2024, month: 6, targetAmount: TargetAmountData.Amount(id: 1, amount: 100_000), totalSpending: 0, diffAmount: 100_000)
+        TargetAmountAlamofire.shared.getTotalTargetAmount(getTotalTargetAmountRequestDto) { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    do {
+                        let response = try JSONDecoder().decode(GetTotalTargetAmountResponseDto.self, from: responseData)
+
+                        self.targetAmounts = response.data.targetAmounts
+                        self.sortTargetAmounts = self.targetAmounts.sorted(by: { $0.month < $1.month })
+                        if let firstTargetAmount = self.targetAmounts.first {
+                            self.currentData = firstTargetAmount
+                        }
+                        if let jsonString = String(data: responseData, encoding: .utf8) {
+                            Log.debug("목표 금액 및 총 사용 금액 리스트 조회 완료 \(jsonString)")
+                        }
+
+                        completion(true)
+                    } catch {
+                        Log.fault("Error decoding JSON: \(error)")
+                        completion(false)
+                    }
+                }
+            case let .failure(error):
+                if let statusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(statusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
     }
 }
+
+// init() {
+//    let initialTargetAmounts = [
+//        TargetAmountData(year: 2024, month: 6, targetAmount: TargetAmountData.Amount(id: 1, amount: 100_000), totalSpending: 0, diffAmount: 100_000),
+//        TargetAmountData(year: 2024, month: 5, targetAmount: TargetAmountData.Amount(id: 2, amount: 800_000), totalSpending: 900_000, diffAmount: -100_000),
+//        TargetAmountData(year: 2024, month: 4, targetAmount: TargetAmountData.Amount(id: 3, amount: 700_000), totalSpending: 700_000, diffAmount: 0),
+//        TargetAmountData(year: 2024, month: 3, targetAmount: TargetAmountData.Amount(id: 4, amount: 100_000), totalSpending: 50000, diffAmount: 50000),
+//        TargetAmountData(year: 2024, month: 2, targetAmount: TargetAmountData.Amount(id: 5, amount: 120_000), totalSpending: 60000, diffAmount: 60000),
+//        TargetAmountData(year: 2024, month: 1, targetAmount: TargetAmountData.Amount(id: 6, amount: 1_000_000), totalSpending: 5_000_000, diffAmount: -4_000_000),
+//        TargetAmountData(year: 2023, month: 12, targetAmount: TargetAmountData.Amount(id: 6, amount: 800_000), totalSpending: 1_000_000, diffAmount: -200_000)
+//    ]
+//
+//    targetAmounts = initialTargetAmounts
+//    sortTargetAmounts = initialTargetAmounts.sorted(by: { $0.month < $1.month })
+//    currentData = initialTargetAmounts.first ?? TargetAmountData(year: 2024, month: 6, targetAmount: TargetAmountData.Amount(id: 1, amount: 100_000), totalSpending: 0, diffAmount: 100_000)
+// }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
@@ -2,23 +2,6 @@
 
 import SwiftUI
 
-//// MARK: - TargetAmountData
-//
-///// 임시 데이터 모델 설정
-// struct TargetAmountData: Identifiable {
-//    let id = UUID()
-//    let year: Int
-//    let month: Int
-//    let targetAmount: Amount
-//    let totalSpending: Int
-//    let diffAmount: Int
-//
-//    struct Amount: Codable {
-//        let id: Int
-//        let amount: Int
-//    }
-// }
-
 // MARK: - TotalTargetAmountViewModel
 
 class TotalTargetAmountViewModel: ObservableObject {
@@ -63,18 +46,3 @@ class TotalTargetAmountViewModel: ObservableObject {
     }
 }
 
-// init() {
-//    let initialTargetAmounts = [
-//        TargetAmountData(year: 2024, month: 6, targetAmount: TargetAmountData.Amount(id: 1, amount: 100_000), totalSpending: 0, diffAmount: 100_000),
-//        TargetAmountData(year: 2024, month: 5, targetAmount: TargetAmountData.Amount(id: 2, amount: 800_000), totalSpending: 900_000, diffAmount: -100_000),
-//        TargetAmountData(year: 2024, month: 4, targetAmount: TargetAmountData.Amount(id: 3, amount: 700_000), totalSpending: 700_000, diffAmount: 0),
-//        TargetAmountData(year: 2024, month: 3, targetAmount: TargetAmountData.Amount(id: 4, amount: 100_000), totalSpending: 50000, diffAmount: 50000),
-//        TargetAmountData(year: 2024, month: 2, targetAmount: TargetAmountData.Amount(id: 5, amount: 120_000), totalSpending: 60000, diffAmount: 60000),
-//        TargetAmountData(year: 2024, month: 1, targetAmount: TargetAmountData.Amount(id: 6, amount: 1_000_000), totalSpending: 5_000_000, diffAmount: -4_000_000),
-//        TargetAmountData(year: 2023, month: 12, targetAmount: TargetAmountData.Amount(id: 6, amount: 800_000), totalSpending: 1_000_000, diffAmount: -200_000)
-//    ]
-//
-//    targetAmounts = initialTargetAmounts
-//    sortTargetAmounts = initialTargetAmounts.sorted(by: { $0.month < $1.month })
-//    currentData = initialTargetAmounts.first ?? TargetAmountData(year: 2024, month: 6, targetAmount: TargetAmountData.Amount(id: 1, amount: 100_000), totalSpending: 0, diffAmount: 100_000)
-// }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
@@ -5,9 +5,9 @@ import SwiftUI
 // MARK: - TotalTargetAmountViewModel
 
 class TotalTargetAmountViewModel: ObservableObject {
-    @Published var targetAmounts: [TargetAmount] = []
-    @Published var sortTargetAmounts: [TargetAmount] = []
-    @Published var currentData: TargetAmount = TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0)
+    @Published var targetAmounts: [TargetAmount] = [] // 내림차순 데이터
+    @Published var sortTargetAmounts: [TargetAmount] = [] // 오름차순 정렬
+    @Published var currentData: TargetAmount = TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0) // 당월 데이터
 
     func getTotalTargetAmountApi(completion: @escaping (Bool) -> Void) {
         let getTotalTargetAmountRequestDto = GetTotalTargetAmountRequestDto(date: Date.getBasicformattedDate(from: Date()))
@@ -45,4 +45,3 @@ class TotalTargetAmountViewModel: ObservableObject {
         }
     }
 }
-


### PR DESCRIPTION
## 작업 이유
- 목표 금액 기록 조회 API 연동
- 최근 목표 금액 조회 API 응답 수정

<br/>

## 작업 사항

### 1️⃣ 목표 금액 기록 조회 API 연동 

- TotalTargetAmountViewModel에서 목표 금액 기록 조회 API 연동 처리
기존의 임시 데이터를 사용하는 부분을 제거하고, API를 통해 받아온 데이터를 적용하도록 수정했다.

- 이전에 소비 금액이 없는 데이터인 경우 "0"으로 표시
- 당월에 목표 금액이 없는 경우 "-"으로 표시

<img src = "https://github.com/CollaBu/pennyway-client-ios/assets/103185302/68a2c664-f818-410a-820f-deff49be0033" width = "300"/>

<br/>

<br/>

그리고 의문점이 생긴걸 디자인팀에 질문 남겨놓았고 질문은 아래와 같다. 답변이 오면 추후 수정할 것이다.

```
1. 목표 금액이 없는 경우 리스트에서 제외하는 걸까요?
2. 목표 금액이 없는 경우 리스트에 포함된다면, “짝짝 소비 천재네요”와 같은 문구는 어떤 조건으로 보여주나요?
3. 당월에 목표 금액이 없는 경우 그래프에 표시되는 색상은 민트색으로 고정인가요?
```

<br/>


### 2️⃣ 최근 목표 금액 조회 API 응답 수정

- 구현 위치: TargetAmountAlamofire - TargetAmountRouter - .getTargetAmountForPreviousMonth
- GET `/v2/target-amounts/recent`
- Response: GetTargetAmountForPreviousMonthResponseDto

백엔드에게 year과 month 데이터를 추가해달라고 요청했고, 반영해주셔서 year과 month를 추가했다. 
year과 month, amount는 존재하지 않을 수 있어서 옵셔널 값으로 처리하였다.

![스크린샷 2024-06-27 오전 12 00 03](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/83c1e3ae-17df-4e8f-99b5-e189eab42dbe)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

1️⃣에서 API 연동 처리하였고, 기존에 임시데이터 적용했던 부분을 API를 통해 받아온 데이터로 수정한 거여서 많이 바뀐 부분은 없어요!
그리고 2️⃣번 응답 포맷 수정된 것도 반영했습니다~

<br/>

## 발견한 이슈
없음