### PR TITLE
🎨 이름 변경하기 UI 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		D8180C082BE5168800F837FB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		D8180C0A2BE531C500F837FB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		D81D5A832C16B68D008E5939 /* DateFormatterUtil .swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D5A822C16B68D008E5939 /* DateFormatterUtil .swift */; };
+		D82E30572C5B3FB4004244F1 /* EditUsernameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82E30562C5B3FB4004244F1 /* EditUsernameView.swift */; };
 		D847A7892BEBABC700899AA3 /* FindPwContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847A7882BEBABC700899AA3 /* FindPwContentView.swift */; };
 		D847A78B2BEBABF600899AA3 /* FindPwPhoneVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847A78A2BEBABF600899AA3 /* FindPwPhoneVerificationView.swift */; };
 		D847A78D2BEBB35500899AA3 /* ResetPwViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847A78C2BEBB35500899AA3 /* ResetPwViewModel.swift */; };
@@ -286,13 +287,13 @@
 		D8E637502C06303D00D43BB6 /* MySpendingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E6374F2C06303D00D43BB6 /* MySpendingListViewModel.swift */; };
 		D8F9D7342C57E297005416FC /* handleDeleteButtonUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */; };
 		D8F9D7362C593B71005416FC /* PreparedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7352C593B71005416FC /* PreparedView.swift */; };
+		D8F9D73A2C59576B005416FC /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7392C59576B005416FC /* ImagePicker.swift */; };
 		D8F9D73D2C59FDFD005416FC /* UnreadAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D73C2C59FDFD005416FC /* UnreadAlarmView.swift */; };
 		D8F9D73F2C59FE12005416FC /* ReadAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D73E2C59FE12005416FC /* ReadAlarmView.swift */; };
 		D8F9D7412C59FE22005416FC /* NoAlarmArrivedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7402C59FE22005416FC /* NoAlarmArrivedView.swift */; };
 		D8F9D7432C5A0596005416FC /* ProfileAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7422C5A0596005416FC /* ProfileAlarmView.swift */; };
 		D8F9D7452C5A09ED005416FC /* ArrivedAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7442C5A09EC005416FC /* ArrivedAlarmView.swift */; };
 		D8F9D7472C5A1177005416FC /* AlarmList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7462C5A1177005416FC /* AlarmList.swift */; };
-		D8F9D73A2C59576B005416FC /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7392C59576B005416FC /* ImagePicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -533,6 +534,7 @@
 		D8180C032BE5081F00F837FB /* FindIdContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdContentView.swift; sourceTree = "<group>"; };
 		D8180C052BE5083500F837FB /* FindIdPhoneVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdPhoneVerificationView.swift; sourceTree = "<group>"; };
 		D81D5A822C16B68D008E5939 /* DateFormatterUtil .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatterUtil .swift"; sourceTree = "<group>"; };
+		D82E30562C5B3FB4004244F1 /* EditUsernameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUsernameView.swift; sourceTree = "<group>"; };
 		D847A7882BEBABC700899AA3 /* FindPwContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPwContentView.swift; sourceTree = "<group>"; };
 		D847A78A2BEBABF600899AA3 /* FindPwPhoneVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPwPhoneVerificationView.swift; sourceTree = "<group>"; };
 		D847A78C2BEBB35500899AA3 /* ResetPwViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPwViewModel.swift; sourceTree = "<group>"; };
@@ -578,13 +580,13 @@
 		D8E6374F2C06303D00D43BB6 /* MySpendingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpendingListViewModel.swift; sourceTree = "<group>"; };
 		D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = handleDeleteButtonUtil.swift; sourceTree = "<group>"; };
 		D8F9D7352C593B71005416FC /* PreparedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PreparedView.swift; path = "pennyway-client-iOS/View/TabView/PreparedView.swift"; sourceTree = SOURCE_ROOT; };
+		D8F9D7392C59576B005416FC /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		D8F9D73C2C59FDFD005416FC /* UnreadAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D73E2C59FE12005416FC /* ReadAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D7402C59FE22005416FC /* NoAlarmArrivedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoAlarmArrivedView.swift; sourceTree = "<group>"; };
 		D8F9D7422C5A0596005416FC /* ProfileAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D7442C5A09EC005416FC /* ArrivedAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrivedAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D7462C5A1177005416FC /* AlarmList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmList.swift; sourceTree = "<group>"; };
-		D8F9D7392C59576B005416FC /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		F0F9541D34A887D64D713E30 /* Pods_pennyway_client_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pennyway_client_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -1179,6 +1181,7 @@
 				4A6C79D12C46310B009463E4 /* EditProfileListView.swift */,
 				4A6C79D52C463DB1009463E4 /* EditIdView.swift */,
 				4A6C79DC2C46D28B009463E4 /* EditPhoneNumberView.swift */,
+				D82E30562C5B3FB4004244F1 /* EditUsernameView.swift */,
 			);
 			path = EditProfileView;
 			sourceTree = "<group>";
@@ -2121,6 +2124,7 @@
 				4AB5AB502BB4A8CB00D2C9EA /* ApiStatusLogger.swift in Sources */,
 				D88832982BBC60EC00F49B27 /* TextAutocapitalization.swift in Sources */,
 				4A4703902BCEA4D700AEE04E /* LinkOAuthToAccountRequestDto.swift in Sources */,
+				D82E30572C5B3FB4004244F1 /* EditUsernameView.swift in Sources */,
 				D88832A02BBC615100F49B27 /* ErrorCodeContentView.swift in Sources */,
 				4A47038E2BCEA47600AEE04E /* OAuthVerificationRequestDto.swift in Sources */,
 				4A6C79E82C46DFBE009463E4 /* CodeInputField.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditUsernameView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditUsernameView.swift
@@ -1,0 +1,57 @@
+
+import SwiftUI
+
+struct EditUsernameView: View {
+    @StateObject var formViewModel = EditIdViewModel()
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            VStack {
+                Spacer().frame(height: 35 * DynamicSizeFactor.factor())
+
+                CustomInputView(inputText: $formViewModel.username, titleText: "이름 입력", placeholder: "최대 8자로 입력해주세요", onCommit: {
+                    formViewModel.validateName()
+                }, isSecureText: false, isCustom: false)
+
+                Spacer().frame(height: 12 * DynamicSizeFactor.factor())
+
+                HStack {
+                    Text("현재 이름 : 붕어빵")
+                        .font(.B1MediumFont())
+                        .platformTextColor(color: Color("Gray05"))
+
+                    Spacer()
+
+                    Text("0/8")
+                        .font(.B1MediumFont())
+                        .platformTextColor(color: Color("Gray03"))
+                }
+                .padding(.horizontal, 20)
+
+                Spacer()
+
+                CustomBottomButton(action: {}, label: "완료", isFormValid: $formViewModel.isFormValid)
+                    .padding(.bottom, 34 * DynamicSizeFactor.factor())
+            }
+        }
+        .edgesIgnoringSafeArea(.bottom)
+        .setTabBarVisibility(isHidden: true)
+        .navigationBarColor(UIColor(named: "White01"), title: "이름 수정하기")
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                HStack {
+                    NavigationBackButton()
+                        .padding(.leading, 5)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+
+                }.offset(x: -10)
+            }
+        }
+    }
+}
+
+#Preview {
+    EditUsernameView()
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditUsernameView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditUsernameView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct EditUsernameView: View {
     @StateObject var formViewModel = EditIdViewModel()
 
+    private let maxLength = 8
+
     var body: some View {
         ZStack(alignment: .leading) {
             VStack {
@@ -12,6 +14,12 @@ struct EditUsernameView: View {
                 CustomInputView(inputText: $formViewModel.username, titleText: "이름 입력", placeholder: "최대 8자로 입력해주세요", onCommit: {
                     formViewModel.validateName()
                 }, isSecureText: false, isCustom: false)
+                    .onChange(of: formViewModel.username) { newValue in
+                        if newValue.count > maxLength {
+                            formViewModel.username = String(newValue.prefix(maxLength))
+                        }
+                        formViewModel.validateName()
+                    }
 
                 Spacer().frame(height: 12 * DynamicSizeFactor.factor())
 
@@ -22,9 +30,13 @@ struct EditUsernameView: View {
 
                     Spacer()
 
-                    Text("0/8")
-                        .font(.B1MediumFont())
-                        .platformTextColor(color: Color("Gray03"))
+                    HStack(spacing: 0) {
+                        Text("\(formViewModel.username.count)")
+                            .platformTextColor(color: formViewModel.username.isEmpty ? Color("Gray03") : Color("Gray05"))
+                        Text("/\(maxLength)")
+                            .platformTextColor(color: Color("Gray03"))
+                    }
+                    .font(.B1MediumFont())
                 }
                 .padding(.horizontal, 20)
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -3,12 +3,13 @@ import SwiftUI
 
 struct ProfileMainView: View {
     @State private var isSelectedToolBar = false
+    @State private var navigateToEditUsername = false
 
     var body: some View {
         NavigationAvailable {
             ScrollView {
                 VStack {
-                    ProfileUserInfoView()
+                    ProfileUserInfoView(navigateToEditUsername: $navigateToEditUsername)
 
                     Spacer().frame(height: 33 * DynamicSizeFactor.factor())
 
@@ -56,6 +57,10 @@ struct ProfileMainView: View {
                 }
             }
             NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
+                EmptyView()
+            }.hidden()
+
+            NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
                 EmptyView()
             }.hidden()
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileUserInfoView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileUserInfoView.swift
@@ -9,6 +9,8 @@ struct ProfileUserInfoView: View {
     @State var selectedUIImage: UIImage?
     @State var image: Image?
 
+    @Binding var navigateToEditUsername: Bool
+
     private func loadUserData() {
         if let userData = getUserData() {
             name = userData.name // 사용자 이름
@@ -55,7 +57,9 @@ struct ProfileUserInfoView: View {
 
             Spacer().frame(height: 9 * DynamicSizeFactor.factor())
 
-            Button(action: {}, label: {
+            Button(action: {
+                navigateToEditUsername = true
+            }, label: {
                 HStack(alignment: .center, spacing: 8 * DynamicSizeFactor.factor()) {
                     Text("이름 수정하기")
                         .font(.B2MediumFont())

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/ProfileViewModel/EditIdViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/ProfileViewModel/EditIdViewModel.swift
@@ -24,11 +24,7 @@ class EditIdViewModel: ObservableObject {
     }
 
     func validateForm() {
-//        if !isDuplicateId && !showErrorId && !inputId.isEmpty {
-//            isFormValid = true
-//        } else {
-//            isFormValid = false
-//        }
+
         if !isDuplicateId && !inputId.isEmpty {
             if !showErrorId {
                 isFormValid = true

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/ProfileViewModel/EditIdViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/ProfileViewModel/EditIdViewModel.swift
@@ -3,7 +3,9 @@
 import SwiftUI
 
 class EditIdViewModel: ObservableObject {
+    @Published var username = ""
     @Published var inputId = ""
+    @Published var showErrorName = false
     @Published var showErrorId = false
     @Published var isDuplicateId = false
     @Published var isFormValid = false
@@ -16,11 +18,25 @@ class EditIdViewModel: ObservableObject {
         }
     }
 
+    func validateName() {
+        let nameRegex = "^[가-힣a-zA-Z]{2,8}$"
+        showErrorName = !NSPredicate(format: "SELF MATCHES %@", nameRegex).evaluate(with: username)
+    }
+
     func validateForm() {
-        if !isDuplicateId && !showErrorId && !inputId.isEmpty {
-            isFormValid = true
-        } else {
-            isFormValid = false
+//        if !isDuplicateId && !showErrorId && !inputId.isEmpty {
+//            isFormValid = true
+//        } else {
+//            isFormValid = false
+//        }
+        if !isDuplicateId && !inputId.isEmpty {
+            if !showErrorId {
+                isFormValid = true
+            } else if !showErrorName {
+                isFormValid = true
+            } else {
+                isFormValid = false
+            }
         }
     }
 


### PR DESCRIPTION
## 작업 이유
- 이름 변경하기 UI 구현

<br/>

## 작업 사항
### **1️⃣ 이름 변경하기 UI 구현**
프로필에서 이름 수정하기 버튼을 누르면 연결되는 페이지로 이름 변경 UI를 구현하였다.

**동작과정**
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-01 at 14 51 28](https://github.com/user-attachments/assets/13429553-3136-4ca2-b616-de0a2490f872)
- 최대글자수 8자가 넘어가면 입력이 막혀야 하므로 onChange를 통해 뷰모델에 username을 count하여 maxLength를 넘어가면 앞의 8글자만 보이도록 막아두었다.
- CustomBottomButton의 활성화 조건이랑 액션은 api 연동하면서 같이 작업하기 위해 보류하였다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
1번 UI 구현했습니다! 아이디 수정 부분 보니까 EditIdViewModel로 아이디에 대한 뷰모델을 따로 관리하고 계시던데 수정권한이 있는 뷰모델로 통합하여 사용하면 어떨까요?? 

수정 권한이 있는 뷰들이 많지 않아서 문제는 없을거 같습니다! 
그리고 수정하게 된다면 파일이름도 EditViewModel로 하는게 좋을거 같다는 생각이 드는데 어떻게 생각하시나요?

<br/>

## 발견한 이슈
x