### PR TITLE
📍 목표 금액 그래프 뷰 피드백 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/View/MapCategoryIconUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/View/MapCategoryIconUtil.swift
@@ -1,9 +1,8 @@
 
 import SwiftUI
 
-class MapCategoryIconUtil{
-    
-    static func mapToCategoryIcon(_ icon: CategoryIconName, outputState: IconState) -> CategoryIconName{
+class MapCategoryIconUtil {
+    static func mapToCategoryIcon(_ icon: CategoryIconName, outputState: IconState) -> CategoryIconName {
         return CategoryIconName(baseName: icon.baseName, state: outputState)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -63,10 +63,10 @@ struct SelectCategoryIconView: View {
                 if let selectedCategory = SpendingCategoryIconList.fromIcon(selectedCategoryIcon) {
                     if entryPoint == .create {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                        viewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on)//onMint -> on
+                        viewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on) // onMint -> on
                     } else { // 수정인 경우
                         spendingCategoryViewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                        spendingCategoryViewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on)//onMint -> on
+                        spendingCategoryViewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on) // onMint -> on
                     }
                     isPresented = false
                     Log.debug(selectedCategory.rawValue)
@@ -79,7 +79,7 @@ struct SelectCategoryIconView: View {
         .onAppear {
             // onMint 아이콘으로 매칭
             if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
-                selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(icon, outputState: .onMint)//on -> onMint
+                selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(icon, outputState: .onMint) // on -> onMint
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -94,7 +94,7 @@ struct SpendingCategoryGridView: View {
     private func categoryVGridView(for category: SpendingCategoryData) -> some View {
         Button(action: {
             spendingCategoryViewModel.selectedCategory = category
-            spendingCategoryViewModel.selectedCategory?.icon = MapCategoryIconUtil.mapToCategoryIcon(category.icon, outputState: .on)//onWhite -> on
+            spendingCategoryViewModel.selectedCategory?.icon = MapCategoryIconUtil.mapToCategoryIcon(category.icon, outputState: .on) // onWhite -> on
             spendingCategoryViewModel.initPage() // 데이터 초기화
             spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
             spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -74,11 +74,13 @@ struct TotalTargetAmountContentView: View {
                             
                             Spacer()
                             
-                            DiffAmountDynamicWidthView(
-                                text: determineText(for: content.diffAmount),
-                                backgroundColor: determineBackgroundColor(for: content.diffAmount),
-                                textColor: determineTextColor(for: content.diffAmount)
-                            )
+                            if content.targetAmountDetail.amount != -1 {
+                                DiffAmountDynamicWidthView(
+                                    text: determineText(for: content.diffAmount),
+                                    backgroundColor: determineBackgroundColor(for: content.diffAmount),
+                                    textColor: determineTextColor(for: content.diffAmount)
+                                )
+                            }
                         }
                     }
                     .padding(.horizontal, 18)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -21,7 +21,7 @@ struct TotalTargetAmountContentView: View {
                 
                 Spacer()
                 
-                Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.diffAmount)원" : "-원")
+                Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.diffAmount < 0 ? "" : "-")\(abs(viewModel.currentData.diffAmount))원" : "-원")
                     .font(.B1SemiboldeFont())
                     .platformTextColor(color: determineDiffAmountColor(for: viewModel.currentData.diffAmount))
                     .padding(.trailing, 16)
@@ -99,25 +99,25 @@ struct TotalTargetAmountContentView: View {
     
     func determineDiffAmountColor(for diffAmount: Int) -> Color {
         if viewModel.currentData.targetAmountDetail.amount != -1 {
-            return diffAmount <= 0 ? Color("Red03") : Color("Gray07")
+            return diffAmount > 0 ? Color("Red03") : Color("Gray07")
         } else {
             return Color("Gray07")
         }
     }
     
     func determineBackgroundColor(for diffAmount: Int) -> Color {
-        return diffAmount < 0 ? Color("Red01") : Color("Ashblue01")
+        return diffAmount > 0 ? Color("Red01") : Color("Ashblue01")
     }
     
     func determineTextColor(for diffAmount: Int) -> Color {
-        return diffAmount < 0 ? Color("Red03") : Color("Mint03")
+        return diffAmount > 0 ? Color("Red03") : Color("Mint03")
     }
     
     func determineText(for diffAmount: Int) -> String {
         let diffAmountValue = (NumberFormatterUtil.formatIntToDecimalString(abs(diffAmount)))
         
         if diffAmount != 0 {
-            return diffAmount > 0 ? "\(diffAmountValue)원 절약했어요" : "\(diffAmountValue)원 더 썼어요"
+            return diffAmount < 0 ? "\(diffAmountValue)원 절약했어요" : "\(diffAmountValue)원 더 썼어요"
         } else {
             return "짝짝 소비 천재네요!"
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
@@ -48,7 +48,7 @@ struct TotalTargetAmountGraphView: View {
     func determineColorGray03(for content: TargetAmount) -> Color {
         if content.month == Date.month(from: Date()) {
             if content.targetAmountDetail.amount != -1 {
-                return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+                return content.diffAmount > 0 ? Color("Red03") : Color("Mint03")
             }
             return Color("Mint03")
         } else {
@@ -59,7 +59,7 @@ struct TotalTargetAmountGraphView: View {
     func determineColorGray04(for content: TargetAmount) -> Color {
         if content.month == Date.month(from: Date()) {
             if content.targetAmountDetail.amount != -1 {
-                return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+                return content.diffAmount > 0 ? Color("Red03") : Color("Mint03")
             }
             return Color("Mint03")
         } else {
@@ -70,7 +70,7 @@ struct TotalTargetAmountGraphView: View {
     func determineColorGray06(for content: TargetAmount) -> Color {
         if content.month == Date.month(from: Date()) {
             if content.targetAmountDetail.amount != -1 {
-                return content.diffAmount <= 0 ? Color("Red03") : Color("Mint03")
+                return content.diffAmount > 0 ? Color("Red03") : Color("Mint03")
             }
             return Color("Mint03")
         } else {


### PR DESCRIPTION
## 작업 이유

- 목표 금액 없을 때 이벤트(문구) 없어져야 함
- 목표 금액 리스트에 diffAmount 반전된 거 처리
- 목표 금액 리스트 상단 스크롤 블로킹


<br/>

## 작업 사항

### 1️⃣ 목표 금액 없을 때 이벤트(문구) 없어져야 함

목표 금액이 없는 경우이 "amount"가 -1인 경우에만 문구가 사라지도록 하였다.

<img src = "https://github.com/user-attachments/assets/355032d5-6169-4ff8-b8ce-61e432d4d541" width =300/>

TotalTargetAmountContentView에서 아래와 같이 amount가 -1이 아닌 경우에만 문구가 나오도록 처리하였다.

```swift
if content.targetAmountDetail.amount != -1 {
    DiffAmountDynamicWidthView(
        text: determineText(for: content.diffAmount),
        backgroundColor: determineBackgroundColor(for: content.diffAmount),
        textColor: determineTextColor(for: content.diffAmount)
    )
}
```

<br/>

### 2️⃣ 목표 금액 리스트에 diffAmount 반전된 거 처리

[diffAmount = 총 지출 금액 - 목표 금액]으로 양수면 초과, 음수면 절약을 뜻한다.
그래서 색상 지정해주는 로직을 아래와 같이 수정하였다.


<헤더>

“남은 금액" color
- diffAmount <= 0 => Mint03 
- diffAmount > 0 => Red03

<br/>

<그래프>

- diffAmount <= 0 => Mint03 
- diffAmount > 0 => Red03


<img src = "https://github.com/user-attachments/assets/31aa987f-316a-4bcd-aaf5-b91842b97697" width =300/>

<br/>

### 3️⃣ 목표 금액 리스트 상단 스크롤 블로킹

scrollView의 offset값을 판단해서 상단의 스크롤만 막도록 해야되는데 자료가 거의 없어서 시간이 좀 걸릴 듯 하다..
현재 ScrollViewReader도 사용하여 스크롤 offset값 확인하면서 구현해보려고 했는데 원하는 액션이 잘 나오지 않는다,,

조금 걸릴 것 같아서 다른 피드백 반영부터 먼저 진행하고 진행해야 될 것 같다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

목표 금액 그래프 뷰 피드백 반영하였고 3번은 시간이 좀 걸릴 것 같아서 다른 피드백 반영부터 먼저 하고 진행하려고 하는데 괜찮을까요??

<br/>

## 발견한 이슈
없음