### PR TITLE
📍7월 2주차 피드백 반영 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
@@ -5,6 +5,7 @@ struct AddSpendingCompleteView: View {
 
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @Binding var clickDate: Date?
+    @Binding var isPresented: Bool
     var entryPoint: EntryPoint
     
     var body: some View {
@@ -68,7 +69,9 @@ struct AddSpendingCompleteView: View {
                 if entryPoint == .main {
                     NavigationUtil.popToRootView()
                 } else {
-                    NavigationUtil.popToView(at: 1)
+                    isPresented = false
+                    Log.debug("isPresented: \(isPresented)")
+                    Log.debug("entryPoint: \(entryPoint)")
                 }
 
             }, label: "확인", isFormValid: .constant(true))
@@ -81,5 +84,5 @@ struct AddSpendingCompleteView: View {
 }
 
 #Preview {
-    AddSpendingCompleteView(viewModel: AddSpendingHistoryViewModel(), clickDate: .constant(Date()), entryPoint: .main)
+    AddSpendingCompleteView(viewModel: AddSpendingHistoryViewModel(), clickDate: .constant(Date()), isPresented: .constant(true), entryPoint: .main)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 struct AddSpendingCompleteView: View {
-    @Environment(\.presentationMode) var presentationMode
+//    @Environment(\.presentationMode) var presentationMode
+
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @Binding var clickDate: Date?
-
+    var entryPoint: EntryPoint
+    
     var body: some View {
         VStack {
             Image("icon_illust_add history")
@@ -12,12 +14,12 @@ struct AddSpendingCompleteView: View {
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 160 * DynamicSizeFactor.factor(), height: 160 * DynamicSizeFactor.factor())
                 .padding(.top, 65 * DynamicSizeFactor.factor())
-            
+                
             Text("소비 내역 추가 완료!")
                 .font(.H1SemiboldFont())
-            
+                
             Spacer()
-           
+                
             VStack(spacing: 16 * DynamicSizeFactor.factor()) {
                 HStack {
                     Text("금액")
@@ -32,9 +34,9 @@ struct AddSpendingCompleteView: View {
                     Text("카테고리")
                         .font(.B1MediumFont())
                         .platformTextColor(color: Color("Gray04"))
-                    
+                        
                     Spacer()
-                    
+                        
                     if let category = viewModel.selectedCategory {
                         HStack(spacing: 10 * DynamicSizeFactor.factor()) {
                             Image(category.icon.rawValue)
@@ -52,33 +54,35 @@ struct AddSpendingCompleteView: View {
                         .font(.B1MediumFont())
                         .platformTextColor(color: Color("Gray04"))
                     Spacer()
-                    
+                        
                     Text(Date.getFormattedDate(from: clickDate ?? viewModel.selectedDate))
                         .font(.B1MediumFont())
                         .platformTextColor(color: Color("Gray07"))
                 }
             }
             .padding(.horizontal, 20)
-           
-            Spacer().frame(height: 24 * DynamicSizeFactor.factor())
-            
-            CustomBottomButton(action: {
-                if let date = clickDate {
-                    if Calendar.current.isDateInToday(date) { // 현재 날짜로 등록한 경우 메인화면 -> 메인화면에서 +아이콘을 통해 들어간 경우
-                        NavigationUtil.popToRootView()
-                    } else { // 클릭한 지출내역의 sheet로 
-//                                self.presentationMode.wrappedValue.dismiss() // 수정필요
-                    }
-                }
                 
+            Spacer().frame(height: 24 * DynamicSizeFactor.factor())
+                
+            CustomBottomButton(action: {
+                if entryPoint == .main {
+                    NavigationUtil.popToRootView()
+                } else {
+//                    isPresented = false
+                    NavigationUtil.popToView(at: 1)
+                }
+
+//                NavigationUtil.popToRootView()
+
             }, label: "확인", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }
+        
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(true)
     }
 }
 
 #Preview {
-    AddSpendingCompleteView(viewModel: AddSpendingHistoryViewModel(), clickDate: .constant(Date()))
+    AddSpendingCompleteView(viewModel: AddSpendingHistoryViewModel(), clickDate: .constant(Date()), entryPoint: .main)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
@@ -68,11 +68,8 @@ struct AddSpendingCompleteView: View {
                 if entryPoint == .main {
                     NavigationUtil.popToRootView()
                 } else {
-//                    isPresented = false
                     NavigationUtil.popToView(at: 1)
                 }
-
-//                NavigationUtil.popToRootView()
 
             }, label: "확인", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -15,6 +15,7 @@ struct AddSpendingHistoryView: View {
     @State private var navigateToAddSpendingCategory = false
     @Environment(\.presentationMode) var presentationMode
     @Binding var clickDate: Date?
+    @Binding var isPresented: Bool
     var entryPoint: EntryPoint
 
     var body: some View {
@@ -39,7 +40,7 @@ struct AddSpendingHistoryView: View {
                 }, label: "확인", isFormValid: $viewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
 
-                NavigationLink(destination: AddSpendingCompleteView(viewModel: viewModel, clickDate: $clickDate, entryPoint: entryPoint), isActive: $navigateToAddSpendingCategory) {}
+                NavigationLink(destination: AddSpendingCompleteView(viewModel: viewModel, clickDate: $clickDate, isPresented: $isPresented, entryPoint: entryPoint), isActive: $navigateToAddSpendingCategory) {}
 
                 NavigationLink(
                     destination: AddSpendingCategoryView(viewModel: viewModel, spendingCategoryViewModel: SpendingCategoryViewModel()), isActive: $viewModel.navigateToAddCategory) {}
@@ -81,5 +82,5 @@ struct AddSpendingHistoryView: View {
 }
 
 #Preview {
-    AddSpendingHistoryView(clickDate: .constant(Date()), entryPoint: .main)
+    AddSpendingHistoryView(clickDate: .constant(Date()), isPresented: .constant(true), entryPoint: .main)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -23,6 +23,7 @@ struct AddSpendingHistoryView: View {
                         viewModel.addSpendingHistoryApi { success in
                             if success {
                                 navigateToAddSpendingCategory = true
+                                Log.debug("\(date)에 해당하는 지출내역 추가 성공")
                             }
                         }
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -1,6 +1,13 @@
 
 import SwiftUI
 
+// MARK: - EntryPoint
+
+enum EntryPoint {
+    case main
+    case detailSheet
+}
+
 // MARK: - AddSpendingHistoryView
 
 struct AddSpendingHistoryView: View {
@@ -8,7 +15,8 @@ struct AddSpendingHistoryView: View {
     @State private var navigateToAddSpendingCategory = false
     @Environment(\.presentationMode) var presentationMode
     @Binding var clickDate: Date?
-    
+    var entryPoint: EntryPoint
+
     var body: some View {
         ZStack {
             VStack {
@@ -16,22 +24,23 @@ struct AddSpendingHistoryView: View {
                     AddSpendingInputFormView(viewModel: viewModel, clickDate: $clickDate)
                 }
                 Spacer()
-                
+
                 CustomBottomButton(action: {
                     if viewModel.isFormValid, let date = clickDate {
                         viewModel.clickDate = date
+
                         viewModel.addSpendingHistoryApi { success in
                             if success {
                                 navigateToAddSpendingCategory = true
-                                Log.debug("\(date)에 해당하는 지출내역 추가 성공")
+                                Log.debug("\(viewModel.clickDate)에 해당하는 지출내역 추가 성공")
                             }
                         }
                     }
                 }, label: "확인", isFormValid: $viewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
-                
-                NavigationLink(destination: AddSpendingCompleteView(viewModel: viewModel, clickDate: $clickDate), isActive: $navigateToAddSpendingCategory) {}
-                
+
+                NavigationLink(destination: AddSpendingCompleteView(viewModel: viewModel, clickDate: $clickDate, entryPoint: entryPoint), isActive: $navigateToAddSpendingCategory) {}
+
                 NavigationLink(
                     destination: AddSpendingCategoryView(viewModel: viewModel, spendingCategoryViewModel: SpendingCategoryViewModel()), isActive: $viewModel.navigateToAddCategory) {}
             }
@@ -56,14 +65,14 @@ struct AddSpendingHistoryView: View {
                         .padding(.leading, 5)
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
-                        
+
                     }.offset(x: -10)
                 }
             }
             .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented) {
                 SpendingCategoryListView(viewModel: viewModel, isPresented: $viewModel.isCategoryListViewPresented)
             }
-            
+
             .bottomSheet(isPresented: $viewModel.isSelectDayViewPresented, maxHeight: 300 * DynamicSizeFactor.factor()) {
                 SelectSpendingDayView(viewModel: viewModel, isPresented: $viewModel.isSelectDayViewPresented, clickDate: $clickDate)
             }
@@ -72,5 +81,5 @@ struct AddSpendingHistoryView: View {
 }
 
 #Preview {
-    AddSpendingHistoryView(clickDate: .constant(Date()))
+    AddSpendingHistoryView(clickDate: .constant(Date()), entryPoint: .main)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -8,7 +8,7 @@ struct AddSpendingHistoryView: View {
     @State private var navigateToAddSpendingCategory = false
     @Environment(\.presentationMode) var presentationMode
     @Binding var clickDate: Date?
-
+    
     var body: some View {
         ZStack {
             VStack {
@@ -16,7 +16,7 @@ struct AddSpendingHistoryView: View {
                     AddSpendingInputFormView(viewModel: viewModel, clickDate: $clickDate)
                 }
                 Spacer()
-
+                
                 CustomBottomButton(action: {
                     if viewModel.isFormValid, let date = clickDate {
                         viewModel.clickDate = date
@@ -28,9 +28,9 @@ struct AddSpendingHistoryView: View {
                     }
                 }, label: "확인", isFormValid: $viewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
-
+                
                 NavigationLink(destination: AddSpendingCompleteView(viewModel: viewModel, clickDate: $clickDate), isActive: $navigateToAddSpendingCategory) {}
-
+                
                 NavigationLink(
                     destination: AddSpendingCategoryView(viewModel: viewModel, spendingCategoryViewModel: SpendingCategoryViewModel()), isActive: $viewModel.navigateToAddCategory) {}
             }
@@ -44,7 +44,7 @@ struct AddSpendingHistoryView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     HStack {
                         Button(action: {
-                            self.presentationMode.wrappedValue.dismiss() 
+                            self.presentationMode.wrappedValue.dismiss()
                         }, label: {
                             Image("icon_arrow_back")
                                 .resizable()
@@ -55,20 +55,17 @@ struct AddSpendingHistoryView: View {
                         .padding(.leading, 5)
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
-
+                        
                     }.offset(x: -10)
                 }
             }
-        }
-//        .onAppear {
-//            viewModel.selectedDate = selectedDate
-//        }
-        .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented) {
-            SpendingCategoryListView(viewModel: viewModel, isPresented: $viewModel.isCategoryListViewPresented)
-        }
-
-        .bottomSheet(isPresented: $viewModel.isSelectDayViewPresented, maxHeight: 300 * DynamicSizeFactor.factor()) {
-            SelectSpendingDayView(isPresented: $viewModel.isSelectDayViewPresented, selectedDate: $viewModel.selectedDate)
+            .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented) {
+                SpendingCategoryListView(viewModel: viewModel, isPresented: $viewModel.isCategoryListViewPresented)
+            }
+            
+            .bottomSheet(isPresented: $viewModel.isSelectDayViewPresented, maxHeight: 300 * DynamicSizeFactor.factor()) {
+                SelectSpendingDayView(viewModel: viewModel, isPresented: $viewModel.isSelectDayViewPresented, clickDate: $clickDate)
+            }
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SelectSpendingDayView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SelectSpendingDayView.swift
@@ -1,8 +1,21 @@
 import SwiftUI
 
+// MARK: - SelectSpendingDayView
+
 struct SelectSpendingDayView: View {
+    @ObservedObject var viewModel: AddSpendingHistoryViewModel
+
     @Binding var isPresented: Bool
-    @Binding var selectedDate: Date
+    @Binding var clickDate: Date?
+
+    @State private var selectedDate: Date
+
+    init(viewModel: AddSpendingHistoryViewModel, isPresented: Binding<Bool>, clickDate: Binding<Date?>) {
+        _viewModel = ObservedObject(wrappedValue: viewModel)
+        _isPresented = isPresented
+        _clickDate = clickDate
+        _selectedDate = State(initialValue: clickDate.wrappedValue ?? Date())
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -26,7 +39,9 @@ struct SelectSpendingDayView: View {
             Spacer()
 
             CustomBottomButton(action: {
+                clickDate = selectedDate
                 isPresented = false
+                Log.debug("clickDate: \(self.clickDate)")
             }, label: "확인", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SelectSpendingDayView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SelectSpendingDayView.swift
@@ -33,14 +33,18 @@ struct SelectSpendingDayView: View {
                 .datePickerStyle(WheelDatePickerStyle())
                 .labelsHidden()
                 .environment(\.locale, Locale(identifier: "ko_KR"))
-                .environment(\.timeZone, TimeZone(secondsFromGMT: 0)!)
+                .environment(\.timeZone, TimeZone.autoupdatingCurrent)
                 .frame(height: 114 * DynamicSizeFactor.factor())
                 .clipped()
 
             Spacer()
 
             CustomBottomButton(action: {
-                clickDate = selectedDate
+                let today = Date()
+                let timezone = TimeZone.autoupdatingCurrent
+                let secondsFromGMT = timezone.secondsFromGMT(for: today)
+                let localizedDate = selectedDate.addingTimeInterval(TimeInterval(secondsFromGMT))
+                clickDate = localizedDate
                 isPresented = false
                 Log.debug("clickDate: \(self.clickDate)")
             }, label: "확인", isFormValid: .constant(true))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SelectSpendingDayView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SelectSpendingDayView.swift
@@ -33,6 +33,7 @@ struct SelectSpendingDayView: View {
                 .datePickerStyle(WheelDatePickerStyle())
                 .labelsHidden()
                 .environment(\.locale, Locale(identifier: "ko_KR"))
+                .environment(\.timeZone, TimeZone(secondsFromGMT: 0)!)
                 .frame(height: 114 * DynamicSizeFactor.factor())
                 .clipped()
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct DetailSpendingView: View {
+    @Environment(\.presentationMode) var presentationMode
     @State private var isSelectedCategory: Bool = false
     @State var selectedItem: String? = nil
     @State var listArray: [String] = ["수정하기", "내역 삭제"]
@@ -23,7 +24,7 @@ struct DetailSpendingView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 HStack {
                     Button(action: {
-                        NavigationUtil.popToRootView()
+                        self.presentationMode.wrappedValue.dismiss()
                     }, label: {
                         Image("icon_arrow_back")
                             .resizable()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
@@ -35,7 +35,7 @@ struct NoSpendingHistoryView: View {
                     .background(Color("Mint03"))
                     .cornerRadius(30)
 
-                    NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate), isActive: $navigateToAddSpendingHistory) {
+                    NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate, entryPoint: .detailSheet), isActive: $navigateToAddSpendingHistory) {
                         EmptyView()
                     }.hidden()
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
@@ -35,7 +35,7 @@ struct NoSpendingHistoryView: View {
                     .background(Color("Mint03"))
                     .cornerRadius(30)
 
-                    NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate, entryPoint: .detailSheet), isActive: $navigateToAddSpendingHistory) {
+                    NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .detailSheet), isActive: $navigateToAddSpendingHistory) {
                         EmptyView()
                     }.hidden()
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/NoSpendingHistorySheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/NoSpendingHistorySheetView.swift
@@ -7,7 +7,7 @@ struct NoSpendingHistorySheetView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     Spacer().frame(height: 13 * DynamicSizeFactor.factor())
-                    
+                        
                     HStack(alignment: .center, spacing: 10) {
                         Text("절약왕")
                             .font(.B1SemiboldeFont())
@@ -17,17 +17,17 @@ struct NoSpendingHistorySheetView: View {
                     .padding(.vertical, 4 * DynamicSizeFactor.factor())
                     .background(Color("Ashblue01"))
                     .cornerRadius(15)
-                    
+                        
                     Spacer().frame(height: 8 * DynamicSizeFactor.factor())
-                    
+                        
                     Text("-0원")
                         .font(.H1BoldFont())
                         .platformTextColor(color: Color("Gray07"))
                         .padding(.vertical, 3 * DynamicSizeFactor.factor()) // line-height 적용하면 지울것
                         .padding(.trailing, 254 * DynamicSizeFactor.factor())
-                    
+                        
                     Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-                    
+                        
                     Text("절약왕이 될 상이에요!\n친구들에게 자랑해 볼까요?")
                         .font(.B1MediumFont())
                         .platformTextColor(color: Color("Gray05"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -92,20 +92,21 @@ struct SpendingDetailSheetView: View {
             }
             .fullScreenCover(isPresented: $showAddSpendingHistoryView) {
                 NavigationAvailable {
-                    AddSpendingHistoryView(clickDate: $clickDate, entryPoint: .detailSheet)
+                    AddSpendingHistoryView(clickDate: $clickDate, isPresented: $showAddSpendingHistoryView, entryPoint: .detailSheet)
                 }
             }
         }
         .onAppear {
             Log.debug("SpendingDetailSheetView appeared. Selected date: \(String(describing: clickDate))")
+            getDailyHistoryData()
         }
         .onChange(of: showEditSpendingDetailView) { _ in
-            spendingHistoryViewModel.checkSpendingHistoryApi { success in
-                if success {
-                    Log.debug("뷰 새로고침 성공")
-                } else {
-                    Log.debug("뷰 새로고침 실패")
-                }
+            getDailyHistoryData()
+        }
+        .onChange(of: showAddSpendingHistoryView) { isPresented in
+            if !isPresented {
+                // AddSpendingHistoryView가 닫힐 때 새로고침
+                getDailyHistoryData()
             }
         }
         .onChange(of: clickDate) { _ in
@@ -119,5 +120,15 @@ struct SpendingDetailSheetView: View {
         let day = Calendar.current.component(.day, from: date)
         Log.debug(day)
         return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
+    }
+    
+    private func getDailyHistoryData() {
+        spendingHistoryViewModel.checkSpendingHistoryApi { success in
+            if success {
+                Log.debug("뷰 새로고침 성공")
+            } else {
+                Log.debug("뷰 새로고침 실패")
+            }
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -13,7 +13,7 @@ struct SpendingDetailSheetView: View {
     
     @StateObject var viewModel: AddSpendingHistoryViewModel
     @ObservedObject var spendingHistoryViewModel: SpendingHistoryViewModel
-
+    
     var body: some View {
         ZStack(alignment: .leading) {
             VStack {
@@ -30,7 +30,7 @@ struct SpendingDetailSheetView: View {
                     }
                         
                     Spacer()
-                    
+                        
                     if let clickDate = clickDate, getSpendingAmount(for: clickDate) == nil || isDeleted {
                         // 지출내역이 없을 경우 편집버튼 없음
                     } else {
@@ -45,7 +45,7 @@ struct SpendingDetailSheetView: View {
                         })
                         .padding(10)
                     }
-                
+                        
                     Button(action: {
                         showAddSpendingHistoryView = true
                     }, label: {
@@ -59,7 +59,7 @@ struct SpendingDetailSheetView: View {
                 .padding(.leading, 20)
                 .padding(.trailing, 17)
                 .padding(.top, 12)
-                
+                    
                 if let clickDate = clickDate, getSpendingAmount(for: clickDate) == nil || isDeleted {
                     NoSpendingHistorySheetView()
                 } else {
@@ -74,10 +74,10 @@ struct SpendingDetailSheetView: View {
                             }
                                 
                             Spacer().frame(height: 32 * DynamicSizeFactor.factor())
-
+                                
                             ForEach(spendingHistoryViewModel.filteredSpendings(for: clickDate), id: \.id) { item in
                                 let iconName = SpendingListViewCategoryIconList(rawValue: item.category.icon)?.iconName ?? ""
-
+                                    
                                 CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
                                 Spacer().frame(height: 12 * DynamicSizeFactor.factor())
                             }
@@ -92,7 +92,7 @@ struct SpendingDetailSheetView: View {
             }
             .fullScreenCover(isPresented: $showAddSpendingHistoryView) {
                 NavigationAvailable {
-                    AddSpendingHistoryView(clickDate: $clickDate)
+                    AddSpendingHistoryView(clickDate: $clickDate, entryPoint: .detailSheet)
                 }
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
@@ -181,14 +181,14 @@ private extension SpendingCalenderView {
         var dateComponents = DateComponents()
         dateComponents.day = index
     
-        let timeZone = TimeZone.current
-        let offset = Double(timeZone.secondsFromGMT(for: firstDayOfMonth))
-        dateComponents.second = Int(offset)
+//        let timeZone = TimeZone.current
+//        let offset = Double(timeZone.secondsFromGMT(for: firstDayOfMonth))
+//        dateComponents.second = Int(offset)
     
         let date = calendar.date(byAdding: dateComponents, to: firstDayOfMonth) ?? Date()
         return date
     }
-  
+
     /// 해당 월에 존재하는 일자 수
     func numberOfDays(in date: Date) -> Int {
         return Calendar.current.range(of: .day, in: .month, for: date)?.count ?? 0

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -13,6 +13,7 @@ struct SpendingManagementMainView: View {
     @State private var clickDate: Date? // 선택된 날짜 저장
     @State private var addSpendingClickDate: Date?
     @State private var addSpendingSelectedDate: Date?
+    @State private var entryPoint: EntryPoint = .main
 
     @State private var showToastPopup = false
 
@@ -93,6 +94,7 @@ struct SpendingManagementMainView: View {
                     HStack(spacing: 0) {
                         Button(action: {
                             clickDate = Date() // +아이콘을 통해 들어간 경우 현재날짜 고정
+                            entryPoint = .main
                             navigateToAddSpendingHistory = true
                         }, label: {
                             Image("icon_navigation_add_black")
@@ -128,7 +130,7 @@ struct SpendingManagementMainView: View {
                 }, alignment: .bottom
             )
 
-            NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate), isActive: $navigateToAddSpendingHistory) {
+            NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
                 EmptyView()
             }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -130,7 +130,7 @@ struct SpendingManagementMainView: View {
                 }, alignment: .bottom
             )
 
-            NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
+            NavigationLink(destination: AddSpendingHistoryView(clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
                 EmptyView()
             }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/SignUpFormViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/SignUpFormViewModel.swift
@@ -48,7 +48,7 @@ class SignUpFormViewModel: ObservableObject {
     }
     
     func validateName() {
-        let nameRegex = "^[가-힣a-z]{2,8}$"
+        let nameRegex = "^[가-힣a-zA-Z]{2,8}$"
         showErrorName = !NSPredicate(format: "SELF MATCHES %@", nameRegex).evaluate(with: name)
     }
     

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
@@ -5,6 +5,8 @@ class SpendingHistoryViewModel: ObservableObject {
     @Published var currentDate: Date = Date() // 현재 날짜
     @Published var dailySpendings: [DailySpending] = [] // 데일리 지출 내역
     @Published var dailyDetailSpendings: [IndividualSpending] = [] // 데일리 지출 목록
+    @Published var Spending: [Spending] = [] // 소비내역 
+
     @Published var isChangeMonth: Bool = false
     @Published var selectedDateToScroll: String? = nil
 


### PR DESCRIPTION
## 작업 이유
- 지출 내역 상세 조회 후 뒤로 가기 뷰 처리
- 사용자 이름(name) 대문자 허용
- 지출 내역 추가시 datePicker와 연동

<br/>

## 작업 사항

### **1️⃣ 지출 내역 상세 조회 후 뒤로 가기 뷰 처리**
지출 내역 자세히보기에서 뒤로갔을 때 메인뷰가 아닌, 전의 뷰로 돌아가기 위해서 popToRootView가 아닌 현재 화면을 닫는 로직으로 변경하였다.
` self.presentationMode.wrappedValue.dismiss()
`

### **2️⃣ 사용자 이름(name) 대문자 허용**
아래와 같이 회원가입할 때 사용자 이름에 대한 유효성을 수정하였다
```swift
func validateName() {
        let nameRegex = "^[가-힣a-zA-Z]{2,8}$"
        showErrorName = !NSPredicate(format: "SELF MATCHES %@", nameRegex).evaluate(with: name)
    }
``` 
### **3️⃣ 지출 내역 추가시 datePicker와 연동**
메인캘린더에서 clickDate를 바인딩해서 받아와서, 그 선택한 날(clickDate)를 SelectSpendingDayView에 전달해주도록 구현하였다. 
clickDate는 Date타입인데, DatePicker에서는 Date()타입을 넘겨줘야 해서 SelectSpendingDayView가 실행될 때 초기화를 통해 clickDate를 selectedDate로 넘겨줘서 selectedDate가 datePicker에 전달되도록 한다.
```swift
init(viewModel: AddSpendingHistoryViewModel, isPresented: Binding<Bool>, clickDate: Binding<Date?>) {
        _viewModel = ObservedObject(wrappedValue: viewModel)
        _isPresented = isPresented
        _clickDate = clickDate
        _selectedDate = State(initialValue: clickDate.wrappedValue ?? Date())
    }
``` 

**동작과정**
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-07-16 at 00 41 12](https://github.com/user-attachments/assets/595a5eaa-da70-407f-ac7c-ff10fc42b5db)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
피드백 모두 반영했고 이슈 읽어주시면 될 거 같아요!

<br/>

## 발견한 이슈
### 1. 매달 1일에 지출내역 등록을 하면 전의 달 1일로 지출내역이 추가됨
datePicker랑 연동후에 7월 1일로 지출내역을 등록하니, 6월 1일에 지출내역이 등록되어 표시된다. 근데 로그를 찍어서 확인해보니 api 도 7월 1일로 정상적으로 지출등록이 되어 있고 선택한 날짜도 7월1일로 표시되어 있다.  그래서 6월 1일의 내역을 클릭해도 지출내역은 나오지 않고 금액만 나와있다. (나머지 날짜는 정상적으로 등록되는데, 달의 1일만 그럼)
<img width="613" alt="스크린샷 2024-07-15 오후 9 35 38" src="https://github.com/user-attachments/assets/d3627049-0b68-448b-9fca-5cd6a11511cf">
<img src = "https://github.com/user-attachments/assets/0eb4ee1e-b534-4066-b0dc-7916df834e5b" width = "300" height = "500">
<img src = "https://github.com/user-attachments/assets/46a87e33-fe0a-4c45-b65e-7577fd6acb73" width = "300" height = "500">

아마 메인 화면 캘린더에 timeZone 부분을 수정해야 할 거 같아서 임의로 `SpendingCalenderView`에 특정 날짜를 반환해주는 함수에 TimeZone을 주석처리해서 실행시켜보았는데도 그대로다.
```swift
/// 특정 해당 날짜
    func getDate(for index: Int) -> Date {
        let calendar = Calendar.current
        guard let firstDayOfMonth = calendar.date(
            from: DateComponents(
                year: calendar.component(.year, from: date),
                month: calendar.component(.month, from: date),
                day: 1
            )
        ) else {
            return Date()
        }
    
        var dateComponents = DateComponents()
        dateComponents.day = index
    
//        let timeZone = TimeZone.current
//        let offset = Double(timeZone.secondsFromGMT(for: firstDayOfMonth))
//        dateComponents.second = Int(offset)
    
        let date = calendar.date(byAdding: dateComponents, to: firstDayOfMonth) ?? Date()
        return date
    }
``` 
- 방안: 7월 1일에 지출내역을 추가 했는데 6월 1일에 표시된다.(등록은 7월1일에 정상적으로 되었음) 근데 등록은 7월 1일로 되었으니 지출내역을 눌렀을 때 지출내역이 없는 화면만 보여야 하는데 있는 화면이 보인다. 그래서 아래 로직중 getSpendingAmount에 대한 내용을 수정해봐야 할 거 같음
```swift
if let clickDate = clickDate, let dailyTotalAmount = getSpendingAmount(for: clickDate) {
                                Text("-\(dailyTotalAmount)원")
                                    .font(.H1SemiboldFont())
                                    .platformTextColor(color: Color("Gray07"))
                                    .padding(.leading, 20)
                            }
``` 

### 2. 지출추가 후 AddSpendingCompleteView에서 완료 처리후 화면이동
이건 이슈로 등록해놨었는데 해결해보려했다가 전혀 해결이 되지 않아,, 한번 같이 찾아봐주시면 감사하겠습니다,,
일단 AddSpendingHistoryView에서 enum으로 main화면에서 추가하기를 들어가 지출내역을 추가한것인지, detailSheet를 통해 지출내역을 추가한것인지 분리해서 case별로 뷰에 전달해줬고, detailSheet도 네비게이션으로 연결되어 있어서 아래와 같이  NavigationUtil.popToView(at: 1)로 처리해줬는데 안되네요 ㅠㅠㅠ

```swift
CustomBottomButton(action: {
                if entryPoint == .main {
                    NavigationUtil.popToRootView()
                } else {
                    NavigationUtil.popToView(at: 1)
                }

            }, label: "확인", isFormValid: .constant(true))
                .padding(.bottom, 34 * DynamicSizeFactor.factor())
``` 