### PR TITLE
📍목표금액 + 무한 스크롤 UI 피드백 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
@@ -26,4 +26,15 @@ enum DateFormatterUtil {
         }
         return dateString
     }
+
+    static func getYear(from date: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        guard let date = dateFormatter.date(from: date) else {
+            return ""
+        }
+        let yearFormatter = DateFormatter()
+        yearFormatter.dateFormat = "yyyy"
+        return yearFormatter.string(from: date)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -39,7 +39,7 @@ struct CategoryDetailsView: View {
                     Rectangle()
                         .platformTextColor(color: Color("Gray01"))
                         .frame(maxWidth: .infinity)
-                        .frame(height: 8 * DynamicSizeFactor.factor())
+                        .frame(height: 1 * DynamicSizeFactor.factor())
 
                     Spacer().frame(height: 24 * DynamicSizeFactor.factor())
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -3,11 +3,22 @@ import SwiftUI
 
 struct CategorySpendingListView: View {
     @ObservedObject var viewModel: SpendingCategoryViewModel
+    var currentYear = String(Date.year(from: Date()))
     
     var body: some View {
         LazyVStack(spacing: 0) {
             ForEach(SpendingListGroupUtil.groupedSpendings(from: viewModel.dailyDetailSpendings), id: \.key) { date, spendings in
-                Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+                
+                if DateFormatterUtil.getYear(from: date) != currentYear {
+                    Spacer().frame(height: 5 * DynamicSizeFactor.factor())
+                    
+                    yearSeparatorView(for: DateFormatterUtil.getYear(from: date))
+                        .padding(.horizontal, 20)
+                    
+                    Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+                } else {
+                    Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+                }
                 
                 Section(header: headerView(for: date)) {
                     Spacer().frame(height: 12 * DynamicSizeFactor.factor())
@@ -45,5 +56,21 @@ struct CategorySpendingListView: View {
             .padding(.leading, 20)
             .padding(.bottom, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    
+    private func yearSeparatorView(for year: String) -> some View {
+        HStack {
+            Rectangle()
+                .fill(Color("Gray03"))
+                .frame(height: 1 * DynamicSizeFactor.factor())
+            Text("\(year)년")
+                .font(.B1MediumFont())
+                .platformTextColor(color: Color("Gray04"))
+                .padding(.vertical, 9 * DynamicSizeFactor.factor())
+            Rectangle()
+                .fill(Color("Gray03"))
+                .frame(height: 1 * DynamicSizeFactor.factor())
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
@@ -74,10 +74,10 @@ struct SpendingCalendarCellView: View {
 
             if isCurrentMonthDay {
                 if let dailyTotalAmount = getSpendingAmount(for: day) {
-                    Text("\(dailyTotalAmount)")
+                    Text("-\(dailyTotalAmount)")
                         .font(.B4MediumFont())
                         .platformTextColor(color: isToday ? Color("Mint03") : Color("Gray07"))
-                        .frame(height: 10 * DynamicSizeFactor.factor())
+                        .frame(width: 34 * DynamicSizeFactor.factor(), height: 10 * DynamicSizeFactor.factor())
                 } else {
                     Spacer()
                         .frame(height: 10 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -54,7 +54,7 @@ struct SpendingCheckBoxView: View {
 
                 let progressWidth: CGFloat = {
                     if targetAmount <= 0 {
-                        return 0
+                        return UIScreen.main.bounds.width - 76
                     }
                     let ratio = CGFloat(totalSpending) / CGFloat(targetAmount)
                     let width = ratio * (UIScreen.main.bounds.width - 76)
@@ -62,8 +62,8 @@ struct SpendingCheckBoxView: View {
                 }()
 
                 Rectangle()
-                    .frame(width: progressWidth, height: 24 * DynamicSizeFactor.factor()) // 현재 지출에 따른 프로그래스 바
-                    .platformTextColor(color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
+                    .frame(width: progressWidth, height: 24 * DynamicSizeFactor.factor())
+                    .platformTextColor(color: targetAmount <= 0 || totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
                     .cornerRadius(15)
             }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -88,7 +88,7 @@ struct SpendingCheckBoxView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                         }
-                        .frame(width: 79 * DynamicSizeFactor.factor(), alignment: .trailing)
+                        .frame(alignment: .trailing)
                     }
                 } else {
                     Spacer()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -63,7 +63,7 @@ struct SpendingCheckBoxView: View {
 
                 Rectangle()
                     .frame(width: progressWidth, height: 24 * DynamicSizeFactor.factor())
-                    .platformTextColor(color: targetAmount <= 0 || totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
+                    .platformTextColor(color: targetAmount == 0 || totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
                     .cornerRadius(15)
             }
 


### PR DESCRIPTION
## 작업 이유

- 목표 금액 조회 로직 수정
- 목표 금액 0원에 대한 예외 처리
- 목표 금액 숫자 동적너비 처리
- 카테고리 내 지출 리스트 무한 스크롤 시, 년도 표시

<br/>

## 작업 사항

### 1️⃣ 목표 금액 조회 로직 수정

- 메인화면에서 목표 금액 조회할 때 추천 금액 뷰와 목표 금액 데이터 뷰를 같이 예외 처리하려고 하다보니 계속 로직이 꼬였다.

```
<isRead>
: 사용자가 목표 금액 추천 뷰 확인 여부를 나타낸다. 
사용자가 x버튼을 클릭하거나 사용하기를 클릭한 경우 isRead는 true가 된다.

- isRead == true => 추천 금액 뷰 숨김 
- isRead == false => 추천 금액 뷰 보여주기
```

<br/>

![스크린샷 2024-07-16 오전 2 35 23](https://github.com/user-attachments/assets/4cb7e743-42ed-43d2-9e0a-46322d4ded9a)

<br/>

```
<amount>
: 목표 금액 등록 여부를 나타낸다.

- amount  == -1 => 목표 금액 데이터 적용 x
- amount  != -1 => 목표 금액 데이터 적용
```

<br/>

![스크린샷 2024-07-16 오전 2 35 40](https://github.com/user-attachments/assets/f9a76781-aad3-4d2a-b64c-327cb063863d)

<br/>

```swift
if validTargetAmount.targetAmountDetail.isRead == true {
    // 추천 금액 보여주기 x
    self.isHiddenSuggestionView = true
} else {
    self.isHiddenSuggestionView = false
    self.getTargetAmountForPreviousMonthApi()//가장 최근에 설정한 목표 금액 조회
}

if validTargetAmount.targetAmountDetail.amount == -1 {
    // 목표 금액 데이터 적용 x
    self.isPresentTargetAmount = false
} else {
    self.isPresentTargetAmount = true
}
```

<br/>

### 2️⃣ 목표 금액 0원에 대한 예외 처리

- 목표 금액이 0원인 경우 프로그래스바 다 채우기

<img src = "https://github.com/user-attachments/assets/94887c75-8095-4fb0-aa38-d328ad340f45" width = "300"/>

<br/>

### 3️⃣ 목표 금액 숫자 동적너비 처리

- 목표 금액에 따라서 너비를 동적으로 설정하여 금액이 잘리지 않도록 하였다.

<img src = "https://github.com/user-attachments/assets/20feedda-dbc3-42d4-bf43-d0e943189297" width = "300"/>

<br/>

### 4️⃣ 카테고리 내 지출 리스트 무한 스크롤 시, 년도 표시

- 현재 년도를 제외하고 이전의 년도가 나오면 아래와 같이 구분선으로 처리하였다.

<img src = "https://github.com/user-attachments/assets/4b4054e8-a8ed-4d52-8042-c0c2c6dd9e3d" width = "300"/>

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

피드백 반영했습니다~~~
확인해보시고 궁금한 거 있으면 질문해주세요!!

<br/>

## 발견한 이슈
