### PR TITLE
📍🎨 회원 탈퇴 UI 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		4A57899B2BDC2A2500AFEB26 /* InternalServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */; };
 		4A5DA8C12C3C498D00685F77 /* FcmTokenDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */; };
 		4A60F64C2C595E4700805F2C /* CustomCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */; };
+		4A60F64E2C595F6A00805F2C /* CompleteDeleteUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */; };
 		4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */; };
 		4A69C14A2BE2CF6700A27B82 /* UserDefaultsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A69C1492BE2CF6700A27B82 /* UserDefaultsHelper.swift */; };
 		4A69C14C2BE2DBAC00A27B82 /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A69C14B2BE2DBAC00A27B82 /* AppViewModel.swift */; };
@@ -383,6 +384,7 @@
 		4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalServerError.swift; sourceTree = "<group>"; };
 		4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FcmTokenDto.swift; sourceTree = "<group>"; };
 		4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCompleteView.swift; sourceTree = "<group>"; };
+		4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDeleteUserView.swift; sourceTree = "<group>"; };
 		4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalTargetAmountViewModel.swift; sourceTree = "<group>"; };
 		4A69C1492BE2CF6700A27B82 /* UserDefaultsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsHelper.swift; sourceTree = "<group>"; };
 		4A69C14B2BE2DBAC00A27B82 /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
@@ -1542,6 +1544,7 @@
 				4AD70E282BE015970058A52A /* ProfileSettingListView.swift */,
 				D8E24D922BFCF885006E8046 /* ProfileMenuBarListView.swift */,
 				D8BDAF702C4928D10095D8E7 /* ProfileModifyPwView.swift */,
+				4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */,
 			);
 			path = ProfileMainView;
 			sourceTree = "<group>";
@@ -1957,6 +1960,7 @@
 				4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */,
 				4A3701CD2C08F7F600F0AEBA /* SpendingAlamofire.swift in Sources */,
 				4AE8F3A82C32AB970014F0D4 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */,
+				4A60F64E2C595F6A00805F2C /* CompleteDeleteUserView.swift in Sources */,
 				D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */,
 				D851E71B2C0273BD00316DB3 /* BackofficeRequestDto.swift in Sources */,
 				4AC320422C11D5AC00DDB4B6 /* AddSpendingCompleteView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		4A5789992BDC2A1100AFEB26 /* UnprocessableContentError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */; };
 		4A57899B2BDC2A2500AFEB26 /* InternalServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */; };
 		4A5DA8C12C3C498D00685F77 /* FcmTokenDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */; };
+		4A60F64C2C595E4700805F2C /* CustomCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */; };
 		4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */; };
 		4A69C14A2BE2CF6700A27B82 /* UserDefaultsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A69C1492BE2CF6700A27B82 /* UserDefaultsHelper.swift */; };
 		4A69C14C2BE2DBAC00A27B82 /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A69C14B2BE2DBAC00A27B82 /* AppViewModel.swift */; };
@@ -381,6 +382,7 @@
 		4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnprocessableContentError.swift; sourceTree = "<group>"; };
 		4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalServerError.swift; sourceTree = "<group>"; };
 		4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FcmTokenDto.swift; sourceTree = "<group>"; };
+		4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCompleteView.swift; sourceTree = "<group>"; };
 		4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalTargetAmountViewModel.swift; sourceTree = "<group>"; };
 		4A69C1492BE2CF6700A27B82 /* UserDefaultsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsHelper.swift; sourceTree = "<group>"; };
 		4A69C14B2BE2DBAC00A27B82 /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
@@ -776,6 +778,7 @@
 				4AE8F3AE2C3307940014F0D4 /* CustomDropDownMenuView.swift */,
 				4A148B5F2C370123005C6D4E /* CustomSpendingRow.swift */,
 				4A6C79D32C463C0B009463E4 /* CustomRectangleButton.swift */,
+				4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */,
 			);
 			path = CustomView;
 			sourceTree = "<group>";
@@ -1945,6 +1948,7 @@
 				4A148B602C370123005C6D4E /* CustomSpendingRow.swift in Sources */,
 				4AE8F3AD2C32AED30014F0D4 /* AppDelegate.swift in Sources */,
 				4A5789972BDC29FD00AFEB26 /* PreconditionFailedError.swift in Sources */,
+				4A60F64C2C595E4700805F2C /* CustomCompleteView.swift in Sources */,
 				D8E24D9C2BFDAFDA006E8046 /* CustomToggleStyle.swift in Sources */,
 				D8E24D8D2BFC7FE4006E8046 /* InquiryViewModel.swift in Sources */,
 				4A762AEF2B99A16B001C1188 /* MainView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
@@ -7,26 +7,10 @@ struct CompleteChangePwView: View {
     var body: some View {
         VStack {
             ScrollView {
-                Spacer().frame(height: 171 * DynamicSizeFactor.factor())
-                    
-                Image("icon_illust_completion")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
-                    
-                Spacer().frame(height: 17 * DynamicSizeFactor.factor())
-                    
-                Text("새로운 비밀번호가\n성공적으로 설정되었어요")
-                    .font(.H3SemiboldFont())
-                    .multilineTextAlignment(.center)
-                    
-                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-                    
-                Text("메인화면으로 돌아갈게요")
-                    .font(.H4MediumFont())
-                    .platformTextColor(color: Color("Gray04"))
-                    
-                Spacer()
+                CustomCompleteView(
+                    title: "새로운 비밀번호가\n성공적으로 설정되었어요",
+                    subTitle: "메인화면으로 돌아갈게요"
+                )
             }
                 
             CustomBottomButton(action: {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomCompleteView.swift
@@ -7,26 +7,27 @@ struct CustomCompleteView: View {
 
     var body: some View {
         VStack {
-                Spacer().frame(height: 171 * DynamicSizeFactor.factor())
+            Spacer().frame(height: 171 * DynamicSizeFactor.factor())
                     
-                Image("icon_illust_completion")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
+            Image("icon_illust_completion")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
                     
-                Spacer().frame(height: 17 * DynamicSizeFactor.factor())
+            Spacer().frame(height: 17 * DynamicSizeFactor.factor())
                     
-                Text(title)
-                    .font(.H3SemiboldFont())
-                    .multilineTextAlignment(.center)
+            Text(title)
+                .font(.H3SemiboldFont())
+                .multilineTextAlignment(.center)
+                .platformTextColor(color: Color("Gray07"))
                     
-                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+            Spacer().frame(height: 8 * DynamicSizeFactor.factor())
                     
-                Text(subTitle)
-                    .font(.H4MediumFont())
-                    .platformTextColor(color: Color("Gray04"))
+            Text(subTitle)
+                .font(.H4MediumFont())
+                .platformTextColor(color: Color("Gray04"))
                     
-                Spacer()
+            Spacer()
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomCompleteView.swift
@@ -1,0 +1,32 @@
+
+import SwiftUI
+
+struct CustomCompleteView: View {
+    let title: String
+    let subTitle: String
+
+    var body: some View {
+        VStack {
+                Spacer().frame(height: 171 * DynamicSizeFactor.factor())
+                    
+                Image("icon_illust_completion")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
+                    
+                Spacer().frame(height: 17 * DynamicSizeFactor.factor())
+                    
+                Text(title)
+                    .font(.H3SemiboldFont())
+                    .multilineTextAlignment(.center)
+                    
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                    
+                Text(subTitle)
+                    .font(.H4MediumFont())
+                    .platformTextColor(color: Color("Gray04"))
+                    
+                Spacer()
+        }
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomPopUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomPopUpView.swift
@@ -18,15 +18,17 @@ struct CustomPopUpView: View {
     let secondBtnLabel: String
     let secondBtnColor: Color
 
+    var heightSize: CGFloat? = nil
+
     var body: some View {
-        PopupContent(titleFontSize: 16, subtitleFontSize: 12,
-                     titleLabel: titleLabel,
+        PopupContent(titleLabel: titleLabel,
                      subTitleLabel: subTitleLabel,
                      firstBtnAction: firstBtnAction,
                      firstBtnLabel: firstBtnLabel,
                      secondBtnAction: secondBtnAction,
                      secondBtnLabel: secondBtnLabel,
                      secondBtnColor: secondBtnColor,
+                     heightSize: heightSize,
                      showingPopUp: $showingPopUp)
     }
 }
@@ -35,8 +37,6 @@ struct CustomPopUpView: View {
 
 extension CustomPopUpView {
     struct PopupContent: View {
-        var titleFontSize: CGFloat
-        var subtitleFontSize: CGFloat
         /// title 지정
         let titleLabel: String
         let subTitleLabel: String
@@ -49,6 +49,8 @@ extension CustomPopUpView {
         let secondBtnAction: () -> Void
         let secondBtnLabel: String
         let secondBtnColor: Color
+
+        let heightSize: CGFloat?
 
         @Binding var showingPopUp: Bool
 
@@ -103,10 +105,10 @@ extension CustomPopUpView {
                     .padding(.bottom, 11 * DynamicSizeFactor.factor())
                 }
                 .frame(maxWidth: 229 * DynamicSizeFactor.factor())
-                .background(Color.white)
+                .background(Color("White01"))
                 .cornerRadius(10)
             }
-            .frame(width: 229 * DynamicSizeFactor.factor(), height: 147 * DynamicSizeFactor.factor())
+            .frame(width: 229 * DynamicSizeFactor.factor(), height: (heightSize ?? 147) * DynamicSizeFactor.factor())
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/CompleteDeleteUserView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/CompleteDeleteUserView.swift
@@ -1,23 +1,21 @@
 
 import SwiftUI
 
-struct CompleteChangePwView: View {
-    @Binding var firstNaviLinkActive: Bool
+struct CompleteDeleteUserView: View {
+    @EnvironmentObject var authViewModel: AppViewModel
 
     var body: some View {
         VStack {
             ScrollView {
                 CustomCompleteView(
-                    title: "새로운 비밀번호가\n성공적으로 설정되었어요",
-                    subTitle: "메인화면으로 돌아갈게요"
+                    title: "탈퇴되었어요",
+                    subTitle: "이용해 주셔서 감사합니다"
                 )
             }
 
             CustomBottomButton(action: {
-                firstNaviLinkActive = false
-                NavigationUtil.popToRootView()
+                authViewModel.logout()
 
-                Log.debug("firstNaviLinkActive: \(firstNaviLinkActive)")
             }, label: "메인으로 돌아가기", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
@@ -8,6 +8,8 @@ struct ProfileMenuBarListView: View {
     @StateObject var userProfileViewModel = UserLogoutViewModel()
     @StateObject var userAccountViewModel = UserAccountViewModel()
 
+    @State private var navigateCompleteView = false
+
     var body: some View {
         ZStack {
             ScrollView {
@@ -53,13 +55,17 @@ struct ProfileMenuBarListView: View {
                 CustomPopUpView(showingPopUp: $showLogoutPopUp,
                                 titleLabel: "탈퇴하시겠어요?",
                                 subTitleLabel: "탈퇴 후에는 이용한 서비스\n내역이 모두 사라져요 😢",
-                                firstBtnAction: handleLogout,
+                                firstBtnAction: handleDeleteUserAccount,
                                 firstBtnLabel: "탈퇴하기",
                                 secondBtnAction: { self.showDeleteUserPopUp = false },
                                 secondBtnLabel: "더 써볼게요",
                                 secondBtnColor: Color("Gray05"),
                                 heightSize: 166
                 )
+            }
+
+            NavigationLink(destination: CompleteDeleteUserView(), isActive: $navigateCompleteView) {
+                EmptyView()
             }
         }
     }
@@ -81,7 +87,8 @@ struct ProfileMenuBarListView: View {
         userAccountViewModel.deleteUserAccountApi { success in
             DispatchQueue.main.async {
                 if success {
-                    authViewModel.logout()
+                    showDeleteUserPopUp = false
+                    navigateCompleteView = true
                 } else {
                     Log.error("Fail delete UserAccount")
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
@@ -2,9 +2,11 @@
 import SwiftUI
 
 struct ProfileMenuBarListView: View {
-    @State private var showingPopUp = false
+    @State private var showLogoutPopUp = false
+    @State private var showDeleteUserPopUp = false
     @EnvironmentObject var authViewModel: AppViewModel
     @StateObject var userProfileViewModel = UserLogoutViewModel()
+    @StateObject var userAccountViewModel = UserAccountViewModel()
 
     var body: some View {
         ZStack {
@@ -14,7 +16,7 @@ struct ProfileMenuBarListView: View {
 
                     Spacer().frame(height: 9 * DynamicSizeFactor.factor())
 
-                    ProfileSettingListView(showingPopUp: $showingPopUp)
+                    ProfileSettingListView(showLogoutPopUp: $showLogoutPopUp, showDeleteUserPopUp: $showDeleteUserPopUp)
                 }
                 .background(Color("Gray01"))
             }
@@ -33,16 +35,30 @@ struct ProfileMenuBarListView: View {
                 }
             }
 
-            if showingPopUp {
+            if showLogoutPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                CustomPopUpView(showingPopUp: $showingPopUp,
+                CustomPopUpView(showingPopUp: $showLogoutPopUp,
                                 titleLabel: "로그아웃",
                                 subTitleLabel: "로그아웃하시겠어요?",
-                                firstBtnAction: { self.showingPopUp = false },
+                                firstBtnAction: { self.showLogoutPopUp = false },
                                 firstBtnLabel: "취소",
                                 secondBtnAction: handleLogout,
                                 secondBtnLabel: "로그아웃",
                                 secondBtnColor: Color("Red03")
+                )
+            }
+
+            if showDeleteUserPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                CustomPopUpView(showingPopUp: $showLogoutPopUp,
+                                titleLabel: "탈퇴하시겠어요?",
+                                subTitleLabel: "탈퇴 후에는 이용한 서비스\n내역이 모두 사라져요 😢",
+                                firstBtnAction: handleLogout,
+                                firstBtnLabel: "탈퇴하기",
+                                secondBtnAction: { self.showDeleteUserPopUp = false },
+                                secondBtnLabel: "더 써볼게요",
+                                secondBtnColor: Color("Gray05"),
+                                heightSize: 166
                 )
             }
         }
@@ -53,9 +69,21 @@ struct ProfileMenuBarListView: View {
             DispatchQueue.main.async {
                 if success {
                     authViewModel.logout()
-                    showingPopUp = false
+                    showLogoutPopUp = false
                 } else {
                     Log.error("Fail logout")
+                }
+            }
+        }
+    }
+
+    func handleDeleteUserAccount() {
+        userAccountViewModel.deleteUserAccountApi { success in
+            DispatchQueue.main.async {
+                if success {
+                    authViewModel.logout()
+                } else {
+                    Log.error("Fail delete UserAccount")
                 }
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -4,9 +4,8 @@ import SwiftUI
 // MARK: - ProfileSettingListView
 
 struct ProfileSettingListView: View {
-    @EnvironmentObject var authViewModel: AppViewModel
-    @Binding var showingPopUp: Bool
-    @StateObject var userAccountViewModel = UserAccountViewModel()
+    @Binding var showLogoutPopUp: Bool
+    @Binding var showDeleteUserPopUp: Bool
     @State var firstNaviLinkActive = true
 
     @State private var activeNavigation: ProfileActiveNavigation?
@@ -56,8 +55,8 @@ struct ProfileSettingListView: View {
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
 
                     ProfileSettingSectionView(title: "기타", itemsWithActions: [
-                        ProfileSettingListItem(title: "로그아웃", icon: "icon_logout", action: { self.showingPopUp = true }),
-                        ProfileSettingListItem(title: "회원탈퇴", icon: "icon_cancelmembership", action: handleDeleteUserAccount)
+                        ProfileSettingListItem(title: "로그아웃", icon: "icon_logout", action: { self.showLogoutPopUp = true }),
+                        ProfileSettingListItem(title: "회원탈퇴", icon: "icon_cancelmembership", action: { self.showDeleteUserPopUp = true })
                     ])
                 }
             }
@@ -91,18 +90,6 @@ struct ProfileSettingListView: View {
             EditProfileListView()
         case .modifyPw:
             ProfileModifyPwView(firstNaviLinkActive: $firstNaviLinkActive, entryPoint: .modifyPw)
-        }
-    }
-
-    func handleDeleteUserAccount() {
-        userAccountViewModel.deleteUserAccountApi { success in
-            DispatchQueue.main.async {
-                if success {
-                    authViewModel.logout()
-                } else {
-                    Log.error("Fail delete UserAccount")
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## 작업 이유

- 회원 탈퇴 UI 구현

<br/>

## 작업 사항

### 1️⃣ 회원 탈퇴 UI 구현

이전에 회원 탈퇴시 팝업창 나오는 것 없이 바로 탈퇴 되었는데 팝업창과 탈퇴 완료 뷰를 거친 후 로그인 화면으로 돌아가도록 구현하였다.

비밀번호 찾기 완료 뷰와 동일한 ui이기 때문에 CustomCompleteView로 ui 로직을 분리하였다.

<img src = "https://github.com/user-attachments/assets/b4e34118-55de-41df-8c51-2fe1d0acde85" width = "300"/>

<img src = "https://github.com/user-attachments/assets/6f55af3b-dd1e-4fad-8751-3dbe99ae0fb2" width = "300"/>

<br/>

또한 CustomPopUpView를 사용하는데 회원 탈퇴 완료시에만 subTitleLabel이 두줄이어서 텍스트가 잘리는 문제가 있어서 heightSize를 입력받을 수 있도록 하였다.

- heightSize 사용하지 않는 경우

```swift
CustomPopUpView(showingPopUp: $showLogoutPopUp,
                titleLabel: "로그아웃",
                subTitleLabel: "로그아웃하시겠어요?",
                firstBtnAction: { self.showLogoutPopUp = false },
                firstBtnLabel: "취소",
                secondBtnAction: handleLogout,
                secondBtnLabel: "로그아웃",
                secondBtnColor: Color("Red03")
)
```

- heightSize 사용하는 경우

```swift
CustomPopUpView(showingPopUp: $showLogoutPopUp,
                titleLabel: "탈퇴하시겠어요?",
                subTitleLabel: "탈퇴 후에는 이용한 서비스\n내역이 모두 사라져요 😢",
                firstBtnAction: handleDeleteUserAccount,
                firstBtnLabel: "탈퇴하기",
                secondBtnAction: { self.showDeleteUserPopUp = false },
                secondBtnLabel: "더 써볼게요",
                secondBtnColor: Color("Gray05"),
                heightSize: 166
)
```


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

탈퇴 ui 구현 완료했습니다~~ 
CustomPopUpView에 heightSize 변수 추가된 거랑 CustomCompleteView로 ui 로직 분리한 거 확인 부탁드립니다!

<br/>

## 발견한 이슈
없음
