### PR TITLE
📮📍 비밀번호 재설정 api 연동 + 비밀번호 UI 간격 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -258,6 +258,8 @@
 		D89FB7822BD97A2F0019DE3C /* FindUserNameResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */; };
 		D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */; };
 		D8B0A9282C4EA7FC00716ECB /* ValidatePwRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */; };
+		D8B0A92A2C4EB8E500716ECB /* ResetMyPwRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A9292C4EB8E500716ECB /* ResetMyPwRequestDto.swift */; };
+		D8B0A92C2C4EBDDC00716ECB /* PasswordChangeTypeNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A92B2C4EBDDC00716ECB /* PasswordChangeTypeNavigation.swift */; };
 		D8BDAF712C4928D10095D8E7 /* ProfileModifyPwView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BDAF702C4928D10095D8E7 /* ProfileModifyPwView.swift */; };
 		D8C9AC402BF661A2006D1FCD /* InquiryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */; };
 		D8C9AC422BF66BB3006D1FCD /* InquiryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */; };
@@ -523,6 +525,8 @@
 		D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameRequestDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Request/FindUserNameRequestDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7882BDA925F0019DE3C /* FindUserNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindUserNameViewModel.swift; sourceTree = "<group>"; };
 		D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatePwRequestDto.swift; sourceTree = "<group>"; };
+		D8B0A9292C4EB8E500716ECB /* ResetMyPwRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetMyPwRequestDto.swift; sourceTree = "<group>"; };
+		D8B0A92B2C4EBDDC00716ECB /* PasswordChangeTypeNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordChangeTypeNavigation.swift; sourceTree = "<group>"; };
 		D8BDAF702C4928D10095D8E7 /* ProfileModifyPwView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModifyPwView.swift; sourceTree = "<group>"; };
 		D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryView.swift; sourceTree = "<group>"; };
 		D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryListView.swift; sourceTree = "<group>"; };
@@ -1112,6 +1116,7 @@
 			children = (
 				4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */,
 				D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */,
+				D8B0A9292C4EB8E500716ECB /* ResetMyPwRequestDto.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1130,6 +1135,7 @@
 			isa = PBXGroup;
 			children = (
 				4A6C79DA2C46D067009463E4 /* ProfileActiveNavigation.swift */,
+				D8B0A92B2C4EBDDC00716ECB /* PasswordChangeTypeNavigation.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -1910,6 +1916,7 @@
 				D8E24D8D2BFC7FE4006E8046 /* InquiryViewModel.swift in Sources */,
 				4A762AEF2B99A16B001C1188 /* MainView.swift in Sources */,
 				D80E6A152BB2E0C4009F2DFE /* (null) in Sources */,
+				D8B0A92C2C4EBDDC00716ECB /* PasswordChangeTypeNavigation.swift in Sources */,
 				4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */,
 				4A3701CD2C08F7F600F0AEBA /* SpendingAlamofire.swift in Sources */,
 				4AE8F3A82C32AB970014F0D4 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */,
@@ -2092,6 +2099,7 @@
 				4AC3203F2C11D5AC00DDB4B6 /* AddSpendingCategoryView.swift in Sources */,
 				4A0BC6AD2BF5FA130036D900 /* NumberFormatterUtil.swift in Sources */,
 				4A058F012BD046C1004B6F89 /* OAuthLoginViewModel.swift in Sources */,
+				D8B0A92A2C4EB8E500716ECB /* ResetMyPwRequestDto.swift in Sources */,
 				4ADBFAF52BE2C83600C3ECE4 /* UserAccountViewModel.swift in Sources */,
 				4AC3204C2C11D5AC00DDB4B6 /* ChangeMonthContentView.swift in Sources */,
 				4AD70E1B2BE0109D0058A52A /* WelcomeView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		D88832A02BBC615100F49B27 /* ErrorCodeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D888329F2BBC615100F49B27 /* ErrorCodeContentView.swift */; };
 		D89FB7822BD97A2F0019DE3C /* FindUserNameResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */; };
 		D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */; };
+		D8B0A9282C4EA7FC00716ECB /* ValidatePwRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */; };
 		D8BDAF712C4928D10095D8E7 /* ProfileModifyPwView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BDAF702C4928D10095D8E7 /* ProfileModifyPwView.swift */; };
 		D8C9AC402BF661A2006D1FCD /* InquiryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */; };
 		D8C9AC422BF66BB3006D1FCD /* InquiryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */; };
@@ -521,6 +522,7 @@
 		D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameResponseDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Response/FindUserNameResponseDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameRequestDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Request/FindUserNameRequestDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7882BDA925F0019DE3C /* FindUserNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindUserNameViewModel.swift; sourceTree = "<group>"; };
+		D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatePwRequestDto.swift; sourceTree = "<group>"; };
 		D8BDAF702C4928D10095D8E7 /* ProfileModifyPwView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModifyPwView.swift; sourceTree = "<group>"; };
 		D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryView.swift; sourceTree = "<group>"; };
 		D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryListView.swift; sourceTree = "<group>"; };
@@ -1109,6 +1111,7 @@
 			isa = PBXGroup;
 			children = (
 				4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */,
+				D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1948,6 +1951,7 @@
 				4AD70E292BE015970058A52A /* ProfileSettingListView.swift in Sources */,
 				4A3701D02C08F7F600F0AEBA /* GetSpendingHistoryRequestDto.swift in Sources */,
 				4A762AED2B99A16B001C1188 /* pennyway_client_iOSApp.swift in Sources */,
+				D8B0A9282C4EA7FC00716ECB /* ValidatePwRequestDto.swift in Sources */,
 				4AC3205D2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift in Sources */,
 				4A6A9D112C331A9500394771 /* TargetAmountSetCompleteView.swift in Sources */,
 				4A4703942BCEB21500AEE04E /* StatusError.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Alamofire/UserAccountAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Alamofire/UserAccountAlamofire.swift
@@ -44,4 +44,10 @@ class UserAccountAlamofire {
         
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: UserAccountRouter.settingOffAlarm(type: type), completion: completion)
     }
+    
+    func validatePw(_ dto: ValidatePwRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("UserAccountAlamofire - validatePw() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: UserAccountRouter.validatePw(dto: dto), completion: completion)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Alamofire/UserAccountAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Alamofire/UserAccountAlamofire.swift
@@ -50,4 +50,10 @@ class UserAccountAlamofire {
         
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: UserAccountRouter.validatePw(dto: dto), completion: completion)
     }
+    
+    func resetMyPw(_ dto: ResetMyPwRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("UserAccountAlamofire - resetMyPw() called")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: UserAccountRouter.resetMyPw(dto: dto), completion: completion)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Dto/Request/ResetMyPwRequestDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Dto/Request/ResetMyPwRequestDto.swift
@@ -1,0 +1,13 @@
+
+public struct ResetMyPwRequestDto: Encodable {
+    let oldPassword: String
+    let newPassword: String
+
+    public init(
+        oldPassword: String,
+        newPassword: String
+    ) {
+        self.oldPassword = oldPassword
+        self.newPassword = newPassword
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Dto/Request/ValidatePwRequestDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Dto/Request/ValidatePwRequestDto.swift
@@ -1,0 +1,10 @@
+
+public struct ValidatePwRequestDto: Encodable {
+    let password: String
+
+    public init(
+        password: String
+    ) {
+        self.password = password
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Router/UserAccountRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Router/UserAccountRouter.swift
@@ -8,6 +8,7 @@ enum UserAccountRouter: URLRequestConvertible {
     case registDeviceToken(dto: FcmTokenDto)
     case settingOnAlarm(type: String)
     case settingOffAlarm(type: String)
+    case validatePw(dto: ValidatePwRequestDto)
     
     var method: HTTPMethod {
         switch self {
@@ -19,6 +20,8 @@ enum UserAccountRouter: URLRequestConvertible {
             return .put
         case .settingOnAlarm:
             return .patch
+        case .validatePw:
+            return .post
         }
     }
     
@@ -34,6 +37,8 @@ enum UserAccountRouter: URLRequestConvertible {
             return "v2/users/me/device-tokens"
         case .settingOnAlarm, .settingOffAlarm:
             return "v2/users/me/notifications"
+        case .validatePw:
+            return "v2/users/me/password/verification"
         }
     }
     
@@ -42,6 +47,8 @@ enum UserAccountRouter: URLRequestConvertible {
         case .getUserProfile, .deleteUserAccount:
             return [:]
         case let .registDeviceToken(dto):
+            return try? dto.asDictionary()
+        case let .validatePw(dto):
             return try? dto.asDictionary()
         case let .settingOnAlarm(type), let .settingOffAlarm(type):
             return ["type": type]
@@ -55,7 +62,7 @@ enum UserAccountRouter: URLRequestConvertible {
         switch self {
         case .getUserProfile, .deleteUserAccount:
             request = URLRequest.createURLRequest(url: url, method: method)
-        case .registDeviceToken:
+        case .registDeviceToken, .validatePw:
             request = URLRequest.createURLRequest(url: url, method: method, bodyParameters: parameters)
         case .settingOnAlarm, .settingOffAlarm:
             let queryParameters = parameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Router/UserAccountRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/UserDomain/Router/UserAccountRouter.swift
@@ -9,6 +9,7 @@ enum UserAccountRouter: URLRequestConvertible {
     case settingOnAlarm(type: String)
     case settingOffAlarm(type: String)
     case validatePw(dto: ValidatePwRequestDto)
+    case resetMyPw(dto: ResetMyPwRequestDto)
     
     var method: HTTPMethod {
         switch self {
@@ -18,7 +19,7 @@ enum UserAccountRouter: URLRequestConvertible {
             return .delete
         case .registDeviceToken:
             return .put
-        case .settingOnAlarm:
+        case .settingOnAlarm, .resetMyPw:
             return .patch
         case .validatePw:
             return .post
@@ -39,6 +40,8 @@ enum UserAccountRouter: URLRequestConvertible {
             return "v2/users/me/notifications"
         case .validatePw:
             return "v2/users/me/password/verification"
+        case .resetMyPw:
+            return "v2/users/me/password"
         }
     }
     
@@ -49,6 +52,8 @@ enum UserAccountRouter: URLRequestConvertible {
         case let .registDeviceToken(dto):
             return try? dto.asDictionary()
         case let .validatePw(dto):
+            return try? dto.asDictionary()
+        case let .resetMyPw(dto):
             return try? dto.asDictionary()
         case let .settingOnAlarm(type), let .settingOffAlarm(type):
             return ["type": type]
@@ -62,7 +67,7 @@ enum UserAccountRouter: URLRequestConvertible {
         switch self {
         case .getUserProfile, .deleteUserAccount:
             request = URLRequest.createURLRequest(url: url, method: method)
-        case .registDeviceToken, .validatePw:
+        case .registDeviceToken, .validatePw, .resetMyPw:
             request = URLRequest.createURLRequest(url: url, method: method, bodyParameters: parameters)
         case .settingOnAlarm, .settingOffAlarm:
             let queryParameters = parameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/Navigation/PasswordChangeTypeNavigation.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/Navigation/PasswordChangeTypeNavigation.swift
@@ -1,0 +1,8 @@
+
+import Foundation
+
+/// 비밀번호 변경 진입점
+enum PasswordChangeTypeNavigation: String, CaseIterable {
+    case findPw
+    case modifyPw
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Manager/RegistrationManager.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Manager/RegistrationManager.swift
@@ -4,6 +4,7 @@ struct RegistrationManager {
 
     var name = ""
     var username = ""
+    var oldPassword = ""
     var password = ""
     var phoneNumber = ""
     var formattedPhoneNumber: String? {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
@@ -31,7 +31,7 @@ struct CompleteChangePwView: View {
                 
             CustomBottomButton(action: {
                 firstNaviLinkActive = false
-                    NavigationUtil.popToRootView()
+                NavigationUtil.popToRootView()
                     
                 Log.debug("firstNaviLinkActive: \(firstNaviLinkActive)")
             }, label: "메인으로 돌아가기", isFormValid: .constant(true))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
@@ -2,6 +2,8 @@
 import SwiftUI
 
 struct CompleteChangePwView: View {
+    @Binding var firstNaviLinkActive: Bool
+
     var body: some View {
         VStack {
             ScrollView {
@@ -28,8 +30,10 @@ struct CompleteChangePwView: View {
             }
                 
             CustomBottomButton(action: {
-                NavigationUtil.popToRootView()
-                Log.debug("버튼 누름")
+                firstNaviLinkActive = false
+                    NavigationUtil.popToRootView()
+                    
+                Log.debug("firstNaviLinkActive: \(firstNaviLinkActive)")
             }, label: "메인으로 돌아가기", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }
@@ -40,5 +44,5 @@ struct CompleteChangePwView: View {
 }
 
 #Preview {
-    CompleteChangePwView()
+    CompleteChangePwView(firstNaviLinkActive: .constant(true))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -6,6 +6,7 @@ struct FindPwView: View {
     @State private var isNavigateToFindPwView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @State private var isVerificationError: Bool = false
+//    let entryPoint: PasswordChangeTypeNavigation
 
     var body: some View {
         ZStack {
@@ -23,7 +24,7 @@ struct FindPwView: View {
                 
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
                 
-                NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel()), isActive: $isNavigateToFindPwView) {
+                NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel(), entryPoint: .findPw), isActive: $isNavigateToFindPwView) {
                     EmptyView()
                 }.hidden()
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -6,7 +6,6 @@ struct FindPwView: View {
     @State private var isNavigateToFindPwView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @State private var isVerificationError: Bool = false
-//    let entryPoint: PasswordChangeTypeNavigation
 
     var body: some View {
         ZStack {
@@ -24,7 +23,7 @@ struct FindPwView: View {
                 
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
                 
-                NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel(), entryPoint: .findPw), isActive: $isNavigateToFindPwView) {
+                NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel(), firstNaviLinkActive: .constant(true), entryPoint: .findPw), isActive: $isNavigateToFindPwView) {
                     EmptyView()
                 }.hidden()
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ResetPwFormView: View {
     @ObservedObject var formViewModel: SignUpFormViewModel
+    @ObservedObject var accountViewModel: UserAccountViewModel
     @State private var isPwDeleteButtonVisible: Bool = false
     @State private var isConfirmPwDeleteButtonVisible: Bool = false
 
@@ -67,6 +68,8 @@ struct ResetPwFormView: View {
                     .font(.pretendard(.regular, size: 12))
                     .platformTextColor(color: Color("Gray04"))
 
+                Spacer().frame(height: 13 * DynamicSizeFactor.factor())
+
                 HStack(spacing: 11 * DynamicSizeFactor.factor()) {
                     ZStack {
                         RoundedRectangle(cornerRadius: 4)
@@ -75,6 +78,7 @@ struct ResetPwFormView: View {
 
                         SecureField("", text: $formViewModel.confirmPw, onCommit: {
                             Log.debug("confirmPw: \(formViewModel.confirmPw)")
+                            RegistrationManager.shared.password = formViewModel.confirmPw
                             formViewModel.validateConfirmPw()
                             isConfirmPwDeleteButtonVisible = false
                         })
@@ -128,5 +132,5 @@ struct ResetPwFormView: View {
 }
 
 #Preview {
-    ResetPwFormView(formViewModel: SignUpFormViewModel())
+    ResetPwFormView(formViewModel: SignUpFormViewModel(), accountViewModel: UserAccountViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
@@ -9,35 +9,35 @@ struct ResetPwView: View {
     let entryPoint: PasswordChangeTypeNavigation
     
     var body: some View {
-            VStack(spacing: 0) {
-                ScrollView {
-                    HStack(alignment: .top) {
-                        Text("새로운 비밀번호를\n설정해주세요")
-                            .font(.H1SemiboldFont())
-                            .multilineTextAlignment(.leading)
-                            .padding(.top, 15 * DynamicSizeFactor.factor())
+        VStack(spacing: 0) {
+            ScrollView {
+                HStack(alignment: .top) {
+                    Text("새로운 비밀번호를\n설정해주세요")
+                        .font(.H1SemiboldFont())
+                        .multilineTextAlignment(.leading)
+                        .padding(.top, 15 * DynamicSizeFactor.factor())
                         
-                        Spacer()
-                    }
-                    .padding(.leading, 20)
-                    
-                    Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-                    
-                    ResetPwFormView(formViewModel: formViewModel, accountViewModel: accountViewModel)
+                    Spacer()
                 }
-                Spacer()
-                
-                CustomBottomButton(action: {
-                    continueButtonAction()
-                    formViewModel.validatePwForm()
+                .padding(.leading, 20)
                     
-                }, label: "변경하기", isFormValid: $formViewModel.isFormValid)
-                    .padding(.bottom, 34 * DynamicSizeFactor.factor())
-                
-                NavigationLink(destination: CompleteChangePwView(firstNaviLinkActive: $firstNaviLinkActive), isActive: $navigateView) {
-                    EmptyView()
-                }.hidden()
+                Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+                    
+                ResetPwFormView(formViewModel: formViewModel, accountViewModel: accountViewModel)
             }
+            Spacer()
+                
+            CustomBottomButton(action: {
+                continueButtonAction()
+                formViewModel.validatePwForm()
+                    
+            }, label: "변경하기", isFormValid: $formViewModel.isFormValid)
+                .padding(.bottom, 34 * DynamicSizeFactor.factor())
+                
+            NavigationLink(destination: CompleteChangePwView(firstNaviLinkActive: $firstNaviLinkActive), isActive: $navigateView) {
+                EmptyView()
+            }.hidden()
+        }
         
         .edgesIgnoringSafeArea(.bottom)
         .frame(maxHeight: .infinity)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
@@ -4,6 +4,8 @@ struct ResetPwView: View {
     @StateObject var formViewModel = SignUpFormViewModel()
     @State private var navigateView = false
     @StateObject var resetPwViewModel = ResetPwViewModel()
+    @StateObject var accountViewModel = UserAccountViewModel()
+    let entryPoint: PasswordChangeTypeNavigation
     
     var body: some View {
         VStack(spacing: 0) {
@@ -20,7 +22,7 @@ struct ResetPwView: View {
                     
                 Spacer().frame(height: 33 * DynamicSizeFactor.factor())
                     
-                ResetPwFormView(formViewModel: formViewModel)
+                ResetPwFormView(formViewModel: formViewModel, accountViewModel: accountViewModel)
             }
             Spacer()
                 
@@ -63,13 +65,26 @@ struct ResetPwView: View {
         if formViewModel.isFormValid {
             formViewModel.validatePwForm()
             resetPwViewModel.newPassword = formViewModel.password
-            resetPwViewModel.requestResetPwApi { success in
-                DispatchQueue.main.async {
+
+            if entryPoint == .modifyPw { // 프로필 비밀번호 변경 시
+                accountViewModel.resetMyPwApi { success in
                     if success {
-                        Log.debug("비밀번호 재설정 성공")
+                        Log.debug("사용자 비밀번호 변경 성공")
                         navigateView = true
+
                     } else {
-                        Log.fault("비밀번호 재설정 실패")
+                        Log.debug("사용자 비밀번호 변경 실패")
+                    }
+                }
+            } else { // 비밀번호 찾기에서 진입했을 시
+                resetPwViewModel.requestResetPwApi { success in
+                    DispatchQueue.main.async {
+                        if success {
+                            Log.debug("비밀번호 재설정 성공")
+                            navigateView = true
+                        } else {
+                            Log.fault("비밀번호 재설정 실패")
+                        }
                     }
                 }
             }
@@ -83,5 +98,5 @@ struct ResetPwView: View {
 }
 
 #Preview {
-    ResetPwView()
+    ResetPwView(entryPoint: .modifyPw)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
@@ -5,38 +5,40 @@ struct ResetPwView: View {
     @State private var navigateView = false
     @StateObject var resetPwViewModel = ResetPwViewModel()
     @StateObject var accountViewModel = UserAccountViewModel()
+    @Binding var firstNaviLinkActive: Bool
     let entryPoint: PasswordChangeTypeNavigation
     
     var body: some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                HStack(alignment: .top) {
-                    Text("새로운 비밀번호를\n설정해주세요")
-                        .font(.H1SemiboldFont())
-                        .multilineTextAlignment(.leading)
-                        .padding(.top, 15 * DynamicSizeFactor.factor())
+            VStack(spacing: 0) {
+                ScrollView {
+                    HStack(alignment: .top) {
+                        Text("새로운 비밀번호를\n설정해주세요")
+                            .font(.H1SemiboldFont())
+                            .multilineTextAlignment(.leading)
+                            .padding(.top, 15 * DynamicSizeFactor.factor())
                         
-                    Spacer()
+                        Spacer()
+                    }
+                    .padding(.leading, 20)
+                    
+                    Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+                    
+                    ResetPwFormView(formViewModel: formViewModel, accountViewModel: accountViewModel)
                 }
-                .padding(.leading, 20)
-                    
-                Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-                    
-                ResetPwFormView(formViewModel: formViewModel, accountViewModel: accountViewModel)
-            }
-            Spacer()
+                Spacer()
                 
-            CustomBottomButton(action: {
-                continueButtonAction()
-                formViewModel.validatePwForm()
+                CustomBottomButton(action: {
+                    continueButtonAction()
+                    formViewModel.validatePwForm()
                     
-            }, label: "변경하기", isFormValid: $formViewModel.isFormValid)
-                .padding(.bottom, 34 * DynamicSizeFactor.factor())
-
-            NavigationLink(destination: CompleteChangePwView(), isActive: $navigateView) {
-                EmptyView()
-            }.hidden()
-        }
+                }, label: "변경하기", isFormValid: $formViewModel.isFormValid)
+                    .padding(.bottom, 34 * DynamicSizeFactor.factor())
+                
+                NavigationLink(destination: CompleteChangePwView(firstNaviLinkActive: $firstNaviLinkActive), isActive: $navigateView) {
+                    EmptyView()
+                }.hidden()
+            }
+        
         .edgesIgnoringSafeArea(.bottom)
         .frame(maxHeight: .infinity)
         .navigationBarBackButtonHidden(true)
@@ -45,6 +47,7 @@ struct ResetPwView: View {
                 HStack {
                     Button(action: {
                         NavigationUtil.popToRootView()
+                        firstNaviLinkActive = false
                     }, label: {
                         Image("icon_arrow_back")
                             .resizable()
@@ -98,5 +101,5 @@ struct ResetPwView: View {
 }
 
 #Preview {
-    ResetPwView(entryPoint: .modifyPw)
+    ResetPwView(firstNaviLinkActive: .constant(true), entryPoint: .modifyPw)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -34,7 +34,7 @@ struct ProfileMainView: View {
             }
             NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
                 EmptyView()
-            }
+            }.hidden()
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
@@ -6,7 +6,7 @@ struct ProfileModifyPwView: View {
     @StateObject var viewModel = UserAccountViewModel()
     @State private var navigateView = false
     @State private var isFormValid = false
-    @State var firstNaviLinkActive = true
+    @Binding var firstNaviLinkActive: Bool
 
     let entryPoint: PasswordChangeTypeNavigation
 
@@ -93,5 +93,5 @@ struct ProfileModifyPwView: View {
 }
 
 #Preview {
-    ProfileModifyPwView(entryPoint: .modifyPw)
+    ProfileModifyPwView(firstNaviLinkActive: .constant(true), entryPoint: .modifyPw)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
@@ -3,11 +3,10 @@ import SwiftUI
 
 struct ProfileModifyPwView: View {
     @Environment(\.presentationMode) var presentationMode
-
-    ///    @StateObject var formViewModel = SignUpFormViewModel()
     @StateObject var viewModel = UserAccountViewModel()
     @State private var navigateView = false
     @State private var isFormValid = false
+    let entryPoint: PasswordChangeTypeNavigation
 
     var body: some View {
         NavigationAvailable {
@@ -26,7 +25,7 @@ struct ProfileModifyPwView: View {
                     Spacer().frame(height: 33 * DynamicSizeFactor.factor())
 
                     CustomInputView(inputText: $viewModel.password, titleText: "비밀번호", onCommit: {
-                        RegistrationManager.shared.password = viewModel.password
+                        RegistrationManager.shared.oldPassword = viewModel.password
 
                         validatePwApi()
                     }, isSecureText: true)
@@ -46,7 +45,7 @@ struct ProfileModifyPwView: View {
                     }, label: "완료", isFormValid: $isFormValid)
                         .padding(.bottom, 34 * DynamicSizeFactor.factor())
 
-                    NavigationLink(destination: ResetPwView(), isActive: $navigateView) {
+                    NavigationLink(destination: ResetPwView(entryPoint: .modifyPw), isActive: $navigateView) {
                         EmptyView()
                     }.hidden()
                 }
@@ -92,5 +91,5 @@ struct ProfileModifyPwView: View {
 }
 
 #Preview {
-    ProfileModifyPwView()
+    ProfileModifyPwView(entryPoint: .modifyPw)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
@@ -4,8 +4,10 @@ import SwiftUI
 struct ProfileModifyPwView: View {
     @Environment(\.presentationMode) var presentationMode
 
-    @StateObject var formViewModel = SignUpFormViewModel()
+    ///    @StateObject var formViewModel = SignUpFormViewModel()
+    @StateObject var viewModel = UserAccountViewModel()
     @State private var navigateView = false
+    @State private var isFormValid = false
 
     var body: some View {
         NavigationAvailable {
@@ -16,31 +18,34 @@ struct ProfileModifyPwView: View {
                             .font(.H1SemiboldFont())
                             .multilineTextAlignment(.leading)
                             .padding(.top, 15 * DynamicSizeFactor.factor())
-                        
+
                         Spacer()
                     }
                     .padding(.leading, 20)
-                    
+
                     Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-                    
-                    CustomInputView(inputText: $formViewModel.password, titleText: "비밀번호", onCommit: {
-                        formViewModel.validatePassword()
+
+                    CustomInputView(inputText: $viewModel.password, titleText: "비밀번호", onCommit: {
+                        RegistrationManager.shared.password = viewModel.password
+
+                        validatePwApi()
                     }, isSecureText: true)
-                    
+
                     Spacer().frame(height: 12 * DynamicSizeFactor.factor())
-                    
-                    if formViewModel.showErrorPassword {
+
+                    if viewModel.showErrorPassword {
                         ErrorText(message: "비밀번호가 일치하지 않아요", color: Color("Red03"))
                     }
-                    
+
                     Spacer()
-                    
+
                     CustomBottomButton(action: {
-                        navigateView = true
-                        
-                    }, label: "완료", isFormValid: .constant(true))
+                        if isFormValid {
+                            navigateView = true
+                        }
+                    }, label: "완료", isFormValid: $isFormValid)
                         .padding(.bottom, 34 * DynamicSizeFactor.factor())
-                    
+
                     NavigationLink(destination: ResetPwView(), isActive: $navigateView) {
                         EmptyView()
                     }.hidden()
@@ -67,6 +72,20 @@ struct ProfileModifyPwView: View {
                     .contentShape(Rectangle())
 
                 }.offset(x: -10)
+            }
+        }
+    }
+
+    func validatePwApi() {
+        viewModel.validatePwApi { success in
+            if success {
+                viewModel.showErrorPassword = false
+                isFormValid = true
+                Log.debug("비밀번호 검증 완료")
+            } else {
+                viewModel.showErrorPassword = true
+                isFormValid = false
+                Log.debug("비밃번호 검증 실패")
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
@@ -6,6 +6,8 @@ struct ProfileModifyPwView: View {
     @StateObject var viewModel = UserAccountViewModel()
     @State private var navigateView = false
     @State private var isFormValid = false
+    @State var firstNaviLinkActive = true
+
     let entryPoint: PasswordChangeTypeNavigation
 
     var body: some View {
@@ -45,7 +47,7 @@ struct ProfileModifyPwView: View {
                     }, label: "완료", isFormValid: $isFormValid)
                         .padding(.bottom, 34 * DynamicSizeFactor.factor())
 
-                    NavigationLink(destination: ResetPwView(entryPoint: .modifyPw), isActive: $navigateView) {
+                    NavigationLink(destination: ResetPwView(firstNaviLinkActive: $firstNaviLinkActive, entryPoint: .modifyPw), isActive: $navigateView) {
                         EmptyView()
                     }.hidden()
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -89,7 +89,7 @@ struct ProfileSettingListView: View {
         case .editProfile:
             EditProfileListView()
         case .modifyPw:
-            ProfileModifyPwView()
+            ProfileModifyPwView(entryPoint: .modifyPw)
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -7,6 +7,7 @@ struct ProfileSettingListView: View {
     @EnvironmentObject var authViewModel: AppViewModel
     @Binding var showingPopUp: Bool
     @StateObject var userAccountViewModel = UserAccountViewModel()
+    @State var firstNaviLinkActive = true
 
     @State private var activeNavigation: ProfileActiveNavigation?
 
@@ -89,7 +90,7 @@ struct ProfileSettingListView: View {
         case .editProfile:
             EditProfileListView()
         case .modifyPw:
-            ProfileModifyPwView(entryPoint: .modifyPw)
+            ProfileModifyPwView(firstNaviLinkActive: $firstNaviLinkActive, entryPoint: .modifyPw)
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
@@ -4,6 +4,8 @@ import SwiftUI
 
 class UserAccountViewModel: ObservableObject {
     @Published var toggleStates: [Bool] = [false, false, false]
+    @Published var password: String = ""
+    @Published var showErrorPassword: Bool = false
 
     func getUserProfileApi(completion: @escaping (Bool) -> Void) {
         UserAccountAlamofire.shared.getUserProfile { result in
@@ -116,6 +118,28 @@ class UserAccountViewModel: ObservableObject {
                 Log.debug("알람 설정 갱신 완료")
             } else {
                 Log.error("알람 설정 갱신 실패")
+            }
+        }
+    }
+
+    func validatePwApi(completion: @escaping (Bool) -> Void) {
+        Log.debug("value: \(RegistrationManager.shared.password)")
+
+        let validatePwRequestDto = ValidatePwRequestDto(password: RegistrationManager.shared.password)
+
+        UserAccountAlamofire.shared.validatePw(validatePwRequestDto) { result in
+            switch result {
+            case let .success(data):
+                Log.debug("사용자 비밀번호 검증 완료")
+                completion(true)
+
+            case let .failure(error):
+                if let errorWithDomainErrorAndMessage = error as? StatusSpecificError {
+                    Log.info("Failed to verify: \(errorWithDomainErrorAndMessage)")
+                } else {
+                    Log.error("Failed to verify: \(error)")
+                }
+                completion(false)
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
@@ -5,6 +5,7 @@ import SwiftUI
 class UserAccountViewModel: ObservableObject {
     @Published var toggleStates: [Bool] = [false, false, false]
     @Published var password: String = ""
+    @Published var oldPassword: String = ""
     @Published var showErrorPassword: Bool = false
 
     func getUserProfileApi(completion: @escaping (Bool) -> Void) {
@@ -123,14 +124,36 @@ class UserAccountViewModel: ObservableObject {
     }
 
     func validatePwApi(completion: @escaping (Bool) -> Void) {
-        Log.debug("value: \(RegistrationManager.shared.password)")
+        Log.debug("value: \(RegistrationManager.shared.oldPassword)")
 
-        let validatePwRequestDto = ValidatePwRequestDto(password: RegistrationManager.shared.password)
+        let validatePwRequestDto = ValidatePwRequestDto(password: RegistrationManager.shared.oldPassword)
 
         UserAccountAlamofire.shared.validatePw(validatePwRequestDto) { result in
             switch result {
             case let .success(data):
                 Log.debug("사용자 비밀번호 검증 완료")
+                completion(true)
+
+            case let .failure(error):
+                if let errorWithDomainErrorAndMessage = error as? StatusSpecificError {
+                    Log.info("Failed to verify: \(errorWithDomainErrorAndMessage)")
+                } else {
+                    Log.error("Failed to verify: \(error)")
+                }
+                completion(false)
+            }
+        }
+    }
+
+    func resetMyPwApi(completion: @escaping (Bool) -> Void) {
+        Log.debug("value: \(RegistrationManager.shared.oldPassword), \(RegistrationManager.shared.password)")
+
+        let resetMyPwDto = ResetMyPwRequestDto(oldPassword: RegistrationManager.shared.oldPassword, newPassword: RegistrationManager.shared.password)
+
+        UserAccountAlamofire.shared.resetMyPw(resetMyPwDto) { result in
+            switch result {
+            case let .success(data):
+                Log.debug("사용자 비밀번호 변경 완료")
                 completion(true)
 
             case let .failure(error):


### PR DESCRIPTION
## 작업 이유
- 비밀번호 검증 api 연동
- 비밀번호 재설정 api 연동
- 비밀번호 UI 간격 수정

<br/>

## 작업 사항
### **1️⃣ 비밀번호 검증 api 연동**
- 구현위치: UserAccountAlamofire - UserAccountRouter
- path: v2/users/me/password/verification
- method: post
- query: ValidatePwRequestDto


- 동작과정
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-07-23 at 00 30 59](https://github.com/user-attachments/assets/38786c22-c23b-4280-8264-858c4b9191de)

비밀번호를 입력한 후 onCommit으로 판단하여 비밀번호 검증 api를 호출하고, api에 성공했다면 (즉 기존 비밀번호와 입력비밀번호가 일치하다면) 변경하기 버튼이 활성화되고, 일치하지 않다면 ErrorText가 보여지도록 구현하였다.

### **2️⃣ 비밀번호 재설정 api 연동**
- 구현위치: UserAccountAlamofire - UserAccountRouter
- path: v2/users/me/password
- method: patch
- query: ResetMyPwRequestDto

기존에 만들어둔 ResetPwView에 entryPoint를 두어 continueButtonAction()을 눌렀을 때 진입점에 따라 분기처리 해주었다.
```swift
        if formViewModel.isFormValid {
            formViewModel.validatePwForm()
            resetPwViewModel.newPassword = formViewModel.password

            if entryPoint == .modifyPw { // 프로필 비밀번호 변경 시
                accountViewModel.resetMyPwApi { success in
                    if success {
                        Log.debug("사용자 비밀번호 변경 성공")
                        navigateView = true

                    } else {
                        Log.debug("사용자 비밀번호 변경 실패")
                    }
                }
            } else { // 비밀번호 찾기에서 진입했을 시
                resetPwViewModel.requestResetPwApi { success in
                    DispatchQueue.main.async {
                        if success {
                            Log.debug("비밀번호 재설정 성공")
                            navigateView = true
                        } else {
                            Log.fault("비밀번호 재설정 실패")
                        }
                    }
                }
            }
            
            RegistrationManager.shared.password = formViewModel.password
            
        }
``` 

dto를 전달할 때 비밀번호 검증에서 입력한 비밀번호를 `RegistrationManager.shared.oldPassword`에 저장하고 oldPassword에 이 값을 넘겨주고, newPassword는  `   RegistrationManager.shared.password = formViewModel.confirmPw`을 받아서 저장해주고 있고 이 값을 dto에 넘겨주고 있다. 

### **3️⃣ 비밀번호 UI 간격 수정**
피드백 반영에 해당하는 비밀번호 UI 간격처리하는 부분만 비밀번호 화면 api 연동하는 과정에서 뷰가 같아서 같이 처리했습니다!



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
api 구현 완료 했습니다! 이슈 한번 확인해주세요~

<br/>

## 발견한 이슈
### ResetPwView와 CompleteChangePwView에서 popToRootView가 작동하지 않는 문제 
navigationAvailable로 ProfileMainView가 연결되어 있음에도 불구하고 ProfileModifyPw에서 진입했을 경우 popToRootView가 작동하지 않는 문제가 발생한다. 
그래서 돌아가고 싶은 뷰 (= 즉 루트뷰로 지정해주고 싶은 곳) ProfileSettingListView에  state값으로 `@State var firstNaviLinkActive = true`를 지정해주고 ResetPwView에서와 CompleteChangePwView에 루트뷰로 돌아가야 하는 버튼을 누르면 firstNaviLinkActive = false값을 주어 바인딩으로 처리하였으나 뷰가 돌아가지 않는다.  로그를 확인해보니 firstNaviLinkActive값에는 문제가 없어보인다.
CompleteChangePwView에서 계층구조를 확인해보니 스택에 쌓인 뷰가 없이 CompleteChangePwView만 확인되었다. navigationAvailable이 안먹히는건가..,????

-> 같은 경험이 있으시다면,, 해결법 공유 부탁드립니다..,, 일단 이슈로 등록해놔야 할까요?