### PR TITLE
🎨 지출내역 자세히보기 UI 구현 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		D85927FA2BE9116700653391 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85927F52BE9116700653391 /* LoginViewModel.swift */; };
 		D85927FB2BE9116700653391 /* SignUpNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85927F62BE9116700653391 /* SignUpNavigationViewModel.swift */; };
 		D85927FC2BE9116700653391 /* TermsAndConditionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85927F72BE9116700653391 /* TermsAndConditionsViewModel.swift */; };
+		D874F52B2C32888E00936886 /* DetailSpendingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D874F52A2C32888E00936886 /* DetailSpendingView.swift */; };
 		D87CB0D02BC5A47800BD882A /* FindPwView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87CB0CF2BC5A47800BD882A /* FindPwView.swift */; };
 		D87CB0D22BC5A4BC00BD882A /* ResetPwView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87CB0D12BC5A4BC00BD882A /* ResetPwView.swift */; };
 		D87CB0D42BC5A57D00BD882A /* CompleteChangePwView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87CB0D32BC5A57C00BD882A /* CompleteChangePwView.swift */; };
@@ -227,6 +228,7 @@
 		D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */; };
 		D8C9AC402BF661A2006D1FCD /* InquiryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */; };
 		D8C9AC422BF66BB3006D1FCD /* InquiryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */; };
+		D8CEFB732C32BDF000E61C51 /* MoreDetailSpendingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */; };
 		D8E24D8D2BFC7FE4006E8046 /* InquiryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E24D8C2BFC7FE4006E8046 /* InquiryViewModel.swift */; };
 		D8E24D932BFCF885006E8046 /* ProfileMenuBarListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E24D922BFCF885006E8046 /* ProfileMenuBarListView.swift */; };
 		D8E24D952BFD12BB006E8046 /* SettingAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E24D942BFD12BB006E8046 /* SettingAlarmView.swift */; };
@@ -442,6 +444,7 @@
 		D85927F52BE9116700653391 /* LoginViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		D85927F62BE9116700653391 /* SignUpNavigationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUpNavigationViewModel.swift; sourceTree = "<group>"; };
 		D85927F72BE9116700653391 /* TermsAndConditionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsViewModel.swift; sourceTree = "<group>"; };
+		D874F52A2C32888E00936886 /* DetailSpendingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSpendingView.swift; sourceTree = "<group>"; };
 		D87CB0CF2BC5A47800BD882A /* FindPwView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPwView.swift; sourceTree = "<group>"; };
 		D87CB0D12BC5A4BC00BD882A /* ResetPwView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPwView.swift; sourceTree = "<group>"; };
 		D87CB0D32BC5A57C00BD882A /* CompleteChangePwView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteChangePwView.swift; sourceTree = "<group>"; };
@@ -458,6 +461,7 @@
 		D89FB7882BDA925F0019DE3C /* FindUserNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindUserNameViewModel.swift; sourceTree = "<group>"; };
 		D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryView.swift; sourceTree = "<group>"; };
 		D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryListView.swift; sourceTree = "<group>"; };
+		D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreDetailSpendingView.swift; sourceTree = "<group>"; };
 		D8E24D8C2BFC7FE4006E8046 /* InquiryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryViewModel.swift; sourceTree = "<group>"; };
 		D8E24D922BFCF885006E8046 /* ProfileMenuBarListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileMenuBarListView.swift; sourceTree = "<group>"; };
 		D8E24D942BFD12BB006E8046 /* SettingAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlarmView.swift; sourceTree = "<group>"; };
@@ -1198,6 +1202,7 @@
 		4AC320292C11D5AC00DDB4B6 /* MySpendingListView */ = {
 			isa = PBXGroup;
 			children = (
+				D874F5292C32881400936886 /* DetailSpendingView */,
 				4AC320272C11D5AC00DDB4B6 /* MySpendingListView.swift */,
 				4AC320282C11D5AC00DDB4B6 /* NoSpendingHistoryView.swift */,
 			);
@@ -1482,6 +1487,15 @@
 			path = Alamofire;
 			sourceTree = "<group>";
 		};
+		D874F5292C32881400936886 /* DetailSpendingView */ = {
+			isa = PBXGroup;
+			children = (
+				D874F52A2C32888E00936886 /* DetailSpendingView.swift */,
+				D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */,
+			);
+			path = DetailSpendingView;
+			sourceTree = "<group>";
+		};
 		D87CB0CE2BC5A43B00BD882A /* FindPwView */ = {
 			isa = PBXGroup;
 			children = (
@@ -1761,6 +1775,7 @@
 				4A6E62D82BA6082100111246 /* SignUpView.swift in Sources */,
 				4A4703B02BCF897300AEE04E /* ErrorResponseDto.swift in Sources */,
 				4A0BC6A72BF5F4E20036D900 /* StringAttributeProtocol.swift in Sources */,
+				D874F52B2C32888E00936886 /* DetailSpendingView.swift in Sources */,
 				4AC320562C11D5AC00DDB4B6 /* TotalTargetAmountHeaderView.swift in Sources */,
 				4A69C14C2BE2DBAC00A27B82 /* AppViewModel.swift in Sources */,
 				4A47038C2BCEA43500AEE04E /* OAuthVerificationCodeRequestDto.swift in Sources */,
@@ -1769,6 +1784,7 @@
 				4AC320522C11D5AC00DDB4B6 /* SpendingManagementMainView.swift in Sources */,
 				4ADE80252BF23D2F007FFB01 /* ProfileSettingListItem.swift in Sources */,
 				4A5789932BDC29CA00AFEB26 /* NotAcceptableError.swift in Sources */,
+				D8CEFB732C32BDF000E61C51 /* MoreDetailSpendingView.swift in Sources */,
 				4A57899B2BDC2A2500AFEB26 /* InternalServerError.swift in Sources */,
 				D8880E202BCEED9B00922894 /* NavigationUtil.swift in Sources */,
 				4A1179B52BA9C20900A9CF4C /* ErrorCodePopUpView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct DetailSpendingView: View {
+    var body: some View {
+        ZStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                Spacer().frame(height: 26 * DynamicSizeFactor.factor())
+
+                MoreDetailSpendingView()
+            }
+        }
+        .padding(.bottom, 34 * DynamicSizeFactor.factor())
+        .padding(.horizontal, 20)
+        .setTabBarVisibility(isHidden: true)
+        .edgesIgnoringSafeArea(.bottom)
+        .navigationBarColor(UIColor(named: "White01"), title: "")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                HStack {
+                    Button(action: {
+                        NavigationUtil.popToRootView()
+                    }, label: {
+                        Image("icon_arrow_back")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 34, height: 34)
+                            .padding(5)
+                    })
+                    .padding(.leading, 5)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+
+                }.offset(x: -10)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                HStack(spacing: 0) {
+                    Button(action: {}, label: {
+                        Image("icon_arrow_back")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                            .padding(5)
+                    })
+                    .padding(.trailing, 5)
+                    .frame(width: 44, height: 44)
+                }
+                .offset(x: 10)
+            }
+        }
+    }
+}
+
+#Preview {
+    DetailSpendingView()
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 struct DetailSpendingView: View {
+    @State private var isSelectedCategory: Bool = false
+    @State var selectedItem: String? = nil
+    @State var listArray: [String] = ["수정하기", "내역 삭제"]
+
     var body: some View {
         ZStack(alignment: .leading) {
             VStack(alignment: .leading) {
@@ -13,6 +17,7 @@ struct DetailSpendingView: View {
         .padding(.horizontal, 20)
         .setTabBarVisibility(isHidden: true)
         .edgesIgnoringSafeArea(.bottom)
+        .navigationBarBackButtonHidden(true)
         .navigationBarColor(UIColor(named: "White01"), title: "")
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -34,19 +39,69 @@ struct DetailSpendingView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 0) {
-                    Button(action: {}, label: {
+                    Button(action: {
+                        isSelectedCategory.toggle()
+                        Log.debug("isSelectedCategory: \(isSelectedCategory)")
+                    }, label: {
                         Image("icon_arrow_back")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                             .padding(5)
                     })
+                    .buttonStyle(PlainButtonStyle())
                     .padding(.trailing, 5)
                     .frame(width: 44, height: 44)
                 }
                 .offset(x: 10)
             }
         }
+        .overlay(
+            VStack(alignment: .center) {
+                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
+                if isSelectedCategory {
+                    ZStack {
+                        Rectangle()
+                            .cornerRadius(4)
+                            .platformTextColor(color: Color("White01"))
+                            .padding(.vertical, 8)
+                            .shadow(color: .black.opacity(0.06), radius: 7, x: 0, y: 0)
+
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(listArray, id: \.self) { item in
+                                Button(action: {
+                                    self.selectedItem = item
+                                }, label: {
+                                    ZStack(alignment: .leading) {
+                                        Rectangle()
+                                            .platformTextColor(color: .clear)
+                                            .frame(width: 120, height: 22)
+                                            .cornerRadius(3)
+
+                                        Text(item)
+                                            .font(.B2MediumFont())
+                                            .multilineTextAlignment(.leading)
+                                            .platformTextColor(color: selectedItem == item ? Color("Gray05") : Color("Gray04"))
+                                            .padding(.leading, 3)
+                                    }
+                                    .padding(.horizontal, 7)
+                                    .padding(.vertical, 11)
+                                    .background(selectedItem == item ? Color("Gray02") : Color("White01"))
+
+                                })
+
+                                .buttonStyle(PlainButtonStyle())
+                            }
+                            .cornerRadius(3)
+                        }
+                        .padding(.vertical, 12 * DynamicSizeFactor.factor())
+                        .zIndex(5)
+                    }
+                    .frame(width: 125 * DynamicSizeFactor.factor(), height: 47 * DynamicSizeFactor.factor())
+                    .zIndex(5)
+                    .offset(x: 175 * DynamicSizeFactor.factor(), y: 13 * DynamicSizeFactor.factor())
+                }
+            }, alignment: .topLeading)
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/MoreDetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/MoreDetailSpendingView.swift
@@ -1,5 +1,3 @@
-
-
 import SwiftUI
 
 struct MoreDetailSpendingView: View {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/MoreDetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/MoreDetailSpendingView.swift
@@ -58,9 +58,8 @@ struct MoreDetailSpendingView: View {
                 }
                 Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                 
-                ZStack(alignment: .leading) {
+                ZStack(alignment: .topLeading) {
                     Rectangle()
-                        //                  .foregroundColor(.clear)
                         .frame(width: 280 * DynamicSizeFactor.factor(), height: 72 * DynamicSizeFactor.factor())
                         .platformTextColor(color: Color("Gray01"))
                         .cornerRadius(4)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/MoreDetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/MoreDetailSpendingView.swift
@@ -1,0 +1,80 @@
+
+
+import SwiftUI
+
+struct MoreDetailSpendingView: View {
+    var body: some View {
+        ZStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                HStack(spacing: 10 * DynamicSizeFactor.factor()) {
+                    Image("icon_category_education_on")
+                        .frame(width: 32 * DynamicSizeFactor.factor(), height: 32 * DynamicSizeFactor.factor())
+                        .scaledToFill()
+
+                    Text("교육")
+                        .platformTextColor(color: Color("Gray07"))
+                        .font(.B1SemiboldeFont())
+                }
+                Spacer().frame(height: 4 * DynamicSizeFactor.factor())
+
+                Text("6,000원")
+                    .platformTextColor(color: Color("Gray07"))
+                    .font(.H1BoldFont())
+
+                Spacer()
+
+                HStack {
+                    Text("날짜")
+                        .platformTextColor(color: Color("Gray04"))
+                        .font(.B1MediumFont())
+                    
+                    Spacer()
+                    
+                    Text("6월 4일")
+                        .platformTextColor(color: Color("Gray07"))
+                        .font(.B1MediumFont())
+                }
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                
+                HStack {
+                    Text("소비처")
+                        .platformTextColor(color: Color("Gray04"))
+                        .font(.B1MediumFont())
+                    
+                    Spacer()
+                    
+                    Text("스터디용 메모장")
+                        .platformTextColor(color: Color("Gray07"))
+                        .font(.B1MediumFont())
+                }
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                
+                HStack {
+                    Text("메모")
+                        .platformTextColor(color: Color("Gray04"))
+                        .font(.B1MediumFont())
+                    
+                    Spacer()
+                }
+                Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+                
+                ZStack(alignment: .leading) {
+                    Rectangle()
+                        //                  .foregroundColor(.clear)
+                        .frame(width: 280 * DynamicSizeFactor.factor(), height: 72 * DynamicSizeFactor.factor())
+                        .platformTextColor(color: Color("Gray01"))
+                        .cornerRadius(4)
+                    
+                    Text("이번 스터디도 무사히\n끝날 수 있도록 해주세요")
+                        .platformTextColor(color: Color("Gray07"))
+                        .font(.B1MediumFont())
+                        .padding(12 * DynamicSizeFactor.factor())
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    MoreDetailSpendingView()
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -37,7 +37,10 @@ struct MySpendingListView: View {
                                             Spacer().frame(height: 12 * DynamicSizeFactor.factor())
                                             ForEach(spendings, id: \.id) { item in
                                                 let iconName = SpendingListViewCategoryIconList(rawValue: item.category.icon)?.iconName ?? ""
-                                                ExpenseRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
+                                                NavigationLink(destination: DetailSpendingView()) {
+                                                    ExpenseRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
+                                                }
+
                                                 Spacer().frame(height: 12 * DynamicSizeFactor.factor())
                                             }
                                             .onAppear {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -8,8 +8,6 @@ struct SpendingManagementMainView: View {
     @State private var navigateToMySpendingList = false
     @State private var showSpendingDetailView = false
     @State private var showEditSpendingDetailView: Bool = false
-    @State private var showDetailView = false // 지출내역 상세조회 view 임시 연결
-
     @State private var ishidden = false // 변수명 바꿀 필요
 
     @State private var showToastPopup = false

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -8,6 +8,7 @@ struct SpendingManagementMainView: View {
     @State private var navigateToMySpendingList = false
     @State private var showSpendingDetailView = false
     @State private var showEditSpendingDetailView: Bool = false
+    @State private var showDetailView = false // 지출내역 상세조회 view 임시 연결
 
     @State private var ishidden = false // 변수명 바꿀 필요
 
@@ -101,7 +102,9 @@ struct SpendingManagementMainView: View {
                         .padding(.trailing, 5 * DynamicSizeFactor.factor())
                         .frame(width: 44, height: 44)
 
-                        Button(action: {}, label: {
+                        Button(action: {
+                            showDetailView = true
+                        }, label: {
                             Image("icon_navigationbar_bell")
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
@@ -130,6 +133,10 @@ struct SpendingManagementMainView: View {
             }
 
             NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel()), isActive: $navigateToMySpendingList) {
+                EmptyView()
+            }
+
+            NavigationLink(destination: DetailSpendingView(), isActive: $showDetailView) {
                 EmptyView()
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -103,7 +103,6 @@ struct SpendingManagementMainView: View {
                         .frame(width: 44, height: 44)
 
                         Button(action: {
-                            showDetailView = true
                         }, label: {
                             Image("icon_navigationbar_bell")
                                 .resizable()
@@ -136,9 +135,6 @@ struct SpendingManagementMainView: View {
                 EmptyView()
             }
 
-            NavigationLink(destination: DetailSpendingView(), isActive: $showDetailView) {
-                EmptyView()
-            }
         }
         .dragBottomSheet(isPresented: $showSpendingDetailView) {
             SpendingDetailSheetView()


### PR DESCRIPTION
## 작업 이유
- 지출 내역 자세히보기 UI 구현
- 네비게이션 link 연결

<br/>

## 작업 사항

### **1️⃣ 지출내역 자세히보기 UI 구현**
<img src ="https://github.com/CollaBu/pennyway-client-ios/assets/122153297/a9f3e082-25be-4a29-beec-d5f514a4fb05" width = "350" height = "600">

지출내역 자세히 보기 메인 UI 구현 및 우측 상단 아이콘 눌렀을 때 옵션바도 같이 나오도록 설정하였다.
우측 아이콘은 아직 디자인팀에서 받지 못해서 임시로 아무 아이콘이나 넣어놓은 상태이다.

지출내역 상세조회에서 지출내역 list를 눌렀을 경우 자세히보기 화면이 뜨도록 연결하였다. 아직은 api 연결 전이라 지출내역 리스트 아무거나 눌러도 모두 같은 날짜의 자세히보기 화면이 나온다.
```swift
ForEach(spendings, id: \.id) { item in
                                                let iconName = SpendingListViewCategoryIconList(rawValue: item.category.icon)?.iconName ?? ""
                                                NavigationLink(destination: DetailSpendingView()) {
                                                    ExpenseRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
                                                }

                                                Spacer().frame(height: 12 * DynamicSizeFactor.factor())
                                            }
``` 

파일 구조는 아래와 같다
```
DetailSpendingView
ㄴ MoreDetailSpendingView
``` 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
UI 구현한거 확인해주시면 될 거 같아요~

<br/>

## 발견한 이슈
없음