### PR TITLE
📮 목표 금액 설정/수정 api 연동

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -81,6 +81,7 @@ struct CategoryDetailsView: View {
                 }
             }, alignment: .topTrailing
         )
+        .navigationBarColor(UIColor(named: "White01"), title: "")
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -103,7 +104,7 @@ struct CategoryDetailsView: View {
                 if category.isCustom {
                     HStack {
                         Button(action: {
-                            isClickMenu = true
+                            isClickMenu.toggle()
                             selectedMenu = nil
                         }, label: {
                             Image("icon_navigationbar_kebabmenu")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
@@ -43,7 +43,3 @@ struct TargetAmountSetCompleteView: View {
         NavigationUtil.popToView(at: 1)
     }
 }
-
-#Preview {
-    TargetAmountSetCompleteView(viewModel: TargetAmountSettingViewModel())
-}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
@@ -43,3 +43,7 @@ struct TargetAmountSetCompleteView: View {
         NavigationUtil.popToView(at: 1)
     }
 }
+
+#Preview {
+    TargetAmountSetCompleteView(viewModel: TargetAmountSettingViewModel(currentData: TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0)))
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
@@ -2,9 +2,14 @@
 import SwiftUI
 
 struct TargetAmountSettingView: View {
-    @Binding var targetAmount: String?
-    @StateObject var viewModel = TargetAmountSettingViewModel()
+    @Binding var currentData: TargetAmount
+    @StateObject var viewModel: TargetAmountSettingViewModel
     @State private var navigateToCompleteTarget = false
+
+    init(currentData: Binding<TargetAmount>) {
+        _currentData = currentData
+        _viewModel = StateObject(wrappedValue: TargetAmountSettingViewModel(currentData: currentData.wrappedValue))
+    }
     
     var body: some View {
         ZStack {
@@ -27,8 +32,8 @@ struct TargetAmountSettingView: View {
                             .fill(Color("Gray01"))
                             .frame(height: 46 * DynamicSizeFactor.factor())
 
-                        if targetAmount != nil {
-                            Text("\(String(describing: targetAmount))")
+                        if currentData.targetAmountDetail.id != -1 {
+                            Text("\(currentData.targetAmountDetail.amount)")
                                 .platformTextColor(color: Color("Gray03"))
                                 .padding(.leading, 13 * DynamicSizeFactor.factor())
                                 .font(.H2SemiboldFont())
@@ -63,17 +68,11 @@ struct TargetAmountSettingView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 HStack {
                     NavigationBackButton(action: {})
-                    
                         .padding(.leading, 5)
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
-                    
                 }.offset(x: -10)
             }
         }
     }
-}
-
-#Preview {
-    TargetAmountSettingView(targetAmount: .constant(nil), viewModel: TargetAmountSettingViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
@@ -32,7 +32,7 @@ struct TargetAmountSettingView: View {
                             .fill(Color("Gray01"))
                             .frame(height: 46 * DynamicSizeFactor.factor())
 
-                        if currentData.targetAmountDetail.id != -1 {
+                        if currentData.targetAmountDetail.amount != -1 && viewModel.inputTargetAmount.isEmpty {
                             Text("\(currentData.targetAmountDetail.amount)")
                                 .platformTextColor(color: Color("Gray03"))
                                 .padding(.leading, 13 * DynamicSizeFactor.factor())
@@ -44,6 +44,7 @@ struct TargetAmountSettingView: View {
                             .keyboardType(.numberPad)
                             .onChange(of: viewModel.inputTargetAmount) { _ in
                                 viewModel.inputTargetAmount = NumberFormatterUtil.formatStringToDecimalString(viewModel.inputTargetAmount)
+                                Log.debug(viewModel.inputTargetAmount)
                                 viewModel.validateForm()
                             }
                     }
@@ -54,7 +55,14 @@ struct TargetAmountSettingView: View {
                 
                 CustomBottomButton(action: {
                     if viewModel.isFormValid {
-                        navigateToCompleteTarget = true
+                        viewModel.editCurrentMonthTargetAmountApi { success in
+                            if success {
+                                Log.debug("목표 금액 수정 성공")
+                                navigateToCompleteTarget = true
+                            } else {
+                                Log.debug("목표 금액 수정 실패")
+                            }
+                        }
                     }
                 }, label: "확인", isFormValid: $viewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
@@ -75,4 +83,8 @@ struct TargetAmountSettingView: View {
             }
         }
     }
+}
+
+#Preview {
+    TargetAmountSettingView(currentData: .constant(TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0)))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -37,7 +37,7 @@ struct TotalTargetAmountView: View {
                     }, alignment: .topTrailing
                 )
             }
-            NavigationLink(destination: TargetAmountSettingView(targetAmount: .constant(nil)), isActive: $navigateToEditTarget) {}
+            NavigationLink(destination: TargetAmountSettingView(currentData: $viewModel.currentData), isActive: $navigateToEditTarget) {}
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color("Gray01"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -19,24 +19,24 @@ struct TotalTargetAmountView: View {
 
                     Spacer().frame(height: 29 * DynamicSizeFactor.factor())
                 }
-                .overlay(
-                    VStack(alignment: .leading) {
-                        if isClickMenu {
-                            CustomDropdownMenuView(
-                                isClickMenu: $isClickMenu,
-                                selectedMenu: $selectedMenu,
-                                listArray: listArray,
-                                onItemSelected: { item in
-                                    if item == "목표금액 수정" {
-                                        navigateToEditTarget = true
-                                    }
-                                    Log.debug("Selected item: \(item)")
-                                }
-                            ).padding(.trailing, 20)
-                        }
-                    }, alignment: .topTrailing
-                )
             }
+            .overlay(
+                VStack(alignment: .leading) {
+                    if isClickMenu {
+                        CustomDropdownMenuView(
+                            isClickMenu: $isClickMenu,
+                            selectedMenu: $selectedMenu,
+                            listArray: listArray,
+                            onItemSelected: { item in
+                                if item == "목표금액 수정" {
+                                    navigateToEditTarget = true
+                                }
+                                Log.debug("Selected item: \(item)")
+                            }
+                        ).padding(.trailing, 20)
+                    }
+                }, alignment: .topTrailing
+            )
             NavigationLink(destination: TargetAmountSettingView(currentData: $viewModel.currentData), isActive: $navigateToEditTarget) {}
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -66,7 +66,7 @@ struct TotalTargetAmountView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 0) {
                     Button(action: {
-                        isClickMenu = true
+                        isClickMenu.toggle()
                         selectedMenu = nil
                     }, label: {
                         Image("icon_navigationbar_kebabmenu_white")

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountSettingViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountSettingViewModel.swift
@@ -4,10 +4,37 @@ import SwiftUI
 // MARK: - TargetAmountSettingViewModel
 
 class TargetAmountSettingViewModel: ObservableObject {
+    @Published var currentData: TargetAmount? = nil
     @Published var inputTargetAmount = ""
     @Published var isFormValid = false
 
+    init(currentData: TargetAmount) {
+        self.currentData = currentData
+        inputTargetAmount = String(currentData.targetAmountDetail.amount)
+    }
+
     func validateForm() {
         isFormValid = !inputTargetAmount.isEmpty
+    }
+
+    func editCurrentMonthTargetAmountApi() {
+        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: currentData?.targetAmountDetail.amount ?? 0)
+
+        TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(targetAmountId: currentData?.targetAmountDetail.id ?? -1, dto: editCurrentMonthTargetAmountRequestDto) { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    if let jsonString = String(data: responseData, encoding: .utf8) {
+                        Log.debug("당월 목표 금액 수정 완료 \(jsonString)")
+                    }
+                }
+            case let .failure(error):
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+            }
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountSettingViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountSettingViewModel.swift
@@ -10,15 +10,14 @@ class TargetAmountSettingViewModel: ObservableObject {
 
     init(currentData: TargetAmount) {
         self.currentData = currentData
-        inputTargetAmount = String(currentData.targetAmountDetail.amount)
     }
 
     func validateForm() {
         isFormValid = !inputTargetAmount.isEmpty
     }
 
-    func editCurrentMonthTargetAmountApi() {
-        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: currentData?.targetAmountDetail.amount ?? 0)
+    func editCurrentMonthTargetAmountApi(completion: @escaping (Bool) -> Void) {
+        let editCurrentMonthTargetAmountRequestDto = EditCurrentMonthTargetAmountRequestDto(amount: Int(inputTargetAmount.replacingOccurrences(of: ",", with: "")) ?? 0)
 
         TargetAmountAlamofire.shared.editCurrentMonthTargetAmount(targetAmountId: currentData?.targetAmountDetail.id ?? -1, dto: editCurrentMonthTargetAmountRequestDto) { result in
             switch result {
@@ -26,6 +25,7 @@ class TargetAmountSettingViewModel: ObservableObject {
                 if let responseData = data {
                     if let jsonString = String(data: responseData, encoding: .utf8) {
                         Log.debug("당월 목표 금액 수정 완료 \(jsonString)")
+                        completion(true)
                     }
                 }
             case let .failure(error):
@@ -34,6 +34,7 @@ class TargetAmountSettingViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
+                completion(false)
             }
         }
     }


### PR DESCRIPTION
## 작업 이유

- 목표 금액 설정/수정 api 연동
- dropdown menu 오류 수정


<br/>

## 작업 사항


### 1️⃣ 목표 금액 설정/수정 api 연동

설정과 수정하는 api는 동일하다.

- 구현 위치: TargetAmountAlamofire - TargetAmountRouter
- path: v2/target-amounts/\(targetAmountId)
- method: patch
- query: `token = {token}`

아래와 같이 예외처리를 하였다.

```
1. 당월 목표 금액이 없는 경우 -> placeholder 숨김
2. 당월 목표 금액이 있는 경우 -> placeholder 표시하는데 데이터는 당월 목표 금액으로
```

TotalTargetAmountView에서 현재 데이터(currentData)를 TargetAmountSettingView로 바인딩해서 넘겨준다.
그러면 TargetAmountSettingView에서 다시 목표 금액 조회할 필요 없이 당월 목표 금액을 알 수 있다.

받아온 currentData의 amount가 -1이면, 목표금액이 없는 경우이므로 placeholder를 숨긴다.

```
 if currentData.targetAmountDetail.amount != -1 && viewModel.inputTargetAmount.isEmpty {
    Text("\(currentData.targetAmountDetail.amount)")
        .platformTextColor(color: Color("Gray03"))
        .padding(.leading, 13 * DynamicSizeFactor.factor())
        .font(.H2SemiboldFont())
}
```

- 동작 예시

아래는 목표 금액이 있는 경우 동작 과정이다.

![Simulator Screen Recording - iPhone 15 Pro - 2024-07-10 at 11 47 02](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/e57e011a-0f24-4952-86ca-8eb670274c93)

<br/>

### 2️⃣ dropdown menu 오류 수정

dropdown menu 클릭 후 메뉴 버튼을 다시 클릭하면 뷰가 사라져야 하는데 사라지지 않는 문제가 있었다.

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-07-10 at 01 59 56](https://github.com/CollaBu/pennyway-client-ios/assets/103185302/d5543c2c-d9af-4bf4-a2a4-88c8ce29fa7e)

그래서 버튼 클릭여부를 toggle로 처리하니 해결되었다.

```swift
Button(action: {
    isClickMenu.toggle()
    selectedMenu = nil
}, label: {
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

목표 금액 설정/수정 api 연동했고, dropdown menu 오류 발견했는데 간단하게 고칠 수 있어서 해결했어요~

<br/>

## 발견한 이슈
없음