### PR TITLE
📍 지출내역에 따른 바텀시트 높이 조절

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/View/BottomSheetExtension.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/View/BottomSheetExtension.swift
@@ -81,20 +81,17 @@ struct DragBottomSheet<SheetContent: View>: ViewModifier {
                                 }
                                 .onEnded { value in
                                     let translation = value.translation.height
-                                    let velocity = value.predictedEndLocation.y - value.location.y
+                                    let velocity = value.predictedEndLocation.y - value.location.y // 속도
 
-                                    // withAnimation(.spring()) {
-                                    if translation < currentHeight * 0.25 || velocity < -300 {
-                                        currentHeight = maxHeight
-                                    } else if translation > currentHeight * 0.25 || velocity > 300 {
-                                        if currentHeight == minHeight {
+                                    withAnimation(.spring()) {
+                                        if -translation > currentHeight * 0.2 || velocity < -150 {
+                                            currentHeight = maxHeight
+                                        } else if translation > currentHeight * 0.2 || velocity > 150 {
                                             isPresented = false
-                                        } else {
-                                            currentHeight = minHeight
                                         }
+
+                                        draggedOffset = 0
                                     }
-                                    draggedOffset = 0
-                                    // }
                                 }
                         )
                         .transition(.move(edge: .bottom))

--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/View/BottomSheetExtension.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/View/BottomSheetExtension.swift
@@ -1,4 +1,3 @@
-
 import SwiftUI
 
 // MARK: - BottomSheet
@@ -40,14 +39,18 @@ struct BottomSheet<SheetContent: View>: ViewModifier {
 struct DragBottomSheet<SheetContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     let sheetContent: SheetContent
+    let minHeight: CGFloat
+    let maxHeight: CGFloat
 
-    @State private var offset: CGFloat = 0
-    @State private var lastDragValue: DragGesture.Value?
-    @State private var currentHeight: CGFloat = UIScreen.main.bounds.height
+    @State private var currentHeight: CGFloat
+    @State private var draggedOffset: CGFloat = 0
 
-    init(isPresented: Binding<Bool>, @ViewBuilder sheetContent: @escaping () -> SheetContent) {
+    init(isPresented: Binding<Bool>, minHeight: CGFloat, maxHeight: CGFloat, @ViewBuilder sheetContent: @escaping () -> SheetContent) {
         _isPresented = isPresented
         self.sheetContent = sheetContent()
+        self.minHeight = minHeight
+        self.maxHeight = maxHeight
+        _currentHeight = State(initialValue: minHeight)
     }
 
     func body(content: Content) -> some View {
@@ -65,28 +68,37 @@ struct DragBottomSheet<SheetContent: View>: ViewModifier {
                     Spacer()
                     sheetContent
                         .frame(maxWidth: .infinity)
+                        .frame(height: currentHeight + draggedOffset)
                         .background(
                             RoundedCornerUtil(radius: 15, corners: [.topLeft, .topRight])
                                 .fill(Color("White01"))
                         )
-                        .offset(y: max(0, offset))
                         .gesture(
                             DragGesture()
                                 .onChanged { value in
                                     let translation = value.translation.height
-                                    self.offset = max(0, translation + (self.lastDragValue?.translation.height ?? 0))
-                                    self.lastDragValue = value
+                                    draggedOffset = -translation
                                 }
-                                .onEnded { _ in
-                                    if self.offset > 400 { // 수정 필요
-                                        self.offset = 0
-                                        self.lastDragValue = nil
-                                        self.isPresented = false
+                                .onEnded { value in
+                                    let translation = value.translation.height
+                                    let velocity = value.predictedEndLocation.y - value.location.y
+
+                                    // withAnimation(.spring()) {
+                                    if translation < currentHeight * 0.25 || velocity < -300 {
+                                        currentHeight = maxHeight
+                                    } else if translation > currentHeight * 0.25 || velocity > 300 {
+                                        if currentHeight == minHeight {
+                                            isPresented = false
+                                        } else {
+                                            currentHeight = minHeight
+                                        }
                                     }
+                                    draggedOffset = 0
+                                    // }
                                 }
                         )
                         .transition(.move(edge: .bottom))
-                        .animation(.easeInOut, value: offset)
+                        .animation(.easeInOut, value: draggedOffset)
                 }
                 .edgesIgnoringSafeArea(.bottom)
             }
@@ -99,7 +111,7 @@ extension View {
         modifier(BottomSheet(isPresented: isPresented, maxHeight: maxHeight, sheetContent: content))
     }
 
-    func dragBottomSheet<SheetContent: View>(isPresented: Binding<Bool>, @ViewBuilder sheetContent: @escaping () -> SheetContent) -> some View {
-        modifier(DragBottomSheet(isPresented: isPresented, sheetContent: sheetContent))
+    func dragBottomSheet<SheetContent: View>(isPresented: Binding<Bool>, minHeight: CGFloat, maxHeight: CGFloat, @ViewBuilder sheetContent: @escaping () -> SheetContent) -> some View {
+        modifier(DragBottomSheet(isPresented: isPresented, minHeight: minHeight, maxHeight: maxHeight, sheetContent: sheetContent))
     }
-} 
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -86,7 +86,7 @@ struct AddSpendingHistoryView: View {
                     }.offset(x: -10)
                 }
             }
-            .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented, minHeight: 255 * DynamicSizeFactor.factor(), maxHeight: 524 * DynamicSizeFactor.factor()) {
+            .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented, minHeight: 524 * DynamicSizeFactor.factor(), maxHeight: 524 * DynamicSizeFactor.factor()) {
                 SpendingCategoryListView(viewModel: viewModel, isPresented: $viewModel.isCategoryListViewPresented)
             }
             .bottomSheet(isPresented: $viewModel.isSelectDayViewPresented, maxHeight: 300 * DynamicSizeFactor.factor()) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -86,7 +86,7 @@ struct AddSpendingHistoryView: View {
                     }.offset(x: -10)
                 }
             }
-            .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented) {
+            .dragBottomSheet(isPresented: $viewModel.isCategoryListViewPresented, minHeight: 255 * DynamicSizeFactor.factor(), maxHeight: 524 * DynamicSizeFactor.factor()) {
                 SpendingCategoryListView(viewModel: viewModel, isPresented: $viewModel.isCategoryListViewPresented)
             }
             .bottomSheet(isPresented: $viewModel.isSelectDayViewPresented, maxHeight: 300 * DynamicSizeFactor.factor()) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -14,7 +14,6 @@ struct SpendingManagementMainView: View {
     @State private var addSpendingClickDate: Date?
     @State private var addSpendingSelectedDate: Date?
     @State private var entryPoint: EntryPoint = .main
-
     @State private var showToastPopup = false
 
     var body: some View {
@@ -110,7 +109,7 @@ struct SpendingManagementMainView: View {
                 EmptyView()
             }
         }
-        .dragBottomSheet(isPresented: $showSpendingDetailView) {
+        .dragBottomSheet(isPresented: $showSpendingDetailView, minHeight: bottomSheetMinHeight, maxHeight: 524 * DynamicSizeFactor.factor()) {
             SpendingDetailSheetView(clickDate: $clickDate,
                                     viewModel: AddSpendingHistoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel)
                 .zIndex(2)
@@ -126,6 +125,22 @@ struct SpendingManagementMainView: View {
             }
         }
         .id(ishidden)
+    }
+
+    private var bottomSheetMinHeight: CGFloat {
+        if let clickDate = clickDate {
+            let filteredSpendings = spendingHistoryViewModel.filteredSpendings(for: clickDate)
+            switch filteredSpendings.count {
+            case 0 ..< 2: // 지출내역 0~1
+                return 255 * DynamicSizeFactor.factor()
+            case 2 ..< 6: // 지출내역 2~5
+                return 412 * DynamicSizeFactor.factor()
+            default: // 지출내역 5이상일 경우
+                return 524 * DynamicSizeFactor.factor()
+            }
+        } else {
+            return 255 * DynamicSizeFactor.factor()
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 이유
- 지출내역에 따른 바텀시트 높이 조절

<br/>

## 작업 사항
### **1️⃣ 지출내역에 따른 바텀시트 높이 조절**

DragBottomSheet 부분에 minHeight, maxHeight를 둬서 바텀시트의 최소높이, 최대높이를 설정해서 사용할 수 있게 로직을 수정하였다.
제스쳐를 표시하는 부분에서는 translation 는 드래그한 총 높이를 선언해주었고 값이 변할 때마다 onChange로 값을 변경 시켜주고
 `draggedOffset = -translation`를 통해 드래그의 방향을 전환시켜주도록 구현하였다.



```swift
.gesture(
                            DragGesture()
                                .onChanged { value in
                                    let translation = value.translation.height
                                    draggedOffset = -translation
                                }
                                .onEnded { value in
                                    let translation = value.translation.height
                                    let velocity = value.predictedEndLocation.y - value.location.y // 속도

                                    withAnimation(.spring()) {
                                        if -translation > currentHeight * 0.2 || velocity < -150 { //바텀시트를 위로
                                            currentHeight = maxHeight
                                        } else if translation > currentHeight * 0.2 || velocity > 150 { //바텀시트를 아래로
                                            isPresented = false
                                        }

                                        draggedOffset = 0
                                    }
                                }
                        )
``` 
애니메이션 부분에서는 임의로 드래그 한 비율이 현재 높이에서 0.2배 만큼을 드래그 했다면 -> translation의 방향에 따라 바텀시트가 드래그 되도록, 제스쳐 속도가 -150/ 150 이상일 경우에 드래그 되도록 구현하였다. 

- 지출내역에 따른 바텀시트 높이 설정
```swift
private var bottomSheetMinHeight: CGFloat {
        if let clickDate = clickDate {
            let filteredSpendings = spendingHistoryViewModel.filteredSpendings(for: clickDate)
            switch filteredSpendings.count {
            case 0 ..< 2: // 지출내역 0~1
                return 255 * DynamicSizeFactor.factor()
            case 2 ..< 6: // 지출내역 2~5
                return 412 * DynamicSizeFactor.factor()
            default: // 지출내역 5이상일 경우
                return 524 * DynamicSizeFactor.factor()
            }
        } else {
            return 255 * DynamicSizeFactor.factor()
        }
    }
``` 
위와 같이 지출내역을 조회하고, 그 지출내역 갯수에 맞게 최소 높이를 반환하도록 설정하였다. 갯수에 따라 바텀시트 높이가 달라지는 건 SpendingDetailSheetView에서만 적용되기 때문에 뷰안에서 함수를 만들어서 관리하였다.

**사용방법**
```swift
.dragBottomSheet(isPresented: $showSpendingDetailView, minHeight: bottomSheetMinHeight, maxHeight: 524 * DynamicSizeFactor.factor()) {
            SpendingDetailSheetView(clickDate: $clickDate,
                                    viewModel: AddSpendingHistoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel)
                .zIndex(2)
        }
``` 
drag 바텀시트를 사용할 때는 minHeight와 maxHeight에 값을 넣어줘서 사용해야 한다.

**동작과정**
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-07-26 at 00 34 47](https://github.com/user-attachments/assets/843498ce-5e91-4d17-98ff-204b3e5f6592)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
지출내역에 따른 바텀시트 높이 구현했습니다! 


<br/>

## 발견한 이슈
뭔가 sheet가 내려갈 때 부자연스러운거 같다 .. 