### PR TITLE
📮 카테고리 수정 API 연동 + 카테고리 생성 뷰 리팩토링

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		4A98BD7C2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */; };
 		4AA52F3F2C05C3AD00B21521 /* RoundedCornerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */; };
 		4AB0B13A2C4E56C900A475F5 /* EntryPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */; };
+		4AB0B13C2C4F497400A475F5 /* MapCategoryIconUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */; };
 		4AB5AB472BB4A32F00D2C9EA /* AuthAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB462BB4A32F00D2C9EA /* AuthAlamofire.swift */; };
 		4AB5AB4A2BB4A37600D2C9EA /* AuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB492BB4A37600D2C9EA /* AuthRouter.swift */; };
 		4AB5AB4E2BB4A60500D2C9EA /* URLRequestExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB4D2BB4A60500D2C9EA /* URLRequestExtension.swift */; };
@@ -414,6 +415,7 @@
 		4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCurrentMonthTargetAmountRequestDto.swift; sourceTree = "<group>"; };
 		4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornerUtil.swift; sourceTree = "<group>"; };
 		4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryPoint.swift; sourceTree = "<group>"; };
+		4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCategoryIconUtil.swift; sourceTree = "<group>"; };
 		4AB5AB462BB4A32F00D2C9EA /* AuthAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAlamofire.swift; sourceTree = "<group>"; };
 		4AB5AB492BB4A37600D2C9EA /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
 		4AB5AB4D2BB4A60500D2C9EA /* URLRequestExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestExtension.swift; sourceTree = "<group>"; };
@@ -1331,6 +1333,7 @@
 			children = (
 				4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */,
 				4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */,
+				4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1917,6 +1920,7 @@
 				D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */,
 				D851E71B2C0273BD00316DB3 /* BackofficeRequestDto.swift in Sources */,
 				4AC320422C11D5AC00DDB4B6 /* AddSpendingCompleteView.swift in Sources */,
+				4AB0B13C2C4F497400A475F5 /* MapCategoryIconUtil.swift in Sources */,
 				4AC3204A2C11D5AC00DDB4B6 /* NoSpendingHistorySheetView.swift in Sources */,
 				4AC320532C11D5AC00DDB4B6 /* DiffAmountDynamicWidthView.swift in Sources */,
 				D87CB0D22BC5A4BC00BD882A /* ResetPwView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		4A9634B22C42EAF6000A218A /* SpendingListGroupUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */; };
 		4A98BD7C2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */; };
 		4AA52F3F2C05C3AD00B21521 /* RoundedCornerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */; };
+		4AB0B13A2C4E56C900A475F5 /* EntryPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */; };
 		4AB5AB472BB4A32F00D2C9EA /* AuthAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB462BB4A32F00D2C9EA /* AuthAlamofire.swift */; };
 		4AB5AB4A2BB4A37600D2C9EA /* AuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB492BB4A37600D2C9EA /* AuthRouter.swift */; };
 		4AB5AB4E2BB4A60500D2C9EA /* URLRequestExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB5AB4D2BB4A60500D2C9EA /* URLRequestExtension.swift */; };
@@ -412,6 +413,7 @@
 		4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingListGroupUtil.swift; sourceTree = "<group>"; };
 		4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCurrentMonthTargetAmountRequestDto.swift; sourceTree = "<group>"; };
 		4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornerUtil.swift; sourceTree = "<group>"; };
+		4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryPoint.swift; sourceTree = "<group>"; };
 		4AB5AB462BB4A32F00D2C9EA /* AuthAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAlamofire.swift; sourceTree = "<group>"; };
 		4AB5AB492BB4A37600D2C9EA /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
 		4AB5AB4D2BB4A60500D2C9EA /* URLRequestExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestExtension.swift; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 			isa = PBXGroup;
 			children = (
 				4A6C79DA2C46D067009463E4 /* ProfileActiveNavigation.swift */,
+				4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -1873,6 +1876,7 @@
 				4A8571342BC650FA0082CE47 /* BaseUrl.swift in Sources */,
 				D85927FA2BE9116700653391 /* LoginViewModel.swift in Sources */,
 				4A6C79E42C46DE8B009463E4 /* VerificationButton.swift in Sources */,
+				4AB0B13A2C4E56C900A475F5 /* EntryPoint.swift in Sources */,
 				4AC320552C11D5AC00DDB4B6 /* TotalTargetAmountGraphView.swift in Sources */,
 				4A1C598A2BC51AEB00EA2B49 /* OAuthRouter.swift in Sources */,
 				4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Alamofire/SpendingCategoryAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Alamofire/SpendingCategoryAlamofire.swift
@@ -37,4 +37,9 @@ class SpendingCategoryAlamofire {
         
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: SpendingCategoryRouter.getCategorySpendingHistory(categoryId: categoryId, dto: dto), completion: completion)
     }
+    func modifyCategory(_ categoryId: Int, _ dto: AddSpendingCustomCategoryRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("SpendingCategoryAlamofire - modifyCategory() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: SpendingCategoryRouter.modifyCategory(categoryId: categoryId, dto: dto), completion: completion)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Alamofire/SpendingCategoryAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Alamofire/SpendingCategoryAlamofire.swift
@@ -37,6 +37,7 @@ class SpendingCategoryAlamofire {
         
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: SpendingCategoryRouter.getCategorySpendingHistory(categoryId: categoryId, dto: dto), completion: completion)
     }
+
     func modifyCategory(_ categoryId: Int, _ dto: AddSpendingCustomCategoryRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
         Log.info("SpendingCategoryAlamofire - modifyCategory() called")
         

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Router/SpendingCategoryRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Router/SpendingCategoryRouter.swift
@@ -7,6 +7,7 @@ enum SpendingCategoryRouter: URLRequestConvertible {
     case getSpendingCustomCategoryList
     case getCategorySpendingCount(categoryId: Int, dto: GetCategorySpendingCountRequestDto)
     case getCategorySpendingHistory(categoryId: Int, dto: GetCategorySpendingHistoryRequestDto)
+    case modifyCategory(categoryId: Int, dto: AddSpendingCustomCategoryRequestDto)
     
     var method: HTTPMethod {
         switch self {
@@ -14,6 +15,8 @@ enum SpendingCategoryRouter: URLRequestConvertible {
             return .get
         case .addSpendingCustomCategory:
             return .post
+        case .modifyCategory:
+            return .patch
         }
     }
     
@@ -29,12 +32,14 @@ enum SpendingCategoryRouter: URLRequestConvertible {
             return "v2/spending-categories/\(categoryId)/spendings"
         case let .getCategorySpendingCount(categoryId, _):
             return "v2/spending-categories/\(categoryId)/spendings/count"
+        case let .modifyCategory(categoryId, _):
+            return "v2/spending-categories/\(categoryId)"
         }
     }
     
     var bodyParameters: Parameters? {
         switch self {
-        case .getSpendingCustomCategoryList, .addSpendingCustomCategory, .getCategorySpendingCount, .getCategorySpendingHistory:
+        case .getSpendingCustomCategoryList, .addSpendingCustomCategory, .getCategorySpendingCount, .getCategorySpendingHistory, .modifyCategory:
             return [:]
         }
     }
@@ -47,6 +52,8 @@ enum SpendingCategoryRouter: URLRequestConvertible {
             return try? dto.asDictionary()
         case let .getCategorySpendingHistory(_, dto):
             return try? dto.asDictionary()
+        case let .modifyCategory(_, dto):
+            return try? dto.asDictionary()
         case .getSpendingCustomCategoryList:
             return [:]
         }
@@ -57,7 +64,7 @@ enum SpendingCategoryRouter: URLRequestConvertible {
         var request: URLRequest
         
         switch self {
-        case .addSpendingCustomCategory, .getCategorySpendingCount, .getCategorySpendingHistory:
+        case .addSpendingCustomCategory, .getCategorySpendingCount, .getCategorySpendingHistory, .modifyCategory:
             let queryDatas = queryParameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
             request = URLRequest.createURLRequest(url: url, method: method, queryParameters: queryDatas)
         case .getSpendingCustomCategoryList:

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/ListItem/CategoryIconListItem.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/ListItem/CategoryIconListItem.swift
@@ -34,8 +34,8 @@ struct CategoryIconName: Hashable {
 struct SpendingCategoryData: Identifiable {
     let id: Int
     let isCustom: Bool
-    let name: String
-    let icon: CategoryIconName
+    var name: String
+    var icon: CategoryIconName
 }
 
 // MARK: - CategoryBaseName

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/Navigation/EntryPoint.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/Navigation/EntryPoint.swift
@@ -1,0 +1,8 @@
+
+
+// MARK: - CustomCategoryEntryPoint
+
+enum CustomCategoryEntryPoint {
+    case create
+    case modify
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/View/MapCategoryIconUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/View/MapCategoryIconUtil.swift
@@ -1,0 +1,9 @@
+
+import SwiftUI
+
+class MapCategoryIconUtil{
+    
+    static func mapToCategoryIcon(_ icon: CategoryIconName, outputState: IconState) -> CategoryIconName{
+        return CategoryIconName(baseName: icon.baseName, state: outputState)
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -43,7 +43,7 @@ struct AddSpendingHistoryView: View {
                 NavigationLink(destination: AddSpendingCompleteView(viewModel: viewModel, clickDate: $clickDate, isPresented: $isPresented, entryPoint: entryPoint), isActive: $navigateToAddSpendingCategory) {}
 
                 NavigationLink(
-                    destination: AddSpendingCategoryView(viewModel: viewModel, spendingCategoryViewModel: SpendingCategoryViewModel()), isActive: $viewModel.navigateToAddCategory) {}
+                    destination: AddSpendingCategoryView(viewModel: viewModel, spendingCategoryViewModel: SpendingCategoryViewModel(), entryPoint: .create), isActive: $viewModel.navigateToAddCategory) {}
             }
             .background(Color("White01"))
             .navigationBarColor(UIColor(named: "White01"), title: "소비 내역 추가하기")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -19,124 +19,26 @@ struct AddSpendingCategoryView: View {
     @State private var isFormValid = false
     let entryPoint: AddCategoryEntryPoint
     
+    private var categoryName: String {
+        get {
+            entryPoint == .create ? viewModel.categoryName : spendingCategoryViewModel.categoryName
+        }
+        set {
+            if entryPoint == .create {
+                viewModel.categoryName = String(newValue.prefix(maxCategoryNameCount))
+            } else {
+                spendingCategoryViewModel.categoryName = String(newValue.prefix(maxCategoryNameCount))
+            }
+        }
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
-            Spacer().frame(height: 14 * DynamicSizeFactor.factor())
-            ZStack {
-                switch entryPoint {
-                case .create:
-                    Image(viewModel.selectedCategoryIcon?.rawValue ?? CategoryIconName(baseName: .etc, state: .on).rawValue)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 60 * DynamicSizeFactor.factor(), height: 60 * DynamicSizeFactor.factor(), alignment: .leading)
-                case .modify:
-                    Image(spendingCategoryViewModel.selectedCategory!.icon.rawValue)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 60 * DynamicSizeFactor.factor(), height: 60 * DynamicSizeFactor.factor(), alignment: .leading)
-                }
-
-                Image("icon_navigationbar_write_gray_bg")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                    .background(Color("Gray04"))
-                    .clipShape(Circle())
-                    .offset(x: 20 * DynamicSizeFactor.factor(), y: 20 * DynamicSizeFactor.factor())
-            }
-            .onTapGesture {
-                viewModel.isSelectAddCategoryViewPresented = true
-            }
-
-            Spacer().frame(height: 20 * DynamicSizeFactor.factor())
-
-            HStack(spacing: 11 * DynamicSizeFactor.factor()) {
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color("Gray01"))
-                        .frame(height: 46 * DynamicSizeFactor.factor())
-
-                    if viewModel.categoryName.isEmpty && spendingCategoryViewModel.categoryName.isEmpty {
-                        switch entryPoint {
-                        case .create:
-                            Text("카테고리명을 입력하세요")
-                                .platformTextColor(color: Color("Gray03"))
-                                .padding(.leading, 13 * DynamicSizeFactor.factor())
-                                .font(.H4MediumFont())
-
-                        case .modify:
-                            Text("\(spendingCategoryViewModel.selectedCategory!.name)")
-                                .platformTextColor(color: Color("Gray03"))
-                                .padding(.leading, 13 * DynamicSizeFactor.factor())
-                                .font(.H4MediumFont())
-                        }
-                    }
-
-                    TextField("", text: entryPoint == .create ? $viewModel.categoryName : $spendingCategoryViewModel.categoryName)
-                        .padding(.leading, 13 * DynamicSizeFactor.factor())
-                        .font(.H4MediumFont())
-                        .platformTextColor(color: Color("Gray07"))
-                        .onChange(of: entryPoint == .create ? viewModel.categoryName : spendingCategoryViewModel.categoryName) { _ in
-                            if (entryPoint == .create ? viewModel.categoryName.count : spendingCategoryViewModel.categoryName.count) > maxCategoryNameCount {
-                                if entryPoint == .create {
-                                    viewModel.categoryName = String(viewModel.categoryName.prefix(maxCategoryNameCount))
-                                } else {
-                                    spendingCategoryViewModel.categoryName = String(spendingCategoryViewModel.categoryName.prefix(maxCategoryNameCount))
-                                }
-                            }
-                            if !(entryPoint == .create ? viewModel.categoryName.isEmpty : spendingCategoryViewModel.categoryName.isEmpty) {
-                                isFormValid = true
-                            } else {
-                                isFormValid = false
-                            }
-                        }
-                }
-            }
-            .padding(.horizontal, 20)
-
-            Spacer().frame(height: 4 * DynamicSizeFactor.factor())
-
-            HStack {
-                Spacer()
-                Text("\(entryPoint == .create ? viewModel.categoryName.count : spendingCategoryViewModel.categoryName.count)/\(maxCategoryNameCount)")
-                    .font(.B2MediumFont())
-                    .platformTextColor(color: Color("Gray03"))
-            }
-            .padding(.horizontal, 20)
-
+            topImageView()
+            categoryInputView()
+            characterCountView()
             Spacer()
-
-            CustomBottomButton(action: {
-                if !viewModel.categoryName.isEmpty || !spendingCategoryViewModel.categoryName.isEmpty {
-                    switch entryPoint {
-                    case .create:
-                        viewModel.addSpendingCustomCategoryApi { success in
-                            if success {
-                                Log.debug("카테고리 생성 완료")
-                                spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in
-                                    presentationMode.wrappedValue.dismiss()
-                                }
-                            } else {
-                                Log.debug("카테고리 생성 실패")
-                            }
-                        }
-                    case .modify: Log.debug("카테고리 수정 완료")
-                        spendingCategoryViewModel.selectedCategory?.name = spendingCategoryViewModel.categoryName
-                        Log.debug(spendingCategoryViewModel.selectedCategory?.name)
-//                        viewModel.modifySpendingCustomCategoryApi { success in
-//                            if success {
-//                                Log.debug("카테고리 수정 완료")
-                        ////                                spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in
-                        ////                                    presentationMode.wrappedValue.dismiss()
-                        ////                                }
-//                            } else {
-//                                Log.debug("카테고리 수정 실패")
-//                            }
-//                        }
-                    }
-                    presentationMode.wrappedValue.dismiss()
-                }
-            }, label: "추가하기", isFormValid: $isFormValid)
+            CustomBottomButton(action: addAction, label: "추가하기", isFormValid: $isFormValid)
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -165,6 +67,106 @@ struct AddSpendingCategoryView: View {
         }
         .bottomSheet(isPresented: $viewModel.isSelectAddCategoryViewPresented, maxHeight: 347 * DynamicSizeFactor.factor()) {
             SelectCategoryIconView(isPresented: $viewModel.isSelectAddCategoryViewPresented, viewModel: viewModel, spendingCategoryViewModel: spendingCategoryViewModel, entryPoint: entryPoint)
+        }
+    }
+
+    @ViewBuilder
+    private func topImageView() -> some View {
+        Spacer().frame(height: 14 * DynamicSizeFactor.factor())
+        ZStack {
+            Image(selectedCategoryIcon())
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 60 * DynamicSizeFactor.factor(), height: 60 * DynamicSizeFactor.factor(), alignment: .leading)
+            
+            Image("icon_navigationbar_write_gray_bg")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                .background(Color("Gray04"))
+                .clipShape(Circle())
+                .offset(x: 20 * DynamicSizeFactor.factor(), y: 20 * DynamicSizeFactor.factor())
+        }
+        .onTapGesture {
+            viewModel.isSelectAddCategoryViewPresented = true
+        }
+        Spacer().frame(height: 20 * DynamicSizeFactor.factor())
+    }
+    
+    private func selectedCategoryIcon() -> String {
+        switch entryPoint {
+        case .create:
+            return viewModel.selectedCategoryIcon?.rawValue ?? CategoryIconName(baseName: .etc, state: .on).rawValue
+        case .modify:
+            return spendingCategoryViewModel.selectedCategoryIcon!.rawValue
+        }
+    }
+
+    @ViewBuilder
+    private func categoryInputView() -> some View {
+        HStack(spacing: 11 * DynamicSizeFactor.factor()) {
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color("Gray01"))
+                    .frame(height: 46 * DynamicSizeFactor.factor())
+                
+                Group {
+                    if viewModel.categoryName.isEmpty && spendingCategoryViewModel.categoryName.isEmpty {
+                        switch entryPoint {
+                        case .create:
+                            Text("카테고리명을 입력하세요")
+                            
+                        case .modify:
+                            Text("\(spendingCategoryViewModel.selectedCategory!.name)")
+                        }
+                    }
+                }.platformTextColor(color: Color("Gray03"))
+                    .padding(.leading, 13 * DynamicSizeFactor.factor())
+                    .font(.H4MediumFont())
+                
+                TextField("", text: entryPoint == .create ? $viewModel.categoryName : $spendingCategoryViewModel.categoryName)
+                    .padding(.leading, 13 * DynamicSizeFactor.factor())
+                    .font(.H4MediumFont())
+                    .platformTextColor(color: Color("Gray07"))
+                    .onChange(of: categoryName) { _ in
+                        isFormValid = !categoryName.isEmpty
+                    }
+            }
+        }
+        .padding(.horizontal, 20)
+    }
+    
+    @ViewBuilder
+    private func characterCountView() -> some View {
+        HStack {
+            Spacer()
+            Text("\(categoryName.count)/\(maxCategoryNameCount)")
+                .font(.B2MediumFont())
+                .platformTextColor(color: Color("Gray03"))
+        }
+        .padding(.horizontal, 20)
+        Spacer().frame(height: 4 * DynamicSizeFactor.factor())
+    }
+
+    private func addAction() {
+        if !categoryName.isEmpty {
+            switch entryPoint {
+            case .create:
+                viewModel.addSpendingCustomCategoryApi { success in
+                    if success {
+                        Log.debug("카테고리 생성 완료")
+                        spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                    } else {
+                        Log.debug("카테고리 생성 실패")
+                    }
+                }
+            case .modify:
+                spendingCategoryViewModel.selectedCategory!.name = categoryName
+                spendingCategoryViewModel.selectedCategory!.icon = spendingCategoryViewModel.selectedCategoryIcon ?? spendingCategoryViewModel.selectedCategory!.icon
+                presentationMode.wrappedValue.dismiss()
+            }
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -1,13 +1,6 @@
 
 import SwiftUI
 
-// MARK: - AddCategoryEntryPoint
-
-enum AddCategoryEntryPoint {
-    case create
-    case modify
-}
-
 // MARK: - AddSpendingCategoryView
 
 struct AddSpendingCategoryView: View {
@@ -17,7 +10,7 @@ struct AddSpendingCategoryView: View {
     
     @State private var maxCategoryNameCount = 8
     @State private var isFormValid = false
-    let entryPoint: AddCategoryEntryPoint
+    let entryPoint: CustomCategoryEntryPoint
     
     private var categoryName: String {
         get {
@@ -165,7 +158,21 @@ struct AddSpendingCategoryView: View {
             case .modify:
                 spendingCategoryViewModel.selectedCategory!.name = categoryName
                 spendingCategoryViewModel.selectedCategory!.icon = spendingCategoryViewModel.selectedCategoryIcon ?? spendingCategoryViewModel.selectedCategory!.icon
-                presentationMode.wrappedValue.dismiss()
+                spendingCategoryViewModel.modifyCategoryApi {
+                    success in
+                    if success {
+                        Log.debug("카테고리 수정 완료")
+                        spendingCategoryViewModel.initPage()
+                        
+                        //카테고리 수정 후 데이터 카테고리 관련 데이터 다시 조회
+                        spendingCategoryViewModel.getCategorySpendingHistoryApi { _ in }
+                        spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in }
+                        presentationMode.wrappedValue.dismiss()
+                            
+                    } else {
+                        Log.debug("카테고리 생성 실패")
+                    }
+                }
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -15,7 +15,8 @@ struct AddSpendingCategoryView: View {
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
 
-    @State var maxCategoryNameCount = "8"
+    @State private var maxCategoryNameCount = 8
+    @State private var isFormValid = false
     let entryPoint: AddCategoryEntryPoint
 
     var body: some View {
@@ -29,7 +30,7 @@ struct AddSpendingCategoryView: View {
                         .aspectRatio(contentMode: .fill)
                         .frame(width: 60 * DynamicSizeFactor.factor(), height: 60 * DynamicSizeFactor.factor(), alignment: .leading)
                 case .modify:
-                    Image(spendingCategoryViewModel.selectedCategory?.icon.rawValue ?? CategoryIconName(baseName: .etc, state: .on).rawValue)
+                    Image(spendingCategoryViewModel.selectedCategory!.icon.rawValue)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: 60 * DynamicSizeFactor.factor(), height: 60 * DynamicSizeFactor.factor(), alignment: .leading)
@@ -75,26 +76,18 @@ struct AddSpendingCategoryView: View {
                         .padding(.leading, 13 * DynamicSizeFactor.factor())
                         .font(.H4MediumFont())
                         .platformTextColor(color: Color("Gray07"))
-                        .onChange(of: viewModel.categoryName) { _ in
-//                            if viewModel.categoryName.count > 8 {
-//                                viewModel.categoryName = String(viewModel.categoryName.prefix(8))
-//                            }
-//                            if !viewModel.categoryName.isEmpty {
-//                                viewModel.isAddCategoryFormValid = true
-//                            } else {
-//                                viewModel.isAddCategoryFormValid = false
-//                            }
-                            if (entryPoint == .create ? viewModel.categoryName.count : spendingCategoryViewModel.categoryName.count) > 8 {
+                        .onChange(of: entryPoint == .create ? viewModel.categoryName : spendingCategoryViewModel.categoryName) { _ in
+                            if (entryPoint == .create ? viewModel.categoryName.count : spendingCategoryViewModel.categoryName.count) > maxCategoryNameCount {
                                 if entryPoint == .create {
-                                    viewModel.categoryName = String(viewModel.categoryName.prefix(8))
+                                    viewModel.categoryName = String(viewModel.categoryName.prefix(maxCategoryNameCount))
                                 } else {
-                                    spendingCategoryViewModel.categoryName = String(spendingCategoryViewModel.categoryName.prefix(8))
+                                    spendingCategoryViewModel.categoryName = String(spendingCategoryViewModel.categoryName.prefix(maxCategoryNameCount))
                                 }
                             }
                             if !(entryPoint == .create ? viewModel.categoryName.isEmpty : spendingCategoryViewModel.categoryName.isEmpty) {
-                                viewModel.isAddCategoryFormValid = true
+                                isFormValid = true
                             } else {
-                                viewModel.isAddCategoryFormValid = false
+                                isFormValid = false
                             }
                         }
                 }
@@ -127,7 +120,9 @@ struct AddSpendingCategoryView: View {
                                 Log.debug("카테고리 생성 실패")
                             }
                         }
-                    case .modify: break
+                    case .modify: Log.debug("카테고리 수정 완료")
+                        spendingCategoryViewModel.selectedCategory?.name = spendingCategoryViewModel.categoryName
+                        Log.debug(spendingCategoryViewModel.selectedCategory?.name)
 //                        viewModel.modifySpendingCustomCategoryApi { success in
 //                            if success {
 //                                Log.debug("카테고리 수정 완료")
@@ -141,7 +136,7 @@ struct AddSpendingCategoryView: View {
                     }
                     presentationMode.wrappedValue.dismiss()
                 }
-            }, label: "추가하기", isFormValid: $viewModel.isAddCategoryFormValid)
+            }, label: "추가하기", isFormValid: $isFormValid)
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -169,7 +164,7 @@ struct AddSpendingCategoryView: View {
             }
         }
         .bottomSheet(isPresented: $viewModel.isSelectAddCategoryViewPresented, maxHeight: 347 * DynamicSizeFactor.factor()) {
-            SelectCategoryIconView(isPresented: $viewModel.isSelectAddCategoryViewPresented, viewModel: viewModel)
+            SelectCategoryIconView(isPresented: $viewModel.isSelectAddCategoryViewPresented, viewModel: viewModel, spendingCategoryViewModel: spendingCategoryViewModel, entryPoint: entryPoint)
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -31,7 +31,7 @@ struct AddSpendingCategoryView: View {
             categoryInputView()
             characterCountView()
             Spacer()
-            CustomBottomButton(action: addAction, label: "추가하기", isFormValid: $isFormValid)
+            CustomBottomButton(action: addAction, label: entryPoint == .create ? "추가하기" : "확인", isFormValid: $isFormValid)
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -164,7 +164,7 @@ struct AddSpendingCategoryView: View {
                         Log.debug("카테고리 수정 완료")
                         spendingCategoryViewModel.initPage()
                         
-                        // 카테고리 수정 후 데이터 카테고리 관련 데이터 다시 조회
+                        // 카테고리 수정 후 카테고리 관련 데이터 다시 조회
                         spendingCategoryViewModel.getCategorySpendingHistoryApi { _ in }
                         spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in }
                         presentationMode.wrappedValue.dismiss()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -14,11 +14,11 @@ struct AddSpendingCategoryView: View {
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
-
+    
     @State private var maxCategoryNameCount = 8
     @State private var isFormValid = false
     let entryPoint: AddCategoryEntryPoint
-
+    
     var body: some View {
         VStack(spacing: 0) {
             Spacer().frame(height: 14 * DynamicSizeFactor.factor())
@@ -159,7 +159,7 @@ struct AddSpendingCategoryView: View {
                     .padding(.leading, 5)
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
-
+                    
                 }.offset(x: -10)
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -27,7 +27,7 @@ struct AddSpendingCategoryView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            topImageView()
+            topCategoryView()
             categoryInputView()
             characterCountView()
             Spacer()
@@ -64,7 +64,7 @@ struct AddSpendingCategoryView: View {
     }
 
     @ViewBuilder
-    private func topImageView() -> some View {
+    private func topCategoryView() -> some View {
         Spacer().frame(height: 14 * DynamicSizeFactor.factor())
         ZStack {
             Image(selectedCategoryIcon())
@@ -164,13 +164,13 @@ struct AddSpendingCategoryView: View {
                         Log.debug("카테고리 수정 완료")
                         spendingCategoryViewModel.initPage()
                         
-                        //카테고리 수정 후 데이터 카테고리 관련 데이터 다시 조회
+                        // 카테고리 수정 후 데이터 카테고리 관련 데이터 다시 조회
                         spendingCategoryViewModel.getCategorySpendingHistoryApi { _ in }
                         spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in }
                         presentationMode.wrappedValue.dismiss()
                             
                     } else {
-                        Log.debug("카테고리 생성 실패")
+                        Log.debug("카테고리 수정 실패")
                     }
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -65,7 +65,7 @@ struct SelectCategoryIconView: View {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
                     } else {
-                        spendingCategoryViewModel.selectedCategory?.icon = mapToOnIcon(selectedCategoryIcon)
+                        spendingCategoryViewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
                     }
                     isPresented = false
                     Log.debug(selectedCategory.rawValue)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -64,7 +64,7 @@ struct SelectCategoryIconView: View {
                     if entryPoint == .create {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
-                    } else {
+                    } else {//수정인 경우
                         spendingCategoryViewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         spendingCategoryViewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
                     }
@@ -77,12 +77,14 @@ struct SelectCategoryIconView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .edgesIgnoringSafeArea(.all)
         .onAppear {
+            //mint 아이콘으로 매칭
             if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
                 selectedCategoryIcon = mapToOnMintIcon(icon)
             }
         }
     }
 
+    //on 아이콘으로 매칭
     private func mapToOnIcon(_ icon: CategoryIconName) -> CategoryIconName {
         if icon.state == .onMint {
             return CategoryIconName(baseName: icon.baseName, state: .on)
@@ -90,8 +92,9 @@ struct SelectCategoryIconView: View {
         return icon
     }
 
+    //onMint 아이콘으로 매칭
     private func mapToOnMintIcon(_ icon: CategoryIconName) -> CategoryIconName {
-        if icon.state == .on || icon.state == .onWhite {
+        if icon.state == .on {
             return CategoryIconName(baseName: icon.baseName, state: .onMint)
         }
         return icon

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -6,7 +6,9 @@ import SwiftUI
 struct SelectCategoryIconView: View {
     @Binding var isPresented: Bool
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
-    @State var selectedCategoryIcon: CategoryIconName = CategoryIconName(baseName: CategoryBaseName.etc, state: .onMint)
+    @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
+    @State var selectedCategoryIcon: CategoryIconName = CategoryIconName(baseName: .etc, state: .on)
+    let entryPoint: AddCategoryEntryPoint
 
     let columns = [
         GridItem(.flexible(), spacing: 32),
@@ -59,9 +61,15 @@ struct SelectCategoryIconView: View {
 
             CustomBottomButton(action: {
                 if let selectedCategory = SpendingCategoryIconList.fromIcon(selectedCategoryIcon) {
-                    viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                    viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
-                    Log.debug(viewModel.selectedCategoryIconTitle)
+                    if entryPoint == .create {
+                        viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
+                        viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
+                        Log.debug(viewModel.selectedCategoryIconTitle)
+                    } else {
+                        spendingCategoryViewModel.selectedCategory?.icon = mapToOnIcon(selectedCategoryIcon)
+                        Log.debug(selectedCategory.rawValue)
+                        Log.debug(spendingCategoryViewModel.selectedCategory?.icon)
+                    }
                     isPresented = false
                 }
             }, label: "확인", isFormValid: .constant(true))
@@ -70,8 +78,9 @@ struct SelectCategoryIconView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .edgesIgnoringSafeArea(.all)
         .onAppear {
-            if let icon = viewModel.selectedCategoryIcon {
+            if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
                 selectedCategoryIcon = mapToOnMintIcon(icon)
+                Log.debug(selectedCategoryIcon)
             }
         }
     }
@@ -84,7 +93,7 @@ struct SelectCategoryIconView: View {
     }
 
     private func mapToOnMintIcon(_ icon: CategoryIconName) -> CategoryIconName {
-        if icon.state == .on {
+        if icon.state == .on || icon.state == .onWhite {
             return CategoryIconName(baseName: icon.baseName, state: .onMint)
         }
         return icon

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -64,13 +64,11 @@ struct SelectCategoryIconView: View {
                     if entryPoint == .create {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
-                        Log.debug(viewModel.selectedCategoryIconTitle)
                     } else {
                         spendingCategoryViewModel.selectedCategory?.icon = mapToOnIcon(selectedCategoryIcon)
-                        Log.debug(selectedCategory.rawValue)
-                        Log.debug(spendingCategoryViewModel.selectedCategory?.icon)
                     }
                     isPresented = false
+                    Log.debug(selectedCategory.rawValue)
                 }
             }, label: "확인", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
@@ -80,7 +78,6 @@ struct SelectCategoryIconView: View {
         .onAppear {
             if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
                 selectedCategoryIcon = mapToOnMintIcon(icon)
-                Log.debug(selectedCategoryIcon)
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -64,7 +64,7 @@ struct SelectCategoryIconView: View {
                     if entryPoint == .create {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
-                    } else {//수정인 경우
+                    } else { // 수정인 경우
                         spendingCategoryViewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         spendingCategoryViewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
                     }
@@ -77,14 +77,14 @@ struct SelectCategoryIconView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .edgesIgnoringSafeArea(.all)
         .onAppear {
-            //mint 아이콘으로 매칭
+            // onMint 아이콘으로 매칭
             if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
                 selectedCategoryIcon = mapToOnMintIcon(icon)
             }
         }
     }
 
-    //on 아이콘으로 매칭
+    /// onMint -> on 아이콘으로 매칭
     private func mapToOnIcon(_ icon: CategoryIconName) -> CategoryIconName {
         if icon.state == .onMint {
             return CategoryIconName(baseName: icon.baseName, state: .on)
@@ -92,7 +92,7 @@ struct SelectCategoryIconView: View {
         return icon
     }
 
-    //onMint 아이콘으로 매칭
+    /// on -> onMint 아이콘으로 매칭
     private func mapToOnMintIcon(_ icon: CategoryIconName) -> CategoryIconName {
         if icon.state == .on {
             return CategoryIconName(baseName: icon.baseName, state: .onMint)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -63,10 +63,10 @@ struct SelectCategoryIconView: View {
                 if let selectedCategory = SpendingCategoryIconList.fromIcon(selectedCategoryIcon) {
                     if entryPoint == .create {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                        viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
+                        viewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on)//onMint -> on
                     } else { // 수정인 경우
                         spendingCategoryViewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                        spendingCategoryViewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
+                        spendingCategoryViewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on)//onMint -> on
                     }
                     isPresented = false
                     Log.debug(selectedCategory.rawValue)
@@ -79,24 +79,8 @@ struct SelectCategoryIconView: View {
         .onAppear {
             // onMint 아이콘으로 매칭
             if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
-                selectedCategoryIcon = mapToOnMintIcon(icon)
+                selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(icon, outputState: .onMint)//on -> onMint
             }
         }
-    }
-
-    /// onMint -> on 아이콘으로 매칭
-    private func mapToOnIcon(_ icon: CategoryIconName) -> CategoryIconName {
-        if icon.state == .onMint {
-            return CategoryIconName(baseName: icon.baseName, state: .on)
-        }
-        return icon
-    }
-
-    /// on -> onMint 아이콘으로 매칭
-    private func mapToOnMintIcon(_ icon: CategoryIconName) -> CategoryIconName {
-        if icon.state == .on {
-            return CategoryIconName(baseName: icon.baseName, state: .onMint)
-        }
-        return icon
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -8,7 +8,7 @@ struct SelectCategoryIconView: View {
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
     @State var selectedCategoryIcon: CategoryIconName = CategoryIconName(baseName: .etc, state: .on)
-    let entryPoint: AddCategoryEntryPoint
+    let entryPoint: CustomCategoryEntryPoint
 
     let columns = [
         GridItem(.flexible(), spacing: 32),
@@ -65,6 +65,7 @@ struct SelectCategoryIconView: View {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         viewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
                     } else {
+                        spendingCategoryViewModel.selectedCategoryIconTitle = selectedCategory.rawValue
                         spendingCategoryViewModel.selectedCategoryIcon = mapToOnIcon(selectedCategoryIcon)
                     }
                     isPresented = false

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SpendingCategoryListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SpendingCategoryListView.swift
@@ -44,7 +44,6 @@ struct SpendingCategoryListView: View {
                                 viewModel.selectedCategoryIcon = CategoryIconName(baseName: CategoryBaseName.etc, state: .on) // icon 초기화
                                 viewModel.categoryName = "" // name 초기화
                                 viewModel.navigateToAddCategory = true
-                                viewModel.isAddCategoryFormValid = false
                                 isPresented = false
                             } else {
                                 viewModel.selectedCategory = category

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -74,6 +74,8 @@ struct CategoryDetailsView: View {
                                 showingPopUp = true
                             } else {
                                 isNavigateToEditCategoryView = true
+                                viewModel.categoryName = ""
+                                viewModel.selectedCategoryIcon = viewModel.selectedCategory?.icon
                             }
                             Log.debug("Selected item: \(item)")
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -10,6 +10,7 @@ struct CategoryDetailsView: View {
     @State private var selectedMenu: String? = nil // 선택한 메뉴
     @State private var listArray: [String] = ["수정하기", "카테고리 삭제"]
     @State private var showingPopUp = false
+    @State private var isNavigateToEditCategoryView = false
 
     var body: some View {
         ZStack {
@@ -71,6 +72,8 @@ struct CategoryDetailsView: View {
                         onItemSelected: { item in
                             if item == "카테고리 삭제" {
                                 showingPopUp = true
+                            } else {
+                                isNavigateToEditCategoryView = true
                             }
                             Log.debug("Selected item: \(item)")
                         }
@@ -116,5 +119,6 @@ struct CategoryDetailsView: View {
                 }
             }
         }
+        NavigationLink(destination: AddSpendingCategoryView(viewModel: AddSpendingHistoryViewModel(), spendingCategoryViewModel: viewModel, entryPoint: .modify), isActive: $isNavigateToEditCategoryView) {}
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -18,7 +18,7 @@ struct CategoryDetailsView: View {
                 VStack {
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
 
-                    Image("\(viewModel.selectedCategory!.icon.rawValue.split(separator: "_").dropLast().joined(separator: "_"))")
+                    Image("\(viewModel.selectedCategory!.icon.rawValue)")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 60 * DynamicSizeFactor.factor(), height: 60 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -94,7 +94,7 @@ struct SpendingCategoryGridView: View {
     private func categoryVGridView(for category: SpendingCategoryData) -> some View {
         Button(action: {
             spendingCategoryViewModel.selectedCategory = category
-            spendingCategoryViewModel.selectedCategory?.icon = mapToOnIcon(category.icon)
+            spendingCategoryViewModel.selectedCategory?.icon = MapCategoryIconUtil.mapToCategoryIcon(category.icon, outputState: .on)//onWhite -> on
             spendingCategoryViewModel.initPage() // 데이터 초기화
             spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
             spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회
@@ -122,13 +122,6 @@ struct SpendingCategoryGridView: View {
             .cornerRadius(8)
         }
         .buttonStyle(PlainButtonStyle())
-    }
-
-    private func mapToOnIcon(_ icon: CategoryIconName) -> CategoryIconName {
-        if icon.state == .onWhite {
-            return CategoryIconName(baseName: icon.baseName, state: .on)
-        }
-        return icon
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -94,6 +94,7 @@ struct SpendingCategoryGridView: View {
     private func categoryVGridView(for category: SpendingCategoryData) -> some View {
         Button(action: {
             spendingCategoryViewModel.selectedCategory = category
+
             spendingCategoryViewModel.initPage() // 데이터 초기화
             spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
             spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // MARK: - SpendingCategoryGridView
 
 struct SpendingCategoryGridView: View {
-    @ObservedObject var SpendingCategoryViewModel: SpendingCategoryViewModel
+    @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
     @ObservedObject var addSpendingHistoryViewModel: AddSpendingHistoryViewModel // 카테고리 생성 연동 처리
     @Environment(\.presentationMode) var presentationMode
     
@@ -19,7 +19,7 @@ struct SpendingCategoryGridView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     // 시스템 카테고리
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 8 * DynamicSizeFactor.factor()) {
-                        ForEach(SpendingCategoryViewModel.systemCategories) { category in
+                        ForEach(spendingCategoryViewModel.systemCategories) { category in
                             categoryVGridView(for: category)
                         }
                     }
@@ -36,7 +36,7 @@ struct SpendingCategoryGridView: View {
                     
                     // 사용자 정의 카테고리
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 8 * DynamicSizeFactor.factor()) {
-                        ForEach(SpendingCategoryViewModel.customCategories) { category in
+                        ForEach(spendingCategoryViewModel.customCategories) { category in
                             categoryVGridView(for: category)
                         }
                     }
@@ -86,20 +86,20 @@ struct SpendingCategoryGridView: View {
             }
         }
         
-        NavigationLink(destination: CategoryDetailsView(viewModel: SpendingCategoryViewModel), isActive: $navigateToCategoryDetails) {}
+        NavigationLink(destination: CategoryDetailsView(viewModel: spendingCategoryViewModel), isActive: $navigateToCategoryDetails) {}
 
-        NavigationLink(destination: AddSpendingCategoryView(viewModel: addSpendingHistoryViewModel, spendingCategoryViewModel: SpendingCategoryViewModel), isActive: $navigateToAddCategoryView) {}
+        NavigationLink(destination: AddSpendingCategoryView(viewModel: addSpendingHistoryViewModel, spendingCategoryViewModel: spendingCategoryViewModel, entryPoint: .create), isActive: $navigateToAddCategoryView) {}
     }
     
     private func categoryVGridView(for category: SpendingCategoryData) -> some View {
         Button(action: {
-            SpendingCategoryViewModel.selectedCategory = category
-            SpendingCategoryViewModel.initPage() // 데이터 초기화
-            SpendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
-            SpendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회
+            spendingCategoryViewModel.selectedCategory = category
+            spendingCategoryViewModel.initPage() // 데이터 초기화
+            spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
+            spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회
                 if success {
                     navigateToCategoryDetails = true
-                    Log.debug(SpendingCategoryViewModel.dailyDetailSpendings)
+                    Log.debug(spendingCategoryViewModel.dailyDetailSpendings)
                 }
             }
         }) {
@@ -125,5 +125,5 @@ struct SpendingCategoryGridView: View {
 }
 
 #Preview {
-    SpendingCategoryGridView(SpendingCategoryViewModel: SpendingCategoryViewModel(), addSpendingHistoryViewModel: AddSpendingHistoryViewModel())
+    SpendingCategoryGridView(spendingCategoryViewModel: SpendingCategoryViewModel(), addSpendingHistoryViewModel: AddSpendingHistoryViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -94,7 +94,7 @@ struct SpendingCategoryGridView: View {
     private func categoryVGridView(for category: SpendingCategoryData) -> some View {
         Button(action: {
             spendingCategoryViewModel.selectedCategory = category
-
+            spendingCategoryViewModel.selectedCategory?.icon = mapToOnIcon(category.icon)
             spendingCategoryViewModel.initPage() // 데이터 초기화
             spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
             spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회
@@ -122,6 +122,13 @@ struct SpendingCategoryGridView: View {
             .cornerRadius(8)
         }
         .buttonStyle(PlainButtonStyle())
+    }
+
+    private func mapToOnIcon(_ icon: CategoryIconName) -> CategoryIconName {
+        if icon.state == .onWhite {
+            return CategoryIconName(baseName: icon.baseName, state: .on)
+        }
+        return icon
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -134,7 +134,7 @@ struct MySpendingListView: View {
             }
         }
 
-        NavigationLink(destination: SpendingCategoryGridView(SpendingCategoryViewModel: spendingCategoryViewModel, addSpendingHistoryViewModel: AddSpendingHistoryViewModel()), isActive: $navigateToCategoryGridView) {}
+        NavigationLink(destination: SpendingCategoryGridView(spendingCategoryViewModel: spendingCategoryViewModel, addSpendingHistoryViewModel: AddSpendingHistoryViewModel()), isActive: $navigateToCategoryGridView) {}
     }
 
     private func headerView(for date: String) -> some View {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -53,7 +53,7 @@ struct SpendingCheckBoxView: View {
                     .cornerRadius(15)
 
                 let progressWidth: CGFloat = {
-                    if targetAmount <= 0 {
+                    if targetAmount == 0 {
                         return UIScreen.main.bounds.width - 76
                     }
                     let ratio = CGFloat(totalSpending) / CGFloat(targetAmount)

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/AddSpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/AddSpendingHistoryViewModel.swift
@@ -11,7 +11,7 @@ class AddSpendingHistoryViewModel: ObservableObject {
     @Published var selectedCategoryIconTitle: String = ""
     @Published var selectedCategoryIcon: CategoryIconName? = nil
     @Published var categoryName: String = ""
-    @Published var isAddCategoryFormValid = false
+
     @Published var navigateToAddCategory = false // 추가하기 버튼 누른 경우
     @Published var isSelectAddCategoryViewPresented: Bool = false
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 class SpendingCategoryViewModel: ObservableObject {
     /// 카테고리 선택
     @Published var selectedCategory: SpendingCategoryData? = nil
+    @Published var categoryName = ""
     
     /// 총 카테고리 리스트
     @Published var spendingCategories: [SpendingCategoryData] = []

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
@@ -5,6 +5,7 @@ class SpendingCategoryViewModel: ObservableObject {
     /// 카테고리 선택
     @Published var selectedCategory: SpendingCategoryData? = nil
     @Published var categoryName = ""
+    @Published var selectedCategoryIcon: CategoryIconName? = nil
     
     /// 총 카테고리 리스트
     @Published var spendingCategories: [SpendingCategoryData] = []

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
@@ -6,6 +6,7 @@ class SpendingCategoryViewModel: ObservableObject {
     @Published var selectedCategory: SpendingCategoryData? = nil
     @Published var categoryName = ""
     @Published var selectedCategoryIcon: CategoryIconName? = nil
+    @Published var selectedCategoryIconTitle: String = ""
     
     /// 총 카테고리 리스트
     @Published var spendingCategories: [SpendingCategoryData] = []
@@ -21,6 +22,7 @@ class SpendingCategoryViewModel: ObservableObject {
     private var currentPageNumber: Int = 0
     private var hasNext: Bool = true
     
+    /// 카테고리 조회 api 호출
     func getSpendingCustomCategoryListApi(completion: @escaping (Bool) -> Void) {
         SpendingCategoryAlamofire.shared.getSpendingCustomCategoryList { result in
             switch result {
@@ -55,6 +57,7 @@ class SpendingCategoryViewModel: ObservableObject {
         }
     }
     
+    /// 카테고리 지출내역 개수 조회 api 호출
     func getCategorySpendingCountApi(completion: @escaping (Bool) -> Void) {
         let getCategorySpendingCountRequestDto = GetCategorySpendingCountRequestDto(type: selectedCategory?.isCustom ?? false ? "CUSTOM" : "DEFAULT")
         
@@ -89,6 +92,7 @@ class SpendingCategoryViewModel: ObservableObject {
         }
     }
     
+    /// 카테고리에 따른 지출내역 리스트 조회 api 호출
     func getCategorySpendingHistoryApi(completion: @escaping (Bool) -> Void) {
         guard hasNext else {
             return
@@ -135,6 +139,7 @@ class SpendingCategoryViewModel: ObservableObject {
         hasNext = true
     }
     
+    /// 무한 스크롤 지출 데이터 merge
     private func mergeNewSpendings(newSpendings: [Spending]) {
         var allNewIndividualSpendings: [IndividualSpending] = []
 
@@ -151,10 +156,35 @@ class SpendingCategoryViewModel: ObservableObject {
         dailyDetailSpendings.sort { $0.spendAt > $1.spendAt }
     }
     
+    /// white 배경색 아이콘 return
     func convertToSpendingCategoryData(from spendingCategory: SpendingCategory) -> SpendingCategoryData? {
         guard let iconList = SpendingCategoryIconList(rawValue: spendingCategory.icon) else {
             return nil
         }
         return SpendingCategoryData(id: spendingCategory.id, isCustom: spendingCategory.isCustom, name: spendingCategory.name, icon: iconList.detailsWhite.icon)
+    }
+    
+    /// 카테고리 수정 api 호출
+    func modifyCategoryApi(completion: @escaping (Bool) -> Void) {
+        let modifyCategoryRequestDto = AddSpendingCustomCategoryRequestDto(name: categoryName, icon: selectedCategoryIconTitle)
+        
+        SpendingCategoryAlamofire.shared.modifyCategory(selectedCategory!.id, modifyCategoryRequestDto) { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    if let jsonString = String(data: responseData, encoding: .utf8) {
+                        Log.debug("카테고리 수정 완료 \(jsonString)")
+                    }
+                    completion(true)
+                }
+            case let .failure(error):
+                if let StatusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(false)
+            }
+        }
     }
 }


### PR DESCRIPTION
## 작업 이유
- 카테고리 수정 API 연동
- 카테고리 생성 뷰 리팩토링

<br/>

## 작업 사항

### 1️⃣ 카테고리 수정 API 연동

- 구현 위치: SpendingCategoryAlamofire - SpendingCategoryRouter - .modifyCategory
- PATCH /v2/spending-categories/{category_id}
- query: name = {name}, icon = {icon}

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-07-22 at 21 08 09](https://github.com/user-attachments/assets/3c5f1978-5692-4a97-941c-95cc2c6b4d63)

create는 새로 추가하는 경우이기 때문에 기본적으로 etc 아이콘과 "카테고리명을 입력하세요" placeholder를 보여주면 된다.
하지만 modify는 선택한 카테고리의 아이콘과 이름을 가져와서 보여줘야하기 때문에 분기처리를 할 수 밖에 없었다.

그래서 AddSpendingCategoryView에서 CustomCategoryEntryPoint를 사용하여 카테고리를 만드는 경우와 수정하는 경우를 나누어서 구현하였다.

```swift
enum CustomCategoryEntryPoint {
    case create
    case modify
}

```

AddSpendingCategoryView와 SelectCategoryIconView에서  create인 경우에는 AddSpendingHistoryViewModel의 카테고리 추가 로직을 사용, modify인 경우에는 SpendingCategoryViewModel의 카테고리 수정 로직을 사용하도록 하였다.

카테고리 수정에 성공하면 카테고리 조회에 관련된 api를 다시 호출해서 수정된 카테고리를 조회할 수 있도록 하였다.

```swift
spendingCategoryViewModel.modifyCategoryApi {
    success in
    if success {
        Log.debug("카테고리 수정 완료")
        spendingCategoryViewModel.initPage()
        
        // 카테고리 수정 후 카테고리 관련 데이터 다시 조회
        spendingCategoryViewModel.getCategorySpendingHistoryApi { _ in }//카테고리에 따른 지출 내역 조회
        spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in }//카테고리 리스트 조회
        presentationMode.wrappedValue.dismiss()
            
    } else {
        Log.debug("카테고리 수정 실패")
    }
}
```

<br/>

### 2️⃣ 카테고리 생성 뷰 리팩토링

AddSpendingCategoryView에서 CustomCategoryEntryPoint로 예외처리를 하다보니 코드가 길어져서 가독성이 좋도록 로직과 뷰들을 분리하여 구현하였다.

아래와 같이 뷰들을 나누어서 각 뷰의 로직을 확인하기 쉽도록 하였다.
```swift
VStack(spacing: 0) {
    topCategoryView()
    categoryInputView()
    characterCountView()
    Spacer()
    CustomBottomButton(action: addAction, label: entryPoint == .create ? "추가하기" : "확인", isFormValid: $isFormValid)
        .padding(.bottom, 34 * DynamicSizeFactor.factor())
}
```

<img src  = "https://github.com/user-attachments/assets/171f8c9b-1f7a-4677-8130-44ff6a12500d" width = "300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

카테고리 수정 구현했습니다~~
혹시 읽어보시고 이해 안 되는 부분 말씀해주세요~


<br/>

## 발견한 이슈
없음