### PR TITLE
📍 비밀번호 x버튼 피드백 반영 및 지출내역 리스트 터치영역 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		D8E24D952BFD12BB006E8046 /* SettingAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E24D942BFD12BB006E8046 /* SettingAlarmView.swift */; };
 		D8E24D9C2BFDAFDA006E8046 /* CustomToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E24D9B2BFDAFDA006E8046 /* CustomToggleStyle.swift */; };
 		D8E637502C06303D00D43BB6 /* MySpendingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E6374F2C06303D00D43BB6 /* MySpendingListViewModel.swift */; };
+		D8F9D7342C57E297005416FC /* handleDeleteButtonUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -544,6 +545,7 @@
 		D8E24D942BFD12BB006E8046 /* SettingAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlarmView.swift; sourceTree = "<group>"; };
 		D8E24D9B2BFDAFDA006E8046 /* CustomToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggleStyle.swift; sourceTree = "<group>"; };
 		D8E6374F2C06303D00D43BB6 /* MySpendingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpendingListViewModel.swift; sourceTree = "<group>"; };
+		D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = handleDeleteButtonUtil.swift; sourceTree = "<group>"; };
 		F0F9541D34A887D64D713E30 /* Pods_pennyway_client_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pennyway_client_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -1357,6 +1359,7 @@
 				4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */,
 				4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */,
 				4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */,
+				D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1962,6 +1965,7 @@
 				4A6C79D22C46310B009463E4 /* EditProfileListView.swift in Sources */,
 				4A0FFBF92BCDA1F600EFEC56 /* LinkAccountToOAuthRequestDto.swift in Sources */,
 				4A1179A02BA9533D00A9CF4C /* FontExtensions.swift in Sources */,
+				D8F9D7342C57E297005416FC /* handleDeleteButtonUtil.swift in Sources */,
 				4A0FFBFB2BCDA74000EFEC56 /* EncodableExtension.swift in Sources */,
 				4A8571422BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift in Sources */,
 				4A5789792BDC1DDE00AFEB26 /* NotAcceptableErrorCode.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/View/handleDeleteButtonUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/View/handleDeleteButtonUtil.swift
@@ -1,0 +1,21 @@
+
+import SwiftUI
+
+struct handleDeleteButtonUtil: View {
+    var isVisible: Bool
+    var action: () -> Void
+
+    var body: some View {
+        if isVisible {
+            Button(action: {
+                action()
+            }, label: {
+                Image("icon_close_filled_primary")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 20 * DynamicSizeFactor.factor(), height: 20 * DynamicSizeFactor.factor())
+            })
+            .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
+        }
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
@@ -42,7 +42,7 @@ struct ResetPwFormView: View {
                             isPwDeleteButtonVisible = !newValue.isEmpty
                         }
 
-                        handleDeleteButtonTapped(isVisible: !formViewModel.password.isEmpty && isPwDeleteButtonVisible, action: {
+                        handleDeleteButtonUtil(isVisible: !formViewModel.password.isEmpty && isPwDeleteButtonVisible, action: {
                             formViewModel.password = ""
                             formViewModel.showErrorPassword = false
                             formViewModel.validatePwForm()
@@ -94,7 +94,7 @@ struct ResetPwFormView: View {
                             isConfirmPwDeleteButtonVisible = !newValue.isEmpty
                         }
 
-                        handleDeleteButtonTapped(isVisible: !formViewModel.confirmPw.isEmpty && isConfirmPwDeleteButtonVisible, action: {
+                        handleDeleteButtonUtil(isVisible: !formViewModel.confirmPw.isEmpty && isConfirmPwDeleteButtonVisible, action: {
                             formViewModel.confirmPw = ""
                             formViewModel.showErrorConfirmPw = false
                             formViewModel.validatePwForm()
@@ -113,22 +113,22 @@ struct ResetPwFormView: View {
         }
     }
 
-    @ViewBuilder
-    private func handleDeleteButtonTapped(isVisible: Bool, action: @escaping () -> Void) -> some View {
-        if isVisible {
-            Button(action: {
-                       action()
-                   },
-                   label: {
-                       Image("icon_close_filled_primary")
-                           .resizable()
-                           .aspectRatio(contentMode: .fit)
-                           .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-
-                   })
-                   .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
-        }
-    }
+//    @ViewBuilder
+//    private func handleDeleteButtonTapped(isVisible: Bool, action: @escaping () -> Void) -> some View {
+//        if isVisible {
+//            Button(action: {
+//                       action()
+//                   },
+//                   label: {
+//                       Image("icon_close_filled_primary")
+//                           .resizable()
+//                           .aspectRatio(contentMode: .fit)
+//                           .frame(width: 12 * DynamicSizeFactor.factor(), height: 12 * DynamicSizeFactor.factor())
+//
+//                   })
+//                   .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
+//        }
+//    }
 }
 
 #Preview {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
@@ -112,23 +112,6 @@ struct ResetPwFormView: View {
             }
         }
     }
-
-//    @ViewBuilder
-//    private func handleDeleteButtonTapped(isVisible: Bool, action: @escaping () -> Void) -> some View {
-//        if isVisible {
-//            Button(action: {
-//                       action()
-//                   },
-//                   label: {
-//                       Image("icon_close_filled_primary")
-//                           .resizable()
-//                           .aspectRatio(contentMode: .fit)
-//                           .frame(width: 12 * DynamicSizeFactor.factor(), height: 12 * DynamicSizeFactor.factor())
-//
-//                   })
-//                   .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
-//        }
-//    }
 }
 
 #Preview {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -1,5 +1,3 @@
-
-
 import SwiftUI
 
 struct CustomInputView: View {
@@ -9,9 +7,13 @@ struct CustomInputView: View {
     var onCommit: (() -> Void)?
     var isSecureText: Bool
     var isCustom: Bool?
+    var showDeleteButton: Bool = false
+    var deleteAction: (() -> Void)?
 
     let baseAttribute: BaseAttribute = BaseAttribute(font: .B1MediumFont(), color: Color("Gray07"))
     let stringAttribute: StringAttribute = StringAttribute(text: "*", font: .B1MediumFont(), color: Color("Mint03"))
+
+    @State private var isDeleteButtonVisible: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
@@ -42,22 +44,38 @@ struct CustomInputView: View {
                     if isSecureText {
                         SecureField("", text: $inputText, onCommit: {
                             onCommit?()
+                            isDeleteButtonVisible.toggle()
                         })
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .padding(.leading, 12 * DynamicSizeFactor.factor())
                         .padding(.vertical, 16 * DynamicSizeFactor.factor())
                         .font(.H4MediumFont())
+                        .onChange(of: inputText) { newValue in
+                            isDeleteButtonVisible = !newValue.isEmpty
+                        }
 
                     } else {
                         TextField("", text: $inputText, onCommit: {
                             onCommit?()
+                            isDeleteButtonVisible.toggle()
                         })
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .padding(.leading, 12 * DynamicSizeFactor.factor())
                         .padding(.vertical, 16 * DynamicSizeFactor.factor())
                         .font(.H4MediumFont())
+                        .onChange(of: inputText) { newValue in
+                            isDeleteButtonVisible = !newValue.isEmpty
+                        }
+                    }
+                    if showDeleteButton {
+                        handleDeleteButtonUtil(isVisible: !inputText.isEmpty && isDeleteButtonVisible, action: {
+                            inputText = ""
+                            isDeleteButtonVisible = false
+                            deleteAction?()
+                        })
+                        .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
                     }
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
@@ -6,7 +6,10 @@ struct ProfileModifyPwView: View {
     @StateObject var viewModel = UserAccountViewModel()
     @State private var navigateView = false
     @State private var isFormValid = false
+    @State private var isPwDeleteButtonVisible: Bool = false
+
     @Binding var firstNaviLinkActive: Bool
+    private let maxLength = 16
 
     let entryPoint: PasswordChangeTypeNavigation
 
@@ -30,7 +33,19 @@ struct ProfileModifyPwView: View {
                         RegistrationManager.shared.oldPassword = viewModel.password
 
                         validatePwApi()
-                    }, isSecureText: true)
+                        isPwDeleteButtonVisible = false
+                    }, isSecureText: true, showDeleteButton: true,
+                    deleteAction: {
+                        viewModel.password = ""
+                        viewModel.showErrorPassword = false
+                        isPwDeleteButtonVisible = false
+                    })
+                    .onChange(of: viewModel.password) { newValue in
+                        if newValue.count > maxLength {
+                            viewModel.password = String(newValue.prefix(maxLength))
+                        }
+                        isPwDeleteButtonVisible = !newValue.isEmpty
+                    }
 
                     Spacer().frame(height: 12 * DynamicSizeFactor.factor())
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -54,6 +54,7 @@ struct MySpendingListView: View {
                                                     showDetailSpendingView = true
                                                 }, label: {
                                                     CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
+                                                        .contentShape(Rectangle())
 
                                                 })
                                                 .buttonStyle(PlainButtonStyle())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -100,12 +100,21 @@ struct SpendingManagementMainView: View {
                     }
                 }, alignment: .bottom
             )
+            .background(
+                NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
+                    EmptyView()
+                }
+                .hidden()
+            )
 
-            NavigationLink(destination: AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
-                EmptyView()
+            if #available(iOS 15.0, *) {
+            } else {
+                NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
+                    EmptyView()
+                }
             }
 
-            NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
+            NavigationLink(destination: AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
                 EmptyView()
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
@@ -7,14 +7,6 @@ class UserAccountViewModel: ObservableObject {
     @Published var password: String = ""
     @Published var oldPassword: String = ""
     @Published var showErrorPassword: Bool = false
-//
-//    func validatePwForm() {
-//        if !password.isEmpty && !showErrorPassword {
-//            isFormValid = true
-//        } else {
-//            isFormValid = false
-//        }
-//    }
 
     func getUserProfileApi(completion: @escaping (Bool) -> Void) {
         UserAccountAlamofire.shared.getUserProfile { result in

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserAccountViewModel.swift
@@ -7,6 +7,14 @@ class UserAccountViewModel: ObservableObject {
     @Published var password: String = ""
     @Published var oldPassword: String = ""
     @Published var showErrorPassword: Bool = false
+//
+//    func validatePwForm() {
+//        if !password.isEmpty && !showErrorPassword {
+//            isFormValid = true
+//        } else {
+//            isFormValid = false
+//        }
+//    }
 
     func getUserProfileApi(completion: @escaping (Bool) -> Void) {
         UserAccountAlamofire.shared.getUserProfile { result in


### PR DESCRIPTION
## 작업 이유
- 비밀번호 x버튼 피드백 반영
- 지출내역 리스트 터치 영역 수정

<br/>

## 작업 사항
### **1️⃣ 비밀번호 x버튼 피드백 반영**
handleDeleteButtonUtil 의 로직을 Util파일로 빼서 관리하였고, CustomInputView에서도 사용할 수 있도록 옵셔널값으로 상태 관리를 할 수 있게 구현하였다.
```swift
var deleteAction: (() -> Void)?
..
if showDeleteButton {
                        handleDeleteButtonUtil(isVisible: !inputText.isEmpty && isDeleteButtonVisible, action: {
                            inputText = ""
                            isDeleteButtonVisible = false
                            deleteAction?()
                        })
                        .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
                    }
```  
**사용방법**
```swift
CustomInputView(inputText: $viewModel.password, titleText: "비밀번호", onCommit: {
                        RegistrationManager.shared.oldPassword = viewModel.password

                        validatePwApi()
                        isPwDeleteButtonVisible = false
                    }, isSecureText: true, showDeleteButton: true,
                    deleteAction: {
                        viewModel.password = ""
                        viewModel.showErrorPassword = false
                        isPwDeleteButtonVisible = false
                    })
``` 
CustomInputView를 사용하는 경우에 x버튼이 있어야 하는 경우 showDeleteAction = true로 해주면 x버튼이 표시되는 입력폼이다. deleteAction에 액션을 생성하여 그 안에 x버튼을 다루는 액션을 넣으면 된다.

### **2️⃣ 지출내역 리스트 터치 영역 수정**
버튼 라벨 전체에 **.contentShape(Rectangle())**을 사용하여 해결하였다.
```swift
                                                Button(action: {
                                                    clickDate = DateFormatterUtil.parseDate(from: date)
                                                    spendingHistoryViewModel.selectedDate = clickDate
                                                    selectedSpendingId = item.id
                                                    Log.debug("Id: \(selectedSpendingId)")
                                                    showDetailSpendingView = true
                                                }, label: {
                                                    CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
                                                        .contentShape(Rectangle())

                                                })

``` 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
x버튼 크기는 원래 전체 여백 포함 아이콘 크기가 24x24여서 여백 제외한 실제 아이콘 크기에 대해서 디자인팀한테 노션으로 문의남겨놓은 상황이고 추후 답변오면 반영할 예정입니다!

<br/>

## 발견한 이슈
입력폼에서 키보드에 return 을 눌러야 x버튼이 없어지고 빈공간을 터치하면 x버튼이 안없어지는데 이건 확인한번 해봐야 할거 같습니다!