### PR TITLE
📍카테고리 수정 피드백 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Model/ListItem/CategoryIconListItem.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/ListItem/CategoryIconListItem.swift
@@ -196,7 +196,7 @@ enum SpendingListViewCategoryIconList: String, CaseIterable, Identifiable {
         case .membershipOrFamilyEvent:
             return "icon_category_event_on"
         case .other:
-            return "icon_category_plus_off"
+            return "icon_category_etc_on"
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -121,8 +121,13 @@ struct AddSpendingCategoryView: View {
                     .padding(.leading, 13 * DynamicSizeFactor.factor())
                     .font(.H4MediumFont())
                     .platformTextColor(color: Color("Gray07"))
-                    .onChange(of: categoryName) { _ in
-                        isFormValid = !categoryName.isEmpty
+                    .onChange(of: categoryName) { newValue in
+                        if entryPoint == .create {
+                            viewModel.categoryName = String(newValue.prefix(maxCategoryNameCount))
+                        } else {
+                            spendingCategoryViewModel.categoryName = String(newValue.prefix(maxCategoryNameCount))
+                        }
+                        isFormValid = !newValue.isEmpty
                     }
             }
         }


### PR DESCRIPTION
## 작업 이유

- 카테고리 수정 글자수 8자로 제한
- 사용자 정의 카테고리 ... 카테고리 매핑 오류


<br/>

## 작업 사항

### 1️⃣ 카테고리 수정 글자수 8자로 제한 

- 카테고리 수정과 추가 모두 같은 ui를 사용해서 textField의 예외처리를 아래와 같이 진행하였다.

8자로 제한해야되기 때문에 prefix로 최대 8자까지만 저장할 수 있도록 구현하였다.


```swift
.onChange(of: categoryName) { newValue in
    if entryPoint == .create {
        viewModel.categoryName = String(newValue.prefix(maxCategoryNameCount))
    } else {
        spendingCategoryViewModel.categoryName = String(newValue.prefix(maxCategoryNameCount))
    }
    isFormValid = !newValue.isEmpty
}
```


### 2️⃣ 사용자 정의 카테고리 ... 카테고리 매핑 오류

- 지출 내역 리스트를 보여줄 때 매핑 오류가 발생해서 알아보니 SpendingListViewCategoryIconList의 other 처리 아이콘을 플러스 아이콘으로 처리한 것이 문제였다.

"icon_category_etc_on"아이콘으로 변경하니 해결되었다.


### 결과

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-07-30 at 02 43 50](https://github.com/user-attachments/assets/fa50e47e-c431-43d7-b5e7-f5ee1279fa9a)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
카테고리 수정 피드백 반영 완료했습니다!!
이상있으면 말씀해주세요!


<br/>

## 발견한 이슈
없음