### PR TITLE
📍💻 전화번호 인증 사용 중인 전화번호 문구 타이밍 수정 + 429 핸들링 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -218,6 +218,8 @@
 		4AE8F3B42C330A0B0014F0D4 /* TargetAmountSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3B32C330A0B0014F0D4 /* TargetAmountSettingView.swift */; };
 		4AE8F3B62C330F7A0014F0D4 /* TargetAmountSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3B52C330F7A0014F0D4 /* TargetAmountSettingViewModel.swift */; };
 		4AF69F642BFDF9E2001D49F8 /* BottomSheetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF69F632BFDF9E2001D49F8 /* BottomSheetExtension.swift */; };
+		4AFC7C9B2C581D9D003CFA8C /* TooManyRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */; };
+		4AFC7C9D2C581E1C003CFA8C /* TooManyRequestErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */; };
 		D809412E2BF276460015CFF9 /* ResetPwFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809412D2BF276460015CFF9 /* ResetPwFormView.swift */; };
 		D80E6A0F2BB2A7F5009F2DFE /* AgreementSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */; };
 		D80E6A152BB2E0C4009F2DFE /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -489,6 +491,8 @@
 		4AE8F3B32C330A0B0014F0D4 /* TargetAmountSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAmountSettingView.swift; sourceTree = "<group>"; };
 		4AE8F3B52C330F7A0014F0D4 /* TargetAmountSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAmountSettingViewModel.swift; sourceTree = "<group>"; };
 		4AF69F632BFDF9E2001D49F8 /* BottomSheetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetExtension.swift; sourceTree = "<group>"; };
+		4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooManyRequestError.swift; sourceTree = "<group>"; };
+		4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooManyRequestErrorCode.swift; sourceTree = "<group>"; };
 		5C86BC7DF91F1ADD72E96E7F /* Pods-pennyway-client-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pennyway-client-iOS.release.xcconfig"; path = "Target Support Files/Pods-pennyway-client-iOS/Pods-pennyway-client-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		D809412D2BF276460015CFF9 /* ResetPwFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPwFormView.swift; sourceTree = "<group>"; };
 		D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementSectionView.swift; sourceTree = "<group>"; };
@@ -1098,6 +1102,7 @@
 				4A57897C2BDC1EDF00AFEB26 /* PreconditionFailedErrorCode.swift */,
 				4A57897E2BDC1F4E00AFEB26 /* UnprocessableContentErrorCode.swift */,
 				4A5789802BDC1FF300AFEB26 /* InternalServerErrorCode.swift */,
+				4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */,
 			);
 			path = ErrorCodes;
 			sourceTree = "<group>";
@@ -1115,6 +1120,7 @@
 				4A5789962BDC29FC00AFEB26 /* PreconditionFailedError.swift */,
 				4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */,
 				4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */,
+				4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */,
 			);
 			path = ErrorCodeHandler;
 			sourceTree = "<group>";
@@ -1937,6 +1943,7 @@
 				4A0FFBEF2BCDA05B00EFEC56 /* SignUpRequestDto.swift in Sources */,
 				4A57898D2BDC291900AFEB26 /* ForbiddenError.swift in Sources */,
 				4A5789872BDC277100AFEB26 /* BadRequestError.swift in Sources */,
+				4AFC7C9D2C581E1C003CFA8C /* TooManyRequestErrorCode.swift in Sources */,
 				4A57897D2BDC1EDF00AFEB26 /* PreconditionFailedErrorCode.swift in Sources */,
 				4A148B5E2C364A3C005C6D4E /* SpendingCategoryViewModel.swift in Sources */,
 				4A148B602C370123005C6D4E /* CustomSpendingRow.swift in Sources */,
@@ -2065,6 +2072,7 @@
 				4AC3204D2C11D5AC00DDB4B6 /* SpendingCalendarCellView.swift in Sources */,
 				4AC4FD0A2BBDCE080027ACD5 /* GoogleOAuthViewModel.swift in Sources */,
 				4A9634B02C42E75A000A218A /* DeleteSpendingHistoryRequestDto.swift in Sources */,
+				4AFC7C9B2C581D9D003CFA8C /* TooManyRequestError.swift in Sources */,
 				4A6C79D42C463C0B009463E4 /* CustomRectangleButton.swift in Sources */,
 				4A57897F2BDC1F4E00AFEB26 /* UnprocessableContentErrorCode.swift in Sources */,
 				4ADBFAF12BE2C4E100C3ECE4 /* GetUserProfileResponseDto.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Error/ErrorCode/ErrorCodeHandler/TooManyRequestError.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Error/ErrorCode/ErrorCodeHandler/TooManyRequestError.swift
@@ -1,0 +1,13 @@
+
+import Foundation
+
+func tooManyRequestError(_ code: String, message: String) -> StatusSpecificError? {
+    guard let tooManyRequestErrorCode = TooManyRequestErrorCode(rawValue: code) else {
+        return nil
+    }
+
+    let defaultMessage = "TooManyRequest Error"
+    let fieldErrors: ErrorResponseData? = nil
+
+    return StatusSpecificError(domainError: .tooManyRequest, code: code, message: message.isEmpty ? defaultMessage : message, fieldErrors: fieldErrors)
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Error/ErrorCode/ErrorCodes/TooManyRequestErrorCode.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Error/ErrorCode/ErrorCodes/TooManyRequestErrorCode.swift
@@ -1,4 +1,4 @@
 
 enum TooManyRequestErrorCode: String {
-    case unexpectedError = "4290"
+    case tooManyRequestError = "4290"
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Error/ErrorCode/ErrorCodes/TooManyRequestErrorCode.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Error/ErrorCode/ErrorCodes/TooManyRequestErrorCode.swift
@@ -1,0 +1,4 @@
+
+enum TooManyRequestErrorCode: String {
+    case unexpectedError = "4290"
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Error/StatusCode/StatusCodeHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Error/StatusCode/StatusCodeHandler.swift
@@ -24,6 +24,8 @@ enum StatusCodeHandler {
             return preconditionFailedError(errorCode, message: defaultMessage)
         case 422:
             return unprocessableContentError(errorCode, message: defaultMessage)
+        case 429:
+            return tooManyRequestError(errorCode, message: defaultMessage)
         case 500:
             return internalServerError(errorCode, message: defaultMessage)
         default:

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Error/StatusCode/StatusError.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Error/StatusCode/StatusError.swift
@@ -9,5 +9,6 @@ enum StatusError: Error {
     case conflict
     case preconditionFailed
     case unprocessableContent
+    case tooManyRequest
     case internalServerError
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/ApiRequstHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/ApiRequstHandler.swift
@@ -14,10 +14,14 @@ class ApiRequstHandler {
                 case let .success(data):
                     completion(.success(data))
                 case let .failure(error):
-                    if let responseData = response.data,
-                       let statusCode = response.response?.statusCode,
-                       let errorResponse = try? JSONDecoder().decode(ErrorResponseDto.self, from: responseData),
-                       let responseError = StatusCodeHandler.handleStatusCode(statusCode, code: errorResponse.code, message: errorResponse.message)
+                    if let afError = error.asAFError, case let .responseValidationFailed(reason) = afError, case let .unacceptableStatusCode(code) = reason, code == 429 {
+                        // 429 Too Many Requests specific handling
+                        let tooManyRequestsError = StatusSpecificError(domainError: .tooManyRequest, code: TooManyRequestErrorCode.tooManyRequestError.rawValue, message: "Too many requests. Please try again later.", fieldErrors: nil)
+                        completion(.failure(tooManyRequestsError))
+                    } else if let responseData = response.data,
+                              let statusCode = response.response?.statusCode,
+                              let errorResponse = try? JSONDecoder().decode(ErrorResponseDto.self, from: responseData),
+                              let responseError = StatusCodeHandler.handleStatusCode(statusCode, code: errorResponse.code, message: errorResponse.message)
                     {
                         let errorWithDomainErrorAndMessage = StatusSpecificError(domainError: responseError.domainError, code: responseError.code, message: responseError.message, fieldErrors: errorResponse.fieldErrors)
                         completion(.failure(errorWithDomainErrorAndMessage))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdContentView.swift
@@ -4,13 +4,13 @@ import SwiftUI
 
 struct FindIdContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
-    @Binding var showingApiRequestPopUp: Bool
+    @Binding var showManyRequestPopUp: Bool
 
     var body: some View {
         VStack {
             Spacer().frame(height: 36 * DynamicSizeFactor.factor())
 
-            FindIdPhoneVerificationView(viewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
+            FindIdPhoneVerificationView(viewModel: phoneVerificationViewModel, showManyRequestPopUp: $showManyRequestPopUp)
 
             Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 
@@ -20,5 +20,5 @@ struct FindIdContentView: View {
 }
 
 #Preview {
-    FindIdContentView(phoneVerificationViewModel: PhoneVerificationViewModel(), showingApiRequestPopUp: .constant(false))
+    FindIdContentView(phoneVerificationViewModel: PhoneVerificationViewModel(), showManyRequestPopUp: .constant(false))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdContentView.swift
@@ -4,12 +4,13 @@ import SwiftUI
 
 struct FindIdContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
+    @Binding var showingApiRequestPopUp: Bool
 
     var body: some View {
         VStack {
             Spacer().frame(height: 36 * DynamicSizeFactor.factor())
 
-            FindIdPhoneVerificationView(viewModel: phoneVerificationViewModel)
+            FindIdPhoneVerificationView(viewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
 
             Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 
@@ -19,5 +20,5 @@ struct FindIdContentView: View {
 }
 
 #Preview {
-    FindIdContentView(phoneVerificationViewModel: PhoneVerificationViewModel())
+    FindIdContentView(phoneVerificationViewModel: PhoneVerificationViewModel(), showingApiRequestPopUp: .constant(false))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -68,7 +68,7 @@ struct FindIdFormView: View {
             Log.debug("else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
                 showingPopUp = true
-                isVerificationError = true//어디 사용??
+                isVerificationError = true // 어디 사용??
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -14,7 +14,7 @@ struct FindIdFormView: View {
         ZStack {
             VStack {
                 ScrollView {
-                    FindIdContentView(phoneVerificationViewModel: phoneVerificationViewModel)
+                    FindIdContentView(phoneVerificationViewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
                 }
 
                 Spacer()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -8,7 +8,6 @@ struct FindIdFormView: View {
     @State private var isNavigateToFindIDView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @StateObject var findUserNameViewModel = FindUserNameViewModel()
-    @State private var isVerificationError: Bool = false
 
     var body: some View {
         ZStack {
@@ -76,7 +75,6 @@ struct FindIdFormView: View {
             Log.debug("else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
                 showingCodeErrorPopUp = true
-                isVerificationError = true // 어디 사용??
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -2,8 +2,8 @@ import os.log
 import SwiftUI
 
 struct FindIdFormView: View {
-    @State private var showingCodeErrorPopUp = false
-    @State private var showingApiRequestPopUp = false
+    @State private var showCodeErrorPopUp = false
+    @State private var showManyRequestPopUp = false
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var isNavigateToFindIDView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
@@ -13,7 +13,7 @@ struct FindIdFormView: View {
         ZStack {
             VStack {
                 ScrollView {
-                    FindIdContentView(phoneVerificationViewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
+                    FindIdContentView(phoneVerificationViewModel: phoneVerificationViewModel, showManyRequestPopUp: $showManyRequestPopUp)
                 }
 
                 Spacer()
@@ -27,14 +27,14 @@ struct FindIdFormView: View {
                     EmptyView()
                 }.hidden()
             }
-            if showingCodeErrorPopUp == true {
+            if showCodeErrorPopUp == true {
                 Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
             }
 
-            if showingApiRequestPopUp {
+            if showManyRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
+                ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -64,7 +64,7 @@ struct FindIdFormView: View {
             phoneVerificationViewModel.isFormValid
         {
             Log.debug("if문 시작")
-            showingCodeErrorPopUp = false
+            showCodeErrorPopUp = false
             isNavigateToFindIDView = true
             viewModel.continueButtonTapped()
 
@@ -74,7 +74,7 @@ struct FindIdFormView: View {
         } else {
             Log.debug("else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
-                showingCodeErrorPopUp = true
+                showCodeErrorPopUp = true
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -68,7 +68,7 @@ struct FindIdFormView: View {
             Log.debug("else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
                 showingPopUp = true
-                isVerificationError = true
+                isVerificationError = true//어디 사용??
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -2,7 +2,8 @@ import os.log
 import SwiftUI
 
 struct FindIdFormView: View {
-    @State private var showingPopUp = false
+    @State private var showingCodeErrorPopUp = false
+    @State private var showingApiRequestPopUp = false
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var isNavigateToFindIDView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
@@ -27,9 +28,14 @@ struct FindIdFormView: View {
                     EmptyView()
                 }.hidden()
             }
-            if showingPopUp == true {
+            if showingCodeErrorPopUp == true {
                 Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingPopUp, label: "사용자 정보를 찾을 수 없어요")
+                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+            }
+
+            if showingApiRequestPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -55,9 +61,11 @@ struct FindIdFormView: View {
     }
 
     private func checkFormValid() {
-        if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && phoneVerificationViewModel.isFormValid {
+        if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser &&
+            phoneVerificationViewModel.isFormValid
+        {
             Log.debug("if문 시작")
-            showingPopUp = false
+            showingCodeErrorPopUp = false
             isNavigateToFindIDView = true
             viewModel.continueButtonTapped()
 
@@ -67,7 +75,7 @@ struct FindIdFormView: View {
         } else {
             Log.debug("else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
-                showingPopUp = true
+                showingCodeErrorPopUp = true
                 isVerificationError = true // 어디 사용??
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
@@ -33,6 +33,7 @@ struct FindIdPhoneVerificationView: View {
                             .platformTextColor(color: Color("Gray07"))
 
                             .onChange(of: viewModel.phoneNumber) { newValue in
+
                                 if Int(newValue) != nil {
                                     if newValue.count > 11 {
                                         viewModel.phoneNumber = String(newValue.prefix(11))
@@ -51,7 +52,7 @@ struct FindIdPhoneVerificationView: View {
                         }
                     }, label: {
                         Text("인증번호 받기")
-                            .font(.pretendard(.medium, size: 13)) // DynamicFontSize에 없음
+                            .font(.B1MediumFont())
                             .platformTextColor(color: !viewModel.isDisabledButton && viewModel.phoneNumber.count >= 11 ? Color("White01") : Color("Gray04"))
                     })
                     .padding(.horizontal, 13)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct FindIdPhoneVerificationView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
-    @Binding var showingApiRequestPopUp: Bool
+    @Binding var showManyRequestPopUp: Bool
     @State private var isFindUser = true
 
     var body: some View {
@@ -51,7 +51,7 @@ struct FindIdPhoneVerificationView: View {
                             Log.debug("아이디 찾기 api 요청")
                             viewModel.requestUserNameVerificationCodeApi {
                                 if viewModel.showErrorApiRequest {
-                                    showingApiRequestPopUp = true
+                                    showManyRequestPopUp = true
                                 } else {
                                     viewModel.judgeTimerRunning()
                                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct FindIdPhoneVerificationView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
+    @Binding var showingApiRequestPopUp: Bool
     @State private var isFindUser = true
 
     var body: some View {
@@ -49,7 +50,11 @@ struct FindIdPhoneVerificationView: View {
                         if isFindUser {
                             Log.debug("아이디 찾기 api 요청")
                             viewModel.requestUserNameVerificationCodeApi {
-                                viewModel.judgeTimerRunning()
+                                if viewModel.showErrorApiRequest {
+                                    showingApiRequestPopUp = true
+                                } else {
+                                    viewModel.judgeTimerRunning()
+                                }
                             }
                         }
                     }, label: {
@@ -80,8 +85,4 @@ struct FindIdPhoneVerificationView: View {
             }
         }
     }
-}
-
-#Preview {
-    FindIdPhoneVerificationView(viewModel: PhoneVerificationViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdPhoneVerificationView.swift
@@ -48,7 +48,9 @@ struct FindIdPhoneVerificationView: View {
                     Button(action: {
                         if isFindUser {
                             Log.debug("아이디 찾기 api 요청")
-                            viewModel.requestUserNameVerificationCodeApi { viewModel.judgeTimerRunning() }
+                            viewModel.requestUserNameVerificationCodeApi {
+                                viewModel.judgeTimerRunning()
+                            }
                         }
                     }, label: {
                         Text("인증번호 받기")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwContentView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 struct FindPwContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
+    @Binding var showingApiRequestPopUp: Bool
 
     var body: some View {
         VStack {
             Spacer().frame(height: 36 * DynamicSizeFactor.factor())
 
-            FindPwPhoneVerificationView(viewModel: phoneVerificationViewModel)
+            FindPwPhoneVerificationView(viewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
 
             Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 
@@ -17,5 +18,5 @@ struct FindPwContentView: View {
 }
 
 #Preview {
-    FindPwContentView(phoneVerificationViewModel: PhoneVerificationViewModel())
+    FindPwContentView(phoneVerificationViewModel: PhoneVerificationViewModel(), showingApiRequestPopUp: .constant(false))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwContentView.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 struct FindPwContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
-    @Binding var showingApiRequestPopUp: Bool
+    @Binding var showManyRequestPopUp: Bool
 
     var body: some View {
         VStack {
             Spacer().frame(height: 36 * DynamicSizeFactor.factor())
 
-            FindPwPhoneVerificationView(viewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
+            FindPwPhoneVerificationView(viewModel: phoneVerificationViewModel, showManyRequestPopUp: $showManyRequestPopUp)
 
             Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 
@@ -18,5 +18,5 @@ struct FindPwContentView: View {
 }
 
 #Preview {
-    FindPwContentView(phoneVerificationViewModel: PhoneVerificationViewModel(), showingApiRequestPopUp: .constant(false))
+    FindPwContentView(phoneVerificationViewModel: PhoneVerificationViewModel(), showManyRequestPopUp: .constant(false))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct FindPwPhoneVerificationView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
-    @Binding var showingApiRequestPopUp: Bool
+    @Binding var showManyRequestPopUp: Bool
     @State private var isFindUser = true
 
     var body: some View {
@@ -46,7 +46,7 @@ struct FindPwPhoneVerificationView: View {
                     Button(action: {
                         if isFindUser {
                             viewModel.requestPwVerificationCodeApi { if viewModel.showErrorApiRequest {
-                                showingApiRequestPopUp = true
+                                showManyRequestPopUp = true
                             } else {
                                 viewModel.judgeTimerRunning()
                             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
@@ -48,7 +48,7 @@ struct FindPwPhoneVerificationView: View {
                         }
                     }, label: {
                         Text("인증번호 받기")
-                            .font(.pretendard(.medium, size: 13)) // 폰트 리스트에 없는 예외
+                            .font(.B1MediumFont()) // 폰트 리스트에 없는 예외
                             .platformTextColor(color: !viewModel.isDisabledButton && viewModel.phoneNumber.count >= 11 ? Color("White01") : Color("Gray04"))
                     })
                     .padding(.horizontal, 13 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct FindPwPhoneVerificationView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
+    @Binding var showingApiRequestPopUp: Bool
     @State private var isFindUser = true
 
     var body: some View {
@@ -44,7 +45,12 @@ struct FindPwPhoneVerificationView: View {
                     }
                     Button(action: {
                         if isFindUser {
-                            viewModel.requestPwVerificationCodeApi { viewModel.judgeTimerRunning() }
+                            viewModel.requestPwVerificationCodeApi { if viewModel.showErrorApiRequest {
+                                showingApiRequestPopUp = true
+                            } else {
+                                viewModel.judgeTimerRunning()
+                            }
+                            }
                         }
                     }, label: {
                         Text("인증번호 받기")
@@ -74,8 +80,4 @@ struct FindPwPhoneVerificationView: View {
             }
         }
     }
-}
-
-#Preview {
-    FindIdPhoneVerificationView(viewModel: PhoneVerificationViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -13,7 +13,7 @@ struct FindPwView: View {
             VStack {
                 ScrollView {
                     VStack {
-                        FindPwContentView(phoneVerificationViewModel: phoneVerificationViewModel)
+                        FindPwContentView(phoneVerificationViewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
                     }
                 }
                 Spacer()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct FindPwView: View {
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
-    @State private var showingPopUp = false
+    @State private var showingCodeErrorPopUp = false
+    @State private var showingApiRequestPopUp = false
     @State private var isNavigateToFindPwView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @State private var isVerificationError: Bool = false
@@ -27,9 +28,13 @@ struct FindPwView: View {
                     EmptyView()
                 }.hidden()
             }
-            if showingPopUp == true {
+            if showingCodeErrorPopUp == true {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingPopUp, label: "사용자 정보를 찾을 수 없어요")
+                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+            }
+            if showingApiRequestPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -66,7 +71,7 @@ struct FindPwView: View {
     private func checkFormValid() {
         if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && phoneVerificationViewModel.isFormValid {
             Log.debug("비밀번호 찾기 checkFormValid if문 시작")
-            showingPopUp = false
+            showingCodeErrorPopUp = false
             isNavigateToFindPwView = true
             viewModel.continueButtonTapped()
 
@@ -75,7 +80,7 @@ struct FindPwView: View {
         } else {
             Log.debug("비밀번호 찾기 checkFormValid else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
-                showingPopUp = true
+                showingCodeErrorPopUp = true
                 isVerificationError = true
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct FindPwView: View {
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
-    @State private var showingCodeErrorPopUp = false
-    @State private var showingApiRequestPopUp = false
+    @State private var showCodeErrorPopUp = false
+    @State private var showManyRequestPopUp = false
     @State private var isNavigateToFindPwView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @State private var isVerificationError: Bool = false
@@ -13,7 +13,7 @@ struct FindPwView: View {
             VStack {
                 ScrollView {
                     VStack {
-                        FindPwContentView(phoneVerificationViewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
+                        FindPwContentView(phoneVerificationViewModel: phoneVerificationViewModel, showManyRequestPopUp: $showManyRequestPopUp)
                     }
                 }
                 Spacer()
@@ -28,13 +28,13 @@ struct FindPwView: View {
                     EmptyView()
                 }.hidden()
             }
-            if showingCodeErrorPopUp == true {
+            if showCodeErrorPopUp == true {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
             }
-            if showingApiRequestPopUp {
+            if showManyRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
+                ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -71,7 +71,7 @@ struct FindPwView: View {
     private func checkFormValid() {
         if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && phoneVerificationViewModel.isFormValid {
             Log.debug("비밀번호 찾기 checkFormValid if문 시작")
-            showingCodeErrorPopUp = false
+            showCodeErrorPopUp = false
             isNavigateToFindPwView = true
             viewModel.continueButtonTapped()
 
@@ -80,7 +80,7 @@ struct FindPwView: View {
         } else {
             Log.debug("비밀번호 찾기 checkFormValid else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
-                showingCodeErrorPopUp = true
+                showCodeErrorPopUp = true
                 isVerificationError = true
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/ErrorCodePopUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/ErrorCodePopUpView.swift
@@ -5,10 +5,11 @@ import SwiftUI
 
 struct ErrorCodePopUpView: View {
     @Binding var showingPopUp: Bool
-    let label: String
+    let titleLabel: String
+    let subLabel: String
 
     var body: some View {
-        PopupContent(imageSize: CGSize(width: 44 * DynamicSizeFactor.factor(), height: 44 * DynamicSizeFactor.factor()), frameHeight: 145 * DynamicSizeFactor.factor(), contentHeight: 70 * DynamicSizeFactor.factor(), label: label, showingPopUp: $showingPopUp)
+        PopupContent(imageSize: CGSize(width: 44 * DynamicSizeFactor.factor(), height: 44 * DynamicSizeFactor.factor()), frameHeight: 145 * DynamicSizeFactor.factor(), contentHeight: 70 * DynamicSizeFactor.factor(), titleLabel: titleLabel, subLabel: subLabel, showingPopUp: $showingPopUp)
     }
 }
 
@@ -19,7 +20,8 @@ extension ErrorCodePopUpView {
         var imageSize: CGSize
         var frameHeight: CGFloat
         var contentHeight: CGFloat
-        let label: String
+        let titleLabel: String
+        let subLabel: String
 
         @Binding var showingPopUp: Bool
 
@@ -60,10 +62,10 @@ extension ErrorCodePopUpView {
                     Spacer().frame(height: 9 * DynamicSizeFactor.factor())
 
                     VStack(spacing: 2 * DynamicSizeFactor.factor()) {
-                        Text(label)
+                        Text(titleLabel)
                             .platformTextColor(color: Color("Gray07"))
                             .font(.H3SemiboldFont())
-                        Text("다시 한 번 확인해주세요")
+                        Text(subLabel)
                             .platformTextColor(color: Color("Gray04"))
                             .font(.B1MediumFont())
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct PhoneNumberInputSectionView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
     @State private var isOAuthRegistration = OAuthRegistrationManager.shared.isOAuthRegistration
-
+    @Binding var showingApiRequestPopUp: Bool
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 11 * DynamicSizeFactor.factor()) {
             phoneNumberSection
@@ -51,13 +52,22 @@ struct PhoneNumberInputSectionView: View {
 
     private func handleVerificationButtonTap() {
         if isOAuthRegistration {
-            viewModel.requestOAuthVerificationCodeApi { viewModel.judgeTimerRunning() }
+            viewModel.requestOAuthVerificationCodeApi { 
+                handleErrorApi()
+            }
         } else {
-            viewModel.requestVerificationCodeApi { viewModel.judgeTimerRunning() }
+            viewModel.requestVerificationCodeApi { 
+                handleErrorApi()
+            }
+        }
+    }
+    
+    private func handleErrorApi(){
+        if viewModel.showErrorApiRequest {
+            showingApiRequestPopUp = true
+        } else {
+            viewModel.judgeTimerRunning()
         }
     }
 }
 
-#Preview {
-    PhoneNumberInputSectionView(viewModel: PhoneVerificationViewModel())
-}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -43,6 +43,8 @@ struct PhoneNumberInputSectionView: View {
             } else {
                 viewModel.showErrorExistingUser = true
             }
+        } else {
+            viewModel.phoneNumber = ""
         }
         viewModel.validateForm()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PhoneNumberInputSectionView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
     @State private var isOAuthRegistration = OAuthRegistrationManager.shared.isOAuthRegistration
-    @Binding var showingApiRequestPopUp: Bool
+    @Binding var showManyRequestPopUp: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 11 * DynamicSizeFactor.factor()) {
@@ -64,7 +64,7 @@ struct PhoneNumberInputSectionView: View {
 
     private func handleErrorApi() {
         if viewModel.showErrorApiRequest {
-            showingApiRequestPopUp = true
+            showManyRequestPopUp = true
         } else {
             viewModel.judgeTimerRunning()
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -38,8 +38,11 @@ struct PhoneNumberInputSectionView: View {
             if newValue.count > 11 {
                 viewModel.phoneNumber = String(newValue.prefix(11))
             }
-        } else {
-            viewModel.phoneNumber = ""
+            if viewModel.phoneNumber != viewModel.firstPhoneNumber {
+                viewModel.showErrorExistingUser = false
+            } else {
+                viewModel.showErrorExistingUser = true
+            }
         }
         viewModel.validateForm()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneNumberInputSectionView.swift
@@ -5,7 +5,7 @@ struct PhoneNumberInputSectionView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
     @State private var isOAuthRegistration = OAuthRegistrationManager.shared.isOAuthRegistration
     @Binding var showingApiRequestPopUp: Bool
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 11 * DynamicSizeFactor.factor()) {
             phoneNumberSection
@@ -61,8 +61,8 @@ struct PhoneNumberInputSectionView: View {
             }
         }
     }
-    
-    private func handleErrorApi(){
+
+    private func handleErrorApi() {
         if viewModel.showErrorApiRequest {
             showingApiRequestPopUp = true
         } else {
@@ -70,4 +70,3 @@ struct PhoneNumberInputSectionView: View {
         }
     }
 }
-

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PhoneVerificationContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
-    @Binding var showingApiRequestPopUp: Bool
+    @Binding var showManyRequestPopUp: Bool
 
     // MARK: Internal
 
@@ -15,7 +15,7 @@ struct PhoneVerificationContentView: View {
 
             Spacer().frame(height: 32 * DynamicSizeFactor.factor())
 
-            PhoneNumberInputSectionView(viewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
+            PhoneNumberInputSectionView(viewModel: phoneVerificationViewModel, showManyRequestPopUp: $showManyRequestPopUp)
 
             Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PhoneVerificationContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
     @Binding var showingApiRequestPopUp: Bool
+
     // MARK: Internal
 
     var body: some View {
@@ -14,15 +15,11 @@ struct PhoneVerificationContentView: View {
 
             Spacer().frame(height: 32 * DynamicSizeFactor.factor())
 
-            PhoneNumberInputSectionView(viewModel: phoneVerificationViewModel) 
+            PhoneNumberInputSectionView(viewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
 
             Spacer().frame(height: 21 * DynamicSizeFactor.factor())
 
             CodeInputSectionView(viewModel: phoneVerificationViewModel)
         }
     }
-}
-
-#Preview {
-    PhoneVerificationContentView(phoneVerificationViewModel: PhoneVerificationViewModel())
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationContentView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PhoneVerificationContentView: View {
     @ObservedObject var phoneVerificationViewModel: PhoneVerificationViewModel
-
+    @Binding var showingApiRequestPopUp: Bool
     // MARK: Internal
 
     var body: some View {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct PhoneVerificationView: View {
-    @State private var showingPopUp = false
+    @State private var showingCodeErrorPopUp = false
+    @State private var showingApiRequestPopUp = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @StateObject var oauthAccountLinkingViewModel = LinkOAuthToAccountViewModel()
@@ -20,7 +21,7 @@ struct PhoneVerificationView: View {
                 
                 Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                 
-                PhoneVerificationContentView(phoneVerificationViewModel: phoneVerificationViewModel)
+                PhoneVerificationContentView(phoneVerificationViewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
                 
                 Spacer()
                 
@@ -34,9 +35,14 @@ struct PhoneVerificationView: View {
                 }
             }
             
-            if showingPopUp {
+            if showingCodeErrorPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingPopUp, label: "잘못된 인증번호예요")
+                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
+            }
+            
+            if showingApiRequestPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -72,8 +78,10 @@ struct PhoneVerificationView: View {
     }
     
     private func checkFormValid() {
-        if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && phoneVerificationViewModel.isFormValid {
-            showingPopUp = false
+        if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser
+            && phoneVerificationViewModel.isFormValid
+        {
+            showingCodeErrorPopUp = false
             viewModel.continueButtonTapped()
             
             if OAuthRegistrationManager.shared.isOAuthRegistration {
@@ -88,7 +96,7 @@ struct PhoneVerificationView: View {
             }
         } else {
             if phoneVerificationViewModel.showErrorVerificationCode {
-                showingPopUp = true
+                showingCodeErrorPopUp = true
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct PhoneVerificationView: View {
-    @State private var showingCodeErrorPopUp = false
-    @State private var showingApiRequestPopUp = false
+    @State private var showCodeErrorPopUp = false
+    @State private var showManyRequestPopUp = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @StateObject var oauthAccountLinkingViewModel = LinkOAuthToAccountViewModel()
@@ -21,7 +21,7 @@ struct PhoneVerificationView: View {
                 
                 Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                 
-                PhoneVerificationContentView(phoneVerificationViewModel: phoneVerificationViewModel, showingApiRequestPopUp: $showingApiRequestPopUp)
+                PhoneVerificationContentView(phoneVerificationViewModel: phoneVerificationViewModel, showManyRequestPopUp: $showManyRequestPopUp)
                 
                 Spacer()
                 
@@ -35,14 +35,14 @@ struct PhoneVerificationView: View {
                 }
             }
             
-            if showingCodeErrorPopUp {
+            if showCodeErrorPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
             }
             
-            if showingApiRequestPopUp {
+            if showManyRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
+                ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -81,7 +81,7 @@ struct PhoneVerificationView: View {
         if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser
             && phoneVerificationViewModel.isFormValid
         {
-            showingCodeErrorPopUp = false
+            showCodeErrorPopUp = false
             viewModel.continueButtonTapped()
             
             if OAuthRegistrationManager.shared.isOAuthRegistration {
@@ -96,7 +96,7 @@ struct PhoneVerificationView: View {
             }
         } else {
             if phoneVerificationViewModel.showErrorVerificationCode {
-                showingCodeErrorPopUp = true
+                showCodeErrorPopUp = true
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -114,10 +114,14 @@ struct EditPhoneNumberView: View {
         if Int(newValue) != nil {
             if newValue.count > 11 {
                 viewModel.phoneNumber = String(newValue.prefix(11))
-                if viewModel.phoneNumber != viewModel.firstPhoneNumber {
-                    viewModel.showErrorExistingUser = false
-                }
             }
+            if viewModel.phoneNumber != viewModel.firstPhoneNumber {
+                viewModel.showErrorExistingUser = false
+            } else {
+                viewModel.showErrorExistingUser = true
+            }
+        } else {
+            viewModel.phoneNumber = ""
         }
         viewModel.validateForm()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 struct EditPhoneNumberView: View {
     @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel = PhoneVerificationViewModel()
-    @State private var showingCodeErrorPopUp = false // 인증번호 오류
-    @State private var showingApiRequestPopUp = false // api 요청 오류
+    @State private var showCodeErrorPopUp = false // 인증번호 오류
+    @State private var showManyRequestPopUp = false // api 요청 오류
 
     var timerString: String {
         let minutes = viewModel.timerSeconds / 60
@@ -88,13 +88,13 @@ struct EditPhoneNumberView: View {
                 }
             }
 
-            if showingCodeErrorPopUp {
+            if showCodeErrorPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
             }
-            if showingApiRequestPopUp {
+            if showManyRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
+                ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
     }
@@ -134,7 +134,7 @@ struct EditPhoneNumberView: View {
     private func handleVerificationButtonTap() {
         viewModel.requestEditVerificationCodeApi { 
             if viewModel.showErrorApiRequest {
-                showingApiRequestPopUp = true
+                showManyRequestPopUp = true
             } else {
                 viewModel.judgeTimerRunning()
             }
@@ -154,11 +154,11 @@ struct EditPhoneNumberView: View {
         if !viewModel.showErrorVerificationCode && !viewModel.showErrorExistingUser &&
             !viewModel.showErrorApiRequest && viewModel.isFormValid
         {
-            showingCodeErrorPopUp = false
+            showCodeErrorPopUp = false
             completion(true)
         } else {
             if viewModel.showErrorVerificationCode {
-                showingCodeErrorPopUp = true
+                showCodeErrorPopUp = true
                 completion(false)
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 struct EditPhoneNumberView: View {
     @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel = PhoneVerificationViewModel()
-    @State private var showingCodeErrorPopUp = false//인증번호 오류
-    @State private var showingApiRequestPopUp = false//api 요청 오류
+    @State private var showingCodeErrorPopUp = false // 인증번호 오류
+    @State private var showingApiRequestPopUp = false // api 요청 오류
 
     var timerString: String {
         let minutes = viewModel.timerSeconds / 60
@@ -64,37 +64,37 @@ struct EditPhoneNumberView: View {
                 }, label: "변경 완료", isFormValid: $viewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
             }
+            .navigationBarBackButtonHidden(true)
+            .navigationBarColor(UIColor(named: "White01"), title: "휴대폰 번호 변경")
+            .background(Color("White01"))
+            .edgesIgnoringSafeArea(.bottom)
+            .setTabBarVisibility(isHidden: true)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    HStack {
+                        Button(action: {
+                            self.presentationMode.wrappedValue.dismiss()
+                        }, label: {
+                            Image("icon_arrow_back")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 34, height: 34)
+                                .padding(5)
+                        })
+                        .padding(.leading, 5)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                    }.offset(x: -10)
+                }
+            }
 
             if showingCodeErrorPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, label: "잘못된 인증번호예요")
+                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
             }
             if showingApiRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, label: "잘못된 인증번호예요")
-            }
-        }
-        .background(Color("White01"))
-        .edgesIgnoringSafeArea(.bottom)
-        .setTabBarVisibility(isHidden: true)
-        .navigationBarBackButtonHidden(true)
-        .navigationBarColor(UIColor(named: "White01"), title: "휴대폰 번호 변경")
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                HStack {
-                    Button(action: {
-                        self.presentationMode.wrappedValue.dismiss()
-                    }, label: {
-                        Image("icon_arrow_back")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 34, height: 34)
-                            .padding(5)
-                    })
-                    .padding(.leading, 5)
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
-                }.offset(x: -10)
+                ErrorCodePopUpView(showingPopUp: $showingApiRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
         }
     }
@@ -132,7 +132,13 @@ struct EditPhoneNumberView: View {
     }
 
     private func handleVerificationButtonTap() {
-        viewModel.requestEditVerificationCodeApi { viewModel.judgeTimerRunning() }
+        viewModel.requestEditVerificationCodeApi { 
+            if viewModel.showErrorApiRequest {
+                showingApiRequestPopUp = true
+            } else {
+                viewModel.judgeTimerRunning()
+            }
+        }
     }
 
     private func handleCodeChange(_ newValue: String) {
@@ -145,7 +151,9 @@ struct EditPhoneNumberView: View {
     }
 
     private func checkFormValid(completion: @escaping (Bool) -> Void) {
-        if !viewModel.showErrorVerificationCode && !viewModel.showErrorExistingUser && viewModel.isFormValid {
+        if !viewModel.showErrorVerificationCode && !viewModel.showErrorExistingUser &&
+            !viewModel.showErrorApiRequest && viewModel.isFormValid
+        {
             showingCodeErrorPopUp = false
             completion(true)
         } else {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct EditPhoneNumberView: View {
     @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel = PhoneVerificationViewModel()
-    @State private var showingPopUp = false
+    @State private var showingCodeErrorPopUp = false//인증번호 오류
+    @State private var showingApiRequestPopUp = false//api 요청 오류
 
     var timerString: String {
         let minutes = viewModel.timerSeconds / 60
@@ -64,9 +65,13 @@ struct EditPhoneNumberView: View {
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
             }
 
-            if showingPopUp {
+            if showingCodeErrorPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showingPopUp, label: "잘못된 인증번호예요")
+                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, label: "잘못된 인증번호예요")
+            }
+            if showingApiRequestPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showingCodeErrorPopUp, label: "잘못된 인증번호예요")
             }
         }
         .background(Color("White01"))
@@ -141,11 +146,11 @@ struct EditPhoneNumberView: View {
 
     private func checkFormValid(completion: @escaping (Bool) -> Void) {
         if !viewModel.showErrorVerificationCode && !viewModel.showErrorExistingUser && viewModel.isFormValid {
-            showingPopUp = false
+            showingCodeErrorPopUp = false
             completion(true)
         } else {
             if viewModel.showErrorVerificationCode {
-                showingPopUp = true
+                showingCodeErrorPopUp = true
                 completion(false)
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -114,9 +114,10 @@ struct EditPhoneNumberView: View {
         if Int(newValue) != nil {
             if newValue.count > 11 {
                 viewModel.phoneNumber = String(newValue.prefix(11))
+                if viewModel.phoneNumber != viewModel.firstPhoneNumber {
+                    viewModel.showErrorExistingUser = false
+                }
             }
-        } else {
-            viewModel.phoneNumber = ""
         }
         viewModel.validateForm()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
@@ -19,6 +19,7 @@ class PhoneVerificationViewModel: ObservableObject {
     @Published var showErrorPhoneNumberFormat = false
     @Published var showErrorVerificationCode = false
     @Published var showErrorExistingUser = false
+    @Published var showErrorApiRequest = false
     @Published var isFormValid = false
 
     @Published var phone: String = ""

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -63,17 +63,17 @@ extension PhoneVerificationViewModel {
                 }
             }
         case let .failure(error):
-//            if let StatusSpecificError = error as? StatusSpecificError {
-//                Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
-//
-//                if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-//                    handleExistUser()
-//                } else {
-//                    showErrorVerificationCode = true
-//                }
-//            } else {
+            if let StatusSpecificError = error as? StatusSpecificError {
+                Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+
+                if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
+                    handleExistUser()
+                } else {
+                    showErrorVerificationCode = true
+                }
+            } else {
             Log.error("Network request failed: \(error)")
-//            }
+            }
         }
         completion()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -30,6 +30,7 @@ extension PhoneVerificationViewModel {
 //                } else {
 //                    showErrorVerificationCode = true
 //                }
+                
             } else {
                 Log.error("Network request failed: \(error)")
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -126,7 +126,7 @@ extension PhoneVerificationViewModel {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
                 showErrorVerificationCode = true
-                
+
             } else {
                 Log.error("Network request failed: \(error)")
             }
@@ -151,7 +151,7 @@ extension PhoneVerificationViewModel {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
                 showErrorVerificationCode = true
-                
+
             } else {
                 Log.error("Network request failed: \(error)")
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -25,12 +25,19 @@ extension PhoneVerificationViewModel {
             if let StatusSpecificError = error as? StatusSpecificError {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
+                if StatusSpecificError.domainError == .tooManyRequest {
+                    showErrorApiRequest = true
+                    isTimerHidden = true
+                    stopTimer()
+                    isDisabledButton = false
+                    print("??: \(showErrorApiRequest)")
+                }
 //                if type == .username || type == .password, StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
 //                    showErrorExistingUser = false
 //                } else {
 //                    showErrorVerificationCode = true
 //                }
-                
+
             } else {
                 Log.error("Network request failed: \(error)")
             }
@@ -56,17 +63,17 @@ extension PhoneVerificationViewModel {
                 }
             }
         case let .failure(error):
-            if let StatusSpecificError = error as? StatusSpecificError {
-                Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
-
-                if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    handleExistUser()
-                } else {
-                    showErrorVerificationCode = true
-                }
-            } else {
-                Log.error("Network request failed: \(error)")
-            }
+//            if let StatusSpecificError = error as? StatusSpecificError {
+//                Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+//
+//                if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
+//                    handleExistUser()
+//                } else {
+//                    showErrorVerificationCode = true
+//                }
+//            } else {
+            Log.error("Network request failed: \(error)")
+//            }
         }
         completion()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -16,7 +16,6 @@ extension PhoneVerificationViewModel {
                         RegistrationManager.shared.phoneNumber = phoneNumber
                     }
                     firstPhoneNumber = phoneNumber
-                    showErrorExistingUser = false
 
                 } catch {
                     Log.fault("Error decoding JSON: \(error)")
@@ -26,11 +25,11 @@ extension PhoneVerificationViewModel {
             if let StatusSpecificError = error as? StatusSpecificError {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
-                if type == .username || type == .password, StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    showErrorExistingUser = false
-                } else {
-                    showErrorVerificationCode = true
-                }
+//                if type == .username || type == .password, StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
+//                    showErrorExistingUser = false
+//                } else {
+//                    showErrorVerificationCode = true
+//                }
             } else {
                 Log.error("Network request failed: \(error)")
             }
@@ -47,7 +46,6 @@ extension PhoneVerificationViewModel {
                 do {
                     let response = try JSONDecoder().decode(VerificationResponseDto.self, from: responseData)
                     showErrorVerificationCode = false
-                    showErrorExistingUser = false
                     let sms = response.data.sms
                     OAuthRegistrationManager.shared.isOAuthUser = sms.oauth
                     OAuthRegistrationManager.shared.username = sms.username ?? ""
@@ -61,11 +59,7 @@ extension PhoneVerificationViewModel {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
                 if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    showErrorExistingUser = true
-                    code = ""
-                    isTimerHidden = true
-                    stopTimer()
-                    isDisabledButton = false
+                    handleExistUser()
                 } else {
                     showErrorVerificationCode = true
                 }
@@ -86,7 +80,6 @@ extension PhoneVerificationViewModel {
                     let response = try JSONDecoder().decode(OAuthVerificationResponseDto.self, from: responseData)
 
                     showErrorVerificationCode = false
-                    showErrorExistingUser = false
                     let sms = response.data.sms
                     OAuthRegistrationManager.shared.isExistUser = sms.existsUser
                     OAuthRegistrationManager.shared.username = sms.username ?? ""
@@ -101,11 +94,7 @@ extension PhoneVerificationViewModel {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
                 if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    showErrorExistingUser = true
-                    code = ""
-                    isTimerHidden = true
-                    stopTimer()
-                    isDisabledButton = false
+                    handleExistUser()
                 } else {
                     showErrorVerificationCode = true
                 }
@@ -136,7 +125,7 @@ extension PhoneVerificationViewModel {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
                 if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    showErrorExistingUser = false
+//                    handleExistUser()
                 } else {
                     showErrorVerificationCode = true
                 }
@@ -164,7 +153,7 @@ extension PhoneVerificationViewModel {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
                 if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    showErrorExistingUser = false
+//                    handleExistUser()
                 } else {
                     showErrorVerificationCode = true
                 }
@@ -183,7 +172,6 @@ extension PhoneVerificationViewModel {
             if let responseData = data {
                 do {
                     let response = try JSONDecoder().decode(ErrorResponseDto.self, from: responseData)
-
                     Log.debug("전화번호 수정 완료 \(response)")
                     updateUserField(fieldName: "phone", value: phoneNumber)
                 } catch {
@@ -195,12 +183,7 @@ extension PhoneVerificationViewModel {
                 Log.info("Failed to verify: \(StatusSpecificError)")
 
                 if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-                    showErrorExistingUser = true
-                    showErrorVerificationCode = false
-                    code = ""
-                    isTimerHidden = true
-                    stopTimer()
-                    isDisabledButton = false
+                    handleExistUser()
                 } else {
                     showErrorVerificationCode = true
                 }
@@ -210,5 +193,14 @@ extension PhoneVerificationViewModel {
             Log.debug("전화번호 수정 실패")
         }
         completion()
+    }
+
+    private func handleExistUser() {
+        showErrorExistingUser = true
+        showErrorVerificationCode = false
+        code = ""
+        isTimerHidden = true
+        stopTimer()
+        isDisabledButton = false
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -30,7 +30,6 @@ extension PhoneVerificationViewModel {
                     isTimerHidden = true
                     stopTimer()
                     isDisabledButton = false
-                    print("??: \(showErrorApiRequest)")
                 }
 //                if type == .username || type == .password, StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
 //                    showErrorExistingUser = false
@@ -72,7 +71,7 @@ extension PhoneVerificationViewModel {
                     showErrorVerificationCode = true
                 }
             } else {
-            Log.error("Network request failed: \(error)")
+                Log.error("Network request failed: \(error)")
             }
         }
         completion()

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneViewModelHandlers.swift
@@ -31,12 +31,6 @@ extension PhoneVerificationViewModel {
                     stopTimer()
                     isDisabledButton = false
                 }
-//                if type == .username || type == .password, StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-//                    showErrorExistingUser = false
-//                } else {
-//                    showErrorVerificationCode = true
-//                }
-
             } else {
                 Log.error("Network request failed: \(error)")
             }
@@ -131,11 +125,8 @@ extension PhoneVerificationViewModel {
             if let StatusSpecificError = error as? StatusSpecificError {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
-                if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-//                    handleExistUser()
-                } else {
-                    showErrorVerificationCode = true
-                }
+                showErrorVerificationCode = true
+                
             } else {
                 Log.error("Network request failed: \(error)")
             }
@@ -159,11 +150,8 @@ extension PhoneVerificationViewModel {
             if let StatusSpecificError = error as? StatusSpecificError {
                 Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
 
-                if StatusSpecificError.domainError == .conflict, StatusSpecificError.code == ConflictErrorCode.resourceAlreadyExists.rawValue {
-//                    handleExistUser()
-                } else {
-                    showErrorVerificationCode = true
-                }
+                showErrorVerificationCode = true
+                
             } else {
                 Log.error("Network request failed: \(error)")
             }


### PR DESCRIPTION
## 작업 이유

- 이미 사용 중인 전화번호 문구가 사라지는 타이밍 수정
- 인증번호 요청 429 too many request 예외 핸들링

<br/>

## 작업 사항

### 1️⃣ "이미 사용 중인 전화번호" 문구가 사라지는 타이밍 수정

사용중인 전화번호인 경우 -> 인증번호 요청을 보낸 전화번호와 다른 전화번호 입력할 경우 사라지도록 구현

예를 들어 010-1234-5678로 인증번호 보낸 후, "사용중인 전화번호" 문구가 나타난다.

1. 010-1234-5678와 다른 번호를 입력할 경우 "사용중인 전화번호" 문구 사라지고 인증번호 받기 버튼 활성화
2. 010-1234-5678와 같은 번호 입력할 경우 "사용중인 전화번호" 문구 나타나고 인증번호 받기 버튼 비활성화


그리고 아이디/비밀번호 찾기에서는 당연히 존재하는 번호가 있어야 하기 때문에 “존재하는 번호”인 409에러에 대해 처리하지 않았다.


> 디코에 올린 실행 영상 확인바람

<br/>

### 2️⃣ 인증번호 요청 429 too many request 예외 핸들링

429는 인증번호 요청을 5번이상 하는 경우 발생하는 에러다. StatusError에 429에러인 경우(tooManyRequest)를 추가하였다.

429에러가 발생하는 경우는 스프링 부트 애플리케이션 단에서 처리하는 것이 아니어서 code가 아닌 state로 판단해서 처리했다.

ApiRequstHandler의 requestWithErrorHandling()의 error 핸들링 하는 로직에 429 state인 경우 예외처리하는 코드를 넣었다.

```swift
 if let afError = error.asAFError, case let .responseValidationFailed(reason) = afError, case let .unacceptableStatusCode(code) = reason, code == 429 {
    // 429 Too Many Requests specific handling
    let tooManyRequestsError = StatusSpecificError(domainError: .tooManyRequest, code: TooManyRequestErrorCode.tooManyRequestError.rawValue, message: "Too many requests. Please try again later.", fieldErrors: nil)
    completion(.failure(tooManyRequestsError))
}
```

그리고 인증번호 받기 api 로직에서 429일때 아래와 같이 처리해서 3가지 예외처리를 해주었다.

```
1. 인증번호 입력 막기 
2. 타이머 숨기기 및 멈춤 
4. 인증번호 받기 버튼 활성화
5. 인증번호 요청 횟수 초과 팝업창
```


```swift
if StatusSpecificError.domainError == .tooManyRequest {//429 에러인 경우
    showErrorApiRequest = true//인증번호 요청 횟수 초과 팝업창

   //타이머 숨기기 및 멈춤
    isTimerHidden = true
    stopTimer()

    isDisabledButton = false //인증번호 입력 막기
}
```

> 디코에 올린 실행 영상 확인바람

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

인증 관련된 부분 구현했습니다! 아래 내용 확인부탁드립니다!!

1. 아이디와 비밀번호 찾기에서 존재하는 유저인지 판단하는 409에러에 대한 핸들링을 하고 있던데 필요하지 않은 것 같아서 일단 주석처리 해놓았는데 확인 부탁드립니다! 

2. FindIdFormView의 isVerificationError변수 사용하지 않는 것 같던데 확인해보시고 필요없으면 삭제해놓을게요!

<br/>

## 발견한 이슈

아이디/비밀번호 찾기에서 인증번호 입력 틀렸을 때 인증 번호 오류 팝업이 나오지 않고 모두 사용자 찾을 수 없음 팝업이 나오더라고요!
에러 핸들링할 때 인증 번호 오류 처리를 하지 않은 것 같아요! 확인 부탁드립니다

![스크린샷 2024-07-30 오후 7 00 01](https://github.com/user-attachments/assets/134b35cf-3f20-47fa-8b7a-1a5b2d3b8d1c)
![스크린샷 2024-07-30 오후 7 00 14](https://github.com/user-attachments/assets/cc1bb065-7a36-4dfa-9fb8-be51aba2dd7d)
