### PR TITLE
📍 fcmToken 관리 로직 제거

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Api/KeychainHelper.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/KeychainHelper.swift
@@ -48,40 +48,6 @@ class KeychainHelper {
         }
     }
     
-    // MARK: fcmToken Keychain
-
-    static func saveFcmToken(fcmToken: String) {
-        let keychainQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: "fcmToken",
-            kSecValueData: fcmToken.data(using: .utf8)!,
-        ]
-        
-        let status = SecItemAdd(keychainQuery as CFDictionary, nil)
-        if status == errSecDuplicateItem {
-            SecItemUpdate(keychainQuery as CFDictionary, [kSecValueData: fcmToken.data(using: .utf8)!] as CFDictionary)
-        } else if status != noErr {
-            Log.error("Failed to save fcmToken to Keychain")
-        }
-    }
-    
-    static func loadFcmToken() -> String? {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: "fcmToken",
-            kSecReturnData: kCFBooleanTrue!,
-        ]
-        
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        
-        if status == noErr, let data = item as? Data, let token = String(data: data, encoding: .utf8) {
-            return token
-        } else {
-            return nil
-        }
-    }
-    
     // MARK: OAuthUserData Keychain
     
     static func saveOAuthUserData(oauthUserData: OAuthUserData) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/KeychainHelper.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/KeychainHelper.swift
@@ -82,18 +82,6 @@ class KeychainHelper {
         }
     }
     
-    static func deleteFcmToken() {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: "fcmToken",
-        ]
-        
-        let status = SecItemDelete(query as CFDictionary)
-        if status != noErr {
-            Log.error("Failed to delete fcmToken from Keychain")
-        }
-    }
-    
     // MARK: OAuthUserData Keychain
     
     static func saveOAuthUserData(oauthUserData: OAuthUserData) {

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -65,7 +65,7 @@ extension AppDelegate: MessagingDelegate {
             case let .success(data):
                 if let responseData = data {
                     do {
-                        let response = try JSONDecoder().decode(AuthResponseDto.self, from: responseData)
+                        let response = try JSONDecoder().decode(ErrorResponseDto.self, from: responseData)
                         Log.debug(response)
                     } catch {
                         Log.fault("Error parsing response JSON: \(error)")

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -51,24 +51,9 @@ extension AppDelegate: MessagingDelegate {
     /// fcm 등록 토큰을 받았을 때
     func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         if let fcmToken = fcmToken {
-            if let storedFcmToken = KeychainHelper.loadFcmToken() {
-                // 2. fcmToken이 KeychainHelper에 저장되어 있는 경우
-                if storedFcmToken != fcmToken {
-                    // 2.1 저장된 값과 비교해서 다르면 -> registDeviceTokenApi() 호출
-                    KeychainHelper.saveFcmToken(fcmToken: fcmToken)
-                    Log.info("fcmToken updated: \(fcmToken)")
-                    registDeviceTokenApi(fcmToken: fcmToken)
-                } else {
-                    // 2.2 저장된 값과 같으면 -> registDeviceTokenApi() 호출 x
-                    Log.info("fcmToken이 저장된 값과 같다")
-                    Log.info("fcmToken updated: \(fcmToken)")
-                }
-            } else {
-                // 1. fcmToken이 KeychainHelper에 저장되지 않은 경우 -> fcmToken 저장
-                KeychainHelper.saveFcmToken(fcmToken: fcmToken)
-                Log.info("fcmToken saved: \(fcmToken)")
-                registDeviceTokenApi(fcmToken: fcmToken)
-            }
+            KeychainHelper.saveFcmToken(fcmToken: fcmToken) // fcmToken 저장
+            Log.info("fcmToken saved: \(fcmToken)")
+            registDeviceTokenApi(fcmToken: fcmToken)
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -51,8 +51,7 @@ extension AppDelegate: MessagingDelegate {
     /// fcm 등록 토큰을 받았을 때
     func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         if let fcmToken = fcmToken {
-            KeychainHelper.saveFcmToken(fcmToken: fcmToken) // fcmToken 저장
-            Log.info("fcmToken saved: \(fcmToken)")
+            Log.info("fcmToken: \(fcmToken)")
             registDeviceTokenApi(fcmToken: fcmToken)
         }
     }


### PR DESCRIPTION
## 작업 이유

fcmToken을 클라이언트에서 관리하니 서버로 전달하지 않는 문제가 발생해서 수정하기로 하였다.
- fcmToken 관리 로직 제거

<br/>

## 작업 사항

### 1️⃣ fcmToken 관리 로직 제거

fcmToken 관리를 아래와 같이 처리하던 걸 모두 제거하고 fcmToken 발급 받으면 바로 서버에 보내도록 수정하였다.

```
<이전 예외처리>

1. fcmToken이 KeychainHelper에 저장되지 않은 경우 -> fcmToken 저장
2. fcmToken이 KeychainHelper에 저장되어 있는 경우
2.1 저장된 값과 비교해서 다르면 -> registDeviceTokenApi() 호출
2.2 저장된 값과 같으면 -> registDeviceTokenApi() 호출 x

<변경된 예외처리>

- fcmToken 발급 -> 서버에 token 전달 -> 끝

```


기존에 키체인에 저장해서 token 비교하는 로직이 필요없어져서 키체인에 저장하고 로드하는 로직 모두 제거하였다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

token 관리하는 로직 제거된 거 확인 부탁드립니다~


<br/>

## 발견한 이슈

없음
