### PR TITLE
📍 지출관리 메인화면 당월 목표 금액 피드백 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_mint.imageset/Contents.json
+++ b/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_mint.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_arrow_front_small_mint.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_mint.imageset/icon_arrow_front_small_mint.svg
+++ b/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_mint.imageset/icon_arrow_front_small_mint.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 16L14 12L10 8" stroke="#00D5E1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/View/MapCategoryIconUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/View/MapCategoryIconUtil.swift
@@ -1,9 +1,8 @@
 
 import SwiftUI
 
-class MapCategoryIconUtil{
-    
-    static func mapToCategoryIcon(_ icon: CategoryIconName, outputState: IconState) -> CategoryIconName{
+class MapCategoryIconUtil {
+    static func mapToCategoryIcon(_ icon: CategoryIconName, outputState: IconState) -> CategoryIconName {
         return CategoryIconName(baseName: icon.baseName, state: outputState)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SelectCategoryIconView.swift
@@ -63,10 +63,10 @@ struct SelectCategoryIconView: View {
                 if let selectedCategory = SpendingCategoryIconList.fromIcon(selectedCategoryIcon) {
                     if entryPoint == .create {
                         viewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                        viewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on)//onMint -> on
+                        viewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on) // onMint -> on
                     } else { // 수정인 경우
                         spendingCategoryViewModel.selectedCategoryIconTitle = selectedCategory.rawValue
-                        spendingCategoryViewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on)//onMint -> on
+                        spendingCategoryViewModel.selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(selectedCategoryIcon, outputState: .on) // onMint -> on
                     }
                     isPresented = false
                     Log.debug(selectedCategory.rawValue)
@@ -79,7 +79,7 @@ struct SelectCategoryIconView: View {
         .onAppear {
             // onMint 아이콘으로 매칭
             if let icon = (entryPoint == .create ? viewModel.selectedCategoryIcon : spendingCategoryViewModel.selectedCategory?.icon) {
-                selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(icon, outputState: .onMint)//on -> onMint
+                selectedCategoryIcon = MapCategoryIconUtil.mapToCategoryIcon(icon, outputState: .onMint) // on -> onMint
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -94,7 +94,7 @@ struct SpendingCategoryGridView: View {
     private func categoryVGridView(for category: SpendingCategoryData) -> some View {
         Button(action: {
             spendingCategoryViewModel.selectedCategory = category
-            spendingCategoryViewModel.selectedCategory?.icon = MapCategoryIconUtil.mapToCategoryIcon(category.icon, outputState: .on)//onWhite -> on
+            spendingCategoryViewModel.selectedCategory?.icon = MapCategoryIconUtil.mapToCategoryIcon(category.icon, outputState: .on) // onWhite -> on
             spendingCategoryViewModel.initPage() // 데이터 초기화
             spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
             spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
@@ -73,7 +73,7 @@ struct RecentTargetAmountSuggestionView: View {
     }
     
     private func getRecentTargetAmount() -> String {
-        let year = 2023
+        let year = Date.year(from: Date())
         let data = "\(viewModel.recentTargetAmountData?.month ?? 0)월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원"
         
         if viewModel.recentTargetAmountData?.year != year {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
@@ -28,7 +28,7 @@ struct RecentTargetAmountSuggestionView: View {
             .padding(.leading, 18 * DynamicSizeFactor.factor())
             .padding(.trailing, 13 * DynamicSizeFactor.factor())
     
-            Text("\(viewModel.recentTargetAmountData?.month ?? 0)월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원")
+            Text(getRecentTargetAmount())
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Mint02"))
                 .padding(.leading, 18 * DynamicSizeFactor.factor())
@@ -70,5 +70,16 @@ struct RecentTargetAmountSuggestionView: View {
         .cornerRadius(8)
         .shadow(color: Color(red: 0, green: 0.83, blue: 0.88).opacity(0.15), radius: 5, x: 0, y: 1) // TODO: 색상 변경 필요
         .padding(.horizontal, 20)
+    }
+    
+    private func getRecentTargetAmount() -> String {
+        let year = 2023
+        let data = "\(viewModel.recentTargetAmountData?.month ?? 0)월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원"
+        
+        if viewModel.recentTargetAmountData?.year != year {
+            return "\(year)년 \(data)"
+        }
+        
+        return data
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -99,7 +99,7 @@ struct SpendingCheckBoxView: View {
                                 .font(.B1SemiboldeFont())
                                 .platformTextColor(color: Color("Mint03"))
 
-                            Image("icon_arrow_front_small")
+                            Image("icon_arrow_front_small_mint")
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
@@ -117,14 +117,13 @@ struct SpendingCheckBoxView: View {
         .background(Color("White01"))
         .cornerRadius(8)
     }
-    
-    private func determineColor() -> Color{
-        if viewModel.isPresentTargetAmount{
-            if totalSpending > targetAmount || (totalSpending == 0 && targetAmount == 0){
+
+    private func determineColor() -> Color {
+        if viewModel.isPresentTargetAmount {
+            if totalSpending > targetAmount || (totalSpending == 0 && targetAmount == 0) {
                 return Color("Red03")
             }
         }
         return Color("Mint03")
     }
 }
-

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -35,7 +35,7 @@ struct SpendingCheckBoxView: View {
                                                StringAttribute(
                                                    text: "\(formattedTotalSpent)원",
                                                    font: .H3SemiboldFont(),
-                                                   color: targetAmount != -1 && totalSpending > targetAmount ? Color("Red03") : Color("Mint03")
+                                                   color: determineColor()
                                                ))
                                                .lineSpacing(3)
                 Spacer()
@@ -73,7 +73,7 @@ struct SpendingCheckBoxView: View {
                 if viewModel.isPresentTargetAmount == true {
                     Text("\(totalSpending)")
                         .font(.B1SemiboldeFont())
-                        .platformTextColor(color: totalSpending > targetAmount ? Color("Red03") : Color("Mint03"))
+                        .platformTextColor(color: determineColor())
 
                     Spacer()
 
@@ -117,4 +117,14 @@ struct SpendingCheckBoxView: View {
         .background(Color("White01"))
         .cornerRadius(8)
     }
+    
+    private func determineColor() -> Color{
+        if viewModel.isPresentTargetAmount{
+            if totalSpending > targetAmount || (totalSpending == 0 && targetAmount == 0){
+                return Color("Red03")
+            }
+        }
+        return Color("Mint03")
+    }
 }
+


### PR DESCRIPTION
## 작업 이유

- 지출 금액과 목표 금액이 0원인 경우, 프로그레스바에서 폰트 색 붉은색으로 변경
- 목표 금액 설정하기 우측 화살표 민트색으로 수정
- 최근 목표 금액 조회 시, 당년 데이터 아니면 년도 표시



<br/>

## 작업 사항

### 1️⃣ 지출 금액과 목표 금액이 0원인 경우, 프로그레스바에서 폰트 색 붉은색으로 변경

```
1. 목표 금액이 없는 경우 -> Mint

2. 목표 금액이 있는 경우

- 목표 금액과 지출 금액 == 0 -> Red
- 목표 금액 < 지출 금액 -> Red
```

```swift
private func determineColor() -> Color {
    if viewModel.isPresentTargetAmount {//목표 금액 존재 여부
        if totalSpending > targetAmount || (totalSpending == 0 && targetAmount == 0) {
            return Color("Red03")
        }
    }
    return Color("Mint03")
}
```

<img src = "https://github.com/user-attachments/assets/c5a5ffe4-c87f-48fa-a83a-49647591219e" width ="300"/>

<br/>

<br/>

### 2️⃣ 목표 금액 설정하기 우측 화살표 민트색으로 수정

화살표 아이콘 민트색으로 수정하였다.

<img src = "https://github.com/user-attachments/assets/e5e2630f-5b2e-4beb-87a9-b7d007b9bd88" width ="300"/>

<br/>

<br/>

### 3️⃣ 최근 목표 금액 조회 시, 당년 데이터 아니면 연도 표시

당년과 비교해서 다른 연도가 나오게 되면 연도를 표시해 주도록 수정하였다.

```swift
private func getRecentTargetAmount() -> String{
    let year = Date.year(from: Date())
    let data = "\(viewModel.recentTargetAmountData?.month ?? 0)월 목표금액: \(NumberFormatterUtil.formatIntToDecimalString(viewModel.recentTargetAmountData?.amount ?? 0))원"
    
    if viewModel.recentTargetAmountData?.year != year{//비교
        return "\(year)년 \(data)"
    }
    return data
}
```

<img src = "https://github.com/user-attachments/assets/742785b5-422e-44fd-b11d-83a17154eaa0" width ="300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

메인화면 목표 금액 관련 피드백 반영했습니다~~ 확인해보시고 이상있으면 말씀해주세요!

<br/>

## 발견한 이슈
