### PR TITLE
📍 수정하기 뷰 placeholder처리 및 아이디/비밀번호 찾기 에러 핸들링

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -8,7 +8,6 @@ struct FindIdFormView: View {
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var isNavigateToFindIDView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
-//    @StateObject var findUserNameViewModel = FindUserNameViewModel()
 
     var body: some View {
         ZStack {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -8,7 +8,7 @@ struct FindIdFormView: View {
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var isNavigateToFindIDView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
-    @StateObject var findUserNameViewModel = FindUserNameViewModel()
+//    @StateObject var findUserNameViewModel = FindUserNameViewModel()
 
     var body: some View {
         ZStack {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct FindIdFormView: View {
     @State private var showCodeErrorPopUp = false
     @State private var showManyRequestPopUp = false
+    @State private var showNotFoundUserPopUp = false
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var isNavigateToFindIDView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
@@ -35,6 +36,11 @@ struct FindIdFormView: View {
             if showManyRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
+            }
+
+            if showNotFoundUserPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showNotFoundUserPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -75,6 +81,9 @@ struct FindIdFormView: View {
             Log.debug("else문 시작")
             if phoneVerificationViewModel.showErrorVerificationCode {
                 showCodeErrorPopUp = true
+            } else if phoneVerificationViewModel.showErrorExistingUser {
+                showCodeErrorPopUp = true
+                Log.debug("인증번호 잘못입력함: \(showCodeErrorPopUp)")
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -28,9 +28,9 @@ struct FindIdFormView: View {
                     EmptyView()
                 }.hidden()
             }
-            if showCodeErrorPopUp == true {
-                Color.black.opacity(0.1).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+            if showNotFoundUserPopUp == true {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showNotFoundUserPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
             }
 
             if showManyRequestPopUp {
@@ -38,9 +38,9 @@ struct FindIdFormView: View {
                 ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
 
-            if showNotFoundUserPopUp {
+            if showCodeErrorPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showNotFoundUserPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
             }
         }
         .edgesIgnoringSafeArea(.bottom)
@@ -66,11 +66,12 @@ struct FindIdFormView: View {
     }
 
     private func checkFormValid() {
-        if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser &&
+        if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && 
             phoneVerificationViewModel.isFormValid
         {
             Log.debug("if문 시작")
             showCodeErrorPopUp = false
+            showNotFoundUserPopUp = false
             isNavigateToFindIDView = true
             viewModel.continueButtonTapped()
 
@@ -79,11 +80,14 @@ struct FindIdFormView: View {
 
         } else {
             Log.debug("else문 시작")
-            if phoneVerificationViewModel.showErrorVerificationCode {
+
+            if phoneVerificationViewModel.showErrorExistingUser {
+                showNotFoundUserPopUp = true
+                Log.debug("사용자 없음: \(showNotFoundUserPopUp)")
+
+            } else if phoneVerificationViewModel.showErrorVerificationCode {
                 showCodeErrorPopUp = true
-            } else if phoneVerificationViewModel.showErrorExistingUser {
-                showCodeErrorPopUp = true
-                Log.debug("인증번호 잘못입력함: \(showCodeErrorPopUp)")
+                Log.debug("인증번호 오류: \(showCodeErrorPopUp)")
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwPhoneVerificationView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct FindPwPhoneVerificationView: View {
     @ObservedObject var viewModel: PhoneVerificationViewModel
     @Binding var showManyRequestPopUp: Bool
+
     @State private var isFindUser = true
 
     var body: some View {
@@ -45,11 +46,13 @@ struct FindPwPhoneVerificationView: View {
                     }
                     Button(action: {
                         if isFindUser {
-                            viewModel.requestPwVerificationCodeApi { if viewModel.showErrorApiRequest {
-                                showManyRequestPopUp = true
-                            } else {
-                                viewModel.judgeTimerRunning()
-                            }
+                            viewModel.requestPwVerificationCodeApi {
+                                if viewModel.showErrorApiRequest {
+                                    showManyRequestPopUp = true
+
+                                } else {
+                                    viewModel.judgeTimerRunning()
+                                }
                             }
                         }
                     }, label: {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -4,7 +4,6 @@ struct FindPwView: View {
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var showCodeErrorPopUp = false
     @State private var showManyRequestPopUp = false
-    @State private var showNotFoundUserPopUp = false
     @State private var isNavigateToFindPwView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @State private var isVerificationError: Bool = false
@@ -22,27 +21,25 @@ struct FindPwView: View {
                 CustomBottomButton(action: {
                     continueButtonAction()
                 }, label: "확인", isFormValid: $phoneVerificationViewModel.isFormValid)
-                
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
                 
                 NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel(), firstNaviLinkActive: .constant(true), entryPoint: .findPw), isActive: $isNavigateToFindPwView) {
                     EmptyView()
                 }.hidden()
             }
+            
             if showCodeErrorPopUp == true {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $showCodeErrorPopUp, titleLabel: "잘못된 인증번호예요", subLabel: "다시 한번 확인해주세요")
             }
             if showManyRequestPopUp {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
-            if showNotFoundUserPopUp {
+            if phoneVerificationViewModel.showErrorExistingUser {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                ErrorCodePopUpView(showingPopUp: $showNotFoundUserPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+                ErrorCodePopUpView(showingPopUp: $phoneVerificationViewModel.showErrorExistingUser, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
             }
-            
-            
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationTitle(Text("비밀번호 찾기"))
@@ -71,7 +68,6 @@ struct FindPwView: View {
     private func continueButtonAction() {
         phoneVerificationViewModel.requestPwVerifyVerificationCodeApi {
             checkFormValid()
-            Log.debug("requestPwVerifyVerificationCodeApi 실행")
         }
     }
     
@@ -79,23 +75,13 @@ struct FindPwView: View {
         if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && phoneVerificationViewModel.isFormValid {
             Log.debug("비밀번호 찾기 checkFormValid if문 시작")
             showCodeErrorPopUp = false
-            showNotFoundUserPopUp = false
             isNavigateToFindPwView = true
             viewModel.continueButtonTapped()
 
             RegistrationManager.shared.code = phoneVerificationViewModel.code
             
         } else {
-            Log.debug("비밀번호 찾기 checkFormValid else문 시작")
-//            if phoneVerificationViewModel.showErrorVerificationCode {
-//                showCodeErrorPopUp = true
-//                isVerificationError = true
-//            }
-            if phoneVerificationViewModel.showErrorExistingUser {
-                showNotFoundUserPopUp = true
-                Log.debug("사용자 없음: \(showNotFoundUserPopUp)")
-
-            } else if phoneVerificationViewModel.showErrorVerificationCode {
+            if phoneVerificationViewModel.showErrorVerificationCode {
                 showCodeErrorPopUp = true
                 isVerificationError = true
                 Log.debug("인증번호 오류: \(showCodeErrorPopUp)")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -4,6 +4,7 @@ struct FindPwView: View {
     @StateObject var phoneVerificationViewModel = PhoneVerificationViewModel()
     @State private var showCodeErrorPopUp = false
     @State private var showManyRequestPopUp = false
+    @State private var showNotFoundUserPopUp = false
     @State private var isNavigateToFindPwView: Bool = false
     @StateObject var viewModel = SignUpNavigationViewModel()
     @State private var isVerificationError: Bool = false
@@ -36,6 +37,12 @@ struct FindPwView: View {
                 Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 ErrorCodePopUpView(showingPopUp: $showManyRequestPopUp, titleLabel: "인증 요청 제한 횟수를 초과했어요", subLabel: "24시간 후에 다시 시도해주세요")
             }
+            if showNotFoundUserPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                ErrorCodePopUpView(showingPopUp: $showNotFoundUserPopUp, titleLabel: "사용자 정보를 찾을 수 없어요", subLabel: "다시 한번 확인해주세요")
+            }
+            
+            
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationTitle(Text("비밀번호 찾기"))
@@ -72,6 +79,7 @@ struct FindPwView: View {
         if !phoneVerificationViewModel.showErrorVerificationCode && !phoneVerificationViewModel.showErrorExistingUser && phoneVerificationViewModel.isFormValid {
             Log.debug("비밀번호 찾기 checkFormValid if문 시작")
             showCodeErrorPopUp = false
+            showNotFoundUserPopUp = false
             isNavigateToFindPwView = true
             viewModel.continueButtonTapped()
 
@@ -79,9 +87,18 @@ struct FindPwView: View {
             
         } else {
             Log.debug("비밀번호 찾기 checkFormValid else문 시작")
-            if phoneVerificationViewModel.showErrorVerificationCode {
+//            if phoneVerificationViewModel.showErrorVerificationCode {
+//                showCodeErrorPopUp = true
+//                isVerificationError = true
+//            }
+            if phoneVerificationViewModel.showErrorExistingUser {
+                showNotFoundUserPopUp = true
+                Log.debug("사용자 없음: \(showNotFoundUserPopUp)")
+
+            } else if phoneVerificationViewModel.showErrorVerificationCode {
                 showCodeErrorPopUp = true
                 isVerificationError = true
+                Log.debug("인증번호 오류: \(showCodeErrorPopUp)")
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -14,6 +14,8 @@ enum EntryPoint {
 
 struct AddSpendingHistoryView: View {
     @StateObject var viewModel = AddSpendingHistoryViewModel()
+    @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
+
     @ObservedObject var spendingHistoryViewModel: SpendingHistoryViewModel
     @State var spendingId: Int = 0
     @State var newDetails = AddSpendingHistoryRequestDto(amount: 0, categoryId: 0, icon: "", spendAt: "", accountName: "", memo: "")
@@ -27,7 +29,7 @@ struct AddSpendingHistoryView: View {
         ZStack {
             VStack {
                 ScrollView {
-                    AddSpendingInputFormView(viewModel: viewModel, spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, entryPoint: entryPoint, spendingId: $spendingId)
+                    AddSpendingInputFormView(viewModel: viewModel, spendingHistoryViewModel: spendingHistoryViewModel, spendingCategoryViewModel: spendingCategoryViewModel, clickDate: $clickDate, entryPoint: entryPoint, spendingId: $spendingId)
                 }
                 Spacer()
 
@@ -97,5 +99,5 @@ struct AddSpendingHistoryView: View {
 }
 
 #Preview {
-    AddSpendingHistoryView(spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: .constant(Date()), isPresented: .constant(true), entryPoint: .main)
+    AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: .constant(Date()), isPresented: .constant(true), entryPoint: .main)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct AddSpendingInputFormView: View {
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @ObservedObject var spendingHistoryViewModel: SpendingHistoryViewModel
+    @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
 
     @Binding var clickDate: Date?
     var entryPoint: EntryPoint
@@ -32,6 +33,22 @@ struct AddSpendingInputFormView: View {
                                 name: spendingDetail.category.name,
                                 icon: convertToSpendingCategoryData(from: spendingDetail.category)?.icon ?? CategoryIconName(baseName: .etc, state: .on)
                             )
+                            viewModel.consumerText = spendingDetail.accountName
+                            viewModel.memoText = spendingDetail.memo
+                            viewModel.validateForm()
+                        }
+                    } else {
+                        if let spendingDetail = spendingCategoryViewModel.dailyDetailSpendings.first {
+//                        if let spendingDetail = spendingCategoryViewModel.getSpendingDetail(by: spendingId) {
+                            viewModel.amountSpentText = String(spendingDetail.amount)
+                            spendingId = spendingDetail.id
+                            viewModel.selectedCategory = SpendingCategoryData(
+                                id: spendingDetail.category.id,
+                                isCustom: spendingDetail.category.isCustom,
+                                name: spendingDetail.category.name,
+                                icon: convertToSpendingCategoryData(from: spendingDetail.category)?.icon ?? CategoryIconName(baseName: .etc, state: .on)
+                            )
+                            viewModel.clickDate = DateFormatterUtil.dateFromString(spendingDetail.spendAt)
                             viewModel.consumerText = spendingDetail.accountName
                             viewModel.memoText = spendingDetail.memo
                             viewModel.validateForm()
@@ -113,7 +130,7 @@ struct AddSpendingInputFormView: View {
                 Spacer()
                 
                 HStack(spacing: 0) {
-                    Text(Date.getFormattedDate(from: clickDate ?? viewModel.selectedDate))
+                    Text(Date.getFormattedDate(from: (clickDate ?? viewModel.clickDate) ?? viewModel.selectedDate))
                         .font(.B1MediumFont())
                         .platformTextColor(color: Color("Gray07"))
                    

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
@@ -39,7 +39,7 @@ struct AddSpendingInputFormView: View {
                             viewModel.validateForm()
                         }
                     } else {
-                        //카테고리 리스트로 진입했을 경우
+                        // 카테고리 리스트로 진입했을 경우
                         if let spendingDetail = spendingCategoryViewModel.dailyDetailSpendings.first {
                             viewModel.amountSpentText = String(spendingDetail.amount)
                             spendingId = spendingDetail.id

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
@@ -23,6 +23,7 @@ struct AddSpendingInputFormView: View {
             Spacer().frame(height: 31 * DynamicSizeFactor.factor())
             AmountInputView(viewModel: viewModel, title: titleCustomTextList[0], placeholder: "소비 금액을 작성해 주세요", baseAttribute: baseAttribute, stringAttribute: stringAttribute)
                 .onAppear {
+                    // 지출내역리스트나 소비내역 바텀시트를 통해 진입한 경우
                     if entryPoint == .detailSpendingView, let clickDate = clickDate {
                         if let spendingDetail = spendingHistoryViewModel.filteredSpendings(for: clickDate).first {
                             viewModel.amountSpentText = String(spendingDetail.amount)
@@ -38,8 +39,8 @@ struct AddSpendingInputFormView: View {
                             viewModel.validateForm()
                         }
                     } else {
+                        //카테고리 리스트로 진입했을 경우
                         if let spendingDetail = spendingCategoryViewModel.dailyDetailSpendings.first {
-//                        if let spendingDetail = spendingCategoryViewModel.getSpendingDetail(by: spendingId) {
                             viewModel.amountSpentText = String(spendingDetail.amount)
                             spendingId = spendingDetail.id
                             viewModel.selectedCategory = SpendingCategoryData(

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -40,6 +40,7 @@ struct CategorySpendingListView: View {
 
                                     }, label: {
                                         CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
+                                            .contentShape(Rectangle())
                                     })
                                     .buttonStyle(PlainButtonStyle())
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
@@ -8,6 +8,7 @@ struct DetailSpendingView: View {
     @State var listArray: [String] = ["수정하기", "내역 삭제"]
     @State var navigateModifySpendingHistoryView = false
     @StateObject var spendingHistoryViewModel = SpendingHistoryViewModel()
+
     @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
     @Binding var clickDate: Date?
     @Binding var spendingId: Int?
@@ -128,7 +129,7 @@ struct DetailSpendingView: View {
             }, alignment: .topTrailing
         )
 
-        NavigationLink(destination: AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: .constant(false), entryPoint: .detailSpendingView), isActive: $navigateModifySpendingHistoryView) {}
+        NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: spendingCategoryViewModel, spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: .constant(false), entryPoint: .detailSpendingView), isActive: $navigateModifySpendingHistoryView) {}
     }
 
     private func loadDataForSelectedDate() {
@@ -163,8 +164,8 @@ struct DetailSpendingView: View {
             isSelectedCategory = false
         }
     }
-
-    private func getSpendingDetail(by id: Int) -> IndividualSpending? {
-        return spendingHistoryViewModel.getSpendingDetail(by: id) ?? spendingCategoryViewModel.getSpendingDetail(by: id)
-    }
+//
+//    private func getSpendingDetail(by id: Int) -> IndividualSpending? {
+//        return spendingHistoryViewModel.getSpendingDetail(by: id) ?? spendingCategoryViewModel.getSpendingDetail(by: id)
+//    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
@@ -108,56 +108,25 @@ struct DetailSpendingView: View {
             VStack(alignment: .center) {
                 Spacer().frame(height: 6 * DynamicSizeFactor.factor())
                 if isSelectedCategory {
-                    ZStack {
-                        Rectangle()
-                            .cornerRadius(4)
-                            .platformTextColor(color: Color("White01"))
-                            .padding(.vertical, 8)
-                            .shadow(color: .black.opacity(0.06), radius: 7, x: 0, y: 0)
-
-                        VStack(alignment: .leading, spacing: 0) {
-                            ForEach(listArray, id: \.self) { item in
-                                Button(action: {
-                                    self.selectedItem = item
-                                    if item == "수정하기" {
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { // 버튼 액션 보이기 위해 임시로 0.2초 지연 후 뷰 넘어가도록 설정
-                                            navigateModifySpendingHistoryView = true
-                                        }
-                                    } else if item == "내역 삭제" {
-                                        showingPopUp = true
-                                        isSelectedCategory = false
-                                    }
-                                }, label: {
-                                    ZStack(alignment: .leading) {
-                                        Rectangle()
-                                            .platformTextColor(color: .clear)
-                                            .frame(width: 120, height: 22)
-                                            .cornerRadius(3)
-
-                                        Text(item)
-                                            .font(.B2MediumFont())
-                                            .multilineTextAlignment(.leading)
-                                            .platformTextColor(color: selectedItem == item ? Color("Gray05") : Color("Gray04"))
-                                            .padding(.leading, 3)
-                                    }
-                                    .padding(.horizontal, 7)
-                                    .padding(.vertical, 9)
-                                    .background(selectedItem == item ? Color("Gray02") : Color("White01"))
-
-                                })
-
-                                .buttonStyle(PlainButtonStyle())
+                    CustomDropdownMenuView(
+                        isClickMenu: $isSelectedCategory,
+                        selectedMenu: $selectedItem,
+                        listArray: listArray,
+                        onItemSelected: { item in
+                            if item == "수정하기" {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { // 버튼 액션 보이기 위해 임시로 0.2초 지연 후 뷰 넘어가도록 설정
+                                    navigateModifySpendingHistoryView = true
+                                }
+                            } else { // 내역 삭제일 경우
+                                showingPopUp = true
+                                isSelectedCategory = false
                             }
-                            .cornerRadius(3)
+                            Log.debug("Selected item: \(item)")
                         }
-                        .padding(.vertical, 12 * DynamicSizeFactor.factor())
-                        .zIndex(5)
-                    }
-                    .frame(width: 125 * DynamicSizeFactor.factor(), height: 47 * DynamicSizeFactor.factor())
-                    .zIndex(5)
-                    .offset(x: 175 * DynamicSizeFactor.factor(), y: 13 * DynamicSizeFactor.factor())
+                    ).padding(.trailing, 20)
                 }
-            }, alignment: .topLeading)
+            }, alignment: .topTrailing
+        )
 
         NavigationLink(destination: AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: .constant(false), entryPoint: .detailSpendingView), isActive: $navigateModifySpendingHistoryView) {}
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
@@ -37,7 +37,7 @@ struct NoSpendingHistoryView: View {
                     .background(Color("Mint03"))
                     .cornerRadius(30)
 
-                    NavigationLink(destination: AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .detailSheet), isActive: $navigateToAddSpendingHistory) {
+                    NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .detailSheet), isActive: $navigateToAddSpendingHistory) {
                         EmptyView()
                     }.hidden()
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/EditSpendingDetailView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/EditSpendingDetailView.swift
@@ -56,6 +56,7 @@ struct EditSpendingDetailView: View {
 
                                 CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
                                     .padding(.leading, 13 * DynamicSizeFactor.factor())
+                                    .contentShape(Rectangle())
                             }
                             .frame(maxWidth: .infinity)
                             .padding(.leading, 14)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -102,7 +102,7 @@ struct SpendingDetailSheetView: View {
             }
             .fullScreenCover(isPresented: $showAddSpendingHistoryView) {
                 NavigationAvailable {
-                    AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $showAddSpendingHistoryView, entryPoint: .detailSheet)
+                    AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $showAddSpendingHistoryView, entryPoint: .detailSheet)
                 }
             }
             .fullScreenCover(isPresented: $showDetailSpendingView) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -85,6 +85,7 @@ struct SpendingDetailSheetView: View {
                                     showDetailSpendingView = true
                                 }, label: {
                                     CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
+                                        .contentShape(Rectangle())
                                 })
                                 .buttonStyle(PlainButtonStyle())
                                 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -115,7 +115,7 @@ struct SpendingManagementMainView: View {
                 }
             }
 
-            NavigationLink(destination: AddSpendingHistoryView(spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
+            NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
                 EmptyView()
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
@@ -149,8 +149,11 @@ class PhoneVerificationViewModel: ObservableObject {
                     if let StatusSpecificError = error as? StatusSpecificError {
                         Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
                         if StatusSpecificError.domainError == .unauthorized && StatusSpecificError.code == UnauthorizedErrorCode.missingOrInvalidCredentials.rawValue {
+                            self.showErrorVerificationCode = true
+                        } else if StatusSpecificError.domainError == .notFound && StatusSpecificError.code == NotFoundErrorCode.resourceNotFound.rawValue {
                             self.showErrorExistingUser = true
                         }
+
                     } else {
                         Log.error("Network request failed: \(error)")
                     }
@@ -170,14 +173,17 @@ class PhoneVerificationViewModel: ObservableObject {
                 switch result {
                 case let .success(data):
                     if data != nil {
-                        self.receivePwVerifyVerificationCode(result: result, completion: completion)
+                        self.handleFindUserNameApi(result: result, completion: completion)
                     }
                 case let .failure(error):
                     if let StatusSpecificError = error as? StatusSpecificError {
                         Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
                         if StatusSpecificError.domainError == .unauthorized && StatusSpecificError.code == UnauthorizedErrorCode.missingOrInvalidCredentials.rawValue {
+                            self.showErrorVerificationCode = true
+                        } else if StatusSpecificError.domainError == .notFound && StatusSpecificError.code == NotFoundErrorCode.resourceNotFound.rawValue {
                             self.showErrorExistingUser = true
                         }
+
                     } else {
                         Log.error("Network request failed: \(error)")
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
@@ -82,7 +82,7 @@ class PhoneVerificationViewModel: ObservableObject {
 
     // MARK: 아이디 찾기 인증번호 코드 요청 API
 
-    func requestUserNameVerificationCodeApi(completion: @escaping () -> Void) { // 아이디 찾기 번호 인증
+    func requestUserNameVerificationCodeApi(completion: @escaping () -> Void) {
         validatePhoneNumber()
         requestVerificationCodeAction()
         let usernameVerificationCodeDto = VerificationCodeRequestDto(phone: formattedPhoneNumber)
@@ -140,6 +140,21 @@ class PhoneVerificationViewModel: ObservableObject {
         if isFormValid {
             AuthAlamofire.shared.findUserName(verificationDto) { result in
                 self.handleFindUserNameApi(result: result, completion: completion)
+                switch result {
+                case let .success(data):
+                    if data != nil {
+                        self.handleFindUserNameApi(result: result, completion: completion)
+                    }
+                case let .failure(error):
+                    if let StatusSpecificError = error as? StatusSpecificError {
+                        Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                        if StatusSpecificError.domainError == .unauthorized && StatusSpecificError.code == UnauthorizedErrorCode.missingOrInvalidCredentials.rawValue {
+                            self.showErrorExistingUser = true
+                        }
+                    } else {
+                        Log.error("Network request failed: \(error)")
+                    }
+                }
             }
         }
     }
@@ -152,7 +167,21 @@ class PhoneVerificationViewModel: ObservableObject {
 
         if isFormValid {
             AuthAlamofire.shared.receivePwVerifyVerificationCode(verificationDto) { result in
-                self.receivePwVerifyVerificationCode(result: result, completion: completion)
+                switch result {
+                case let .success(data):
+                    if data != nil {
+                        self.receivePwVerifyVerificationCode(result: result, completion: completion)
+                    }
+                case let .failure(error):
+                    if let StatusSpecificError = error as? StatusSpecificError {
+                        Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
+                        if StatusSpecificError.domainError == .unauthorized && StatusSpecificError.code == UnauthorizedErrorCode.missingOrInvalidCredentials.rawValue {
+                            self.showErrorExistingUser = true
+                        }
+                    } else {
+                        Log.error("Network request failed: \(error)")
+                    }
+                }
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/PhoneVerificationViewModel/PhoneVerificationViewModel.swift
@@ -165,15 +165,16 @@ class PhoneVerificationViewModel: ObservableObject {
     // MARK: 비밀번호 찾기 번호 검증 API
 
     func requestPwVerifyVerificationCodeApi(completion: @escaping () -> Void) {
-        validatePhoneNumber()
         let verificationDto = VerificationRequestDto(phone: formattedPhoneNumber, code: code)
 
         if isFormValid {
             AuthAlamofire.shared.receivePwVerifyVerificationCode(verificationDto) { result in
+                self.receivePwVerifyVerificationCode(result: result, completion: completion)
+
                 switch result {
                 case let .success(data):
                     if data != nil {
-                        self.handleFindUserNameApi(result: result, completion: completion)
+                        self.receivePwVerifyVerificationCode(result: result, completion: completion)
                     }
                 case let .failure(error):
                     if let StatusSpecificError = error as? StatusSpecificError {
@@ -188,6 +189,7 @@ class PhoneVerificationViewModel: ObservableObject {
                         Log.error("Network request failed: \(error)")
                     }
                 }
+                completion()
             }
         }
     }


### PR DESCRIPTION
## 작업 이유
- 카테고리 리스트에서 수정하기 뷰 진입시 placeholder처리 -> 피드백 반영
- 아이디/비밀번호 찾기 에러 핸들링

<br/>

## 작업 사항
### **1️⃣ 카테고리 리스트에서 수정하기 뷰 진입시 placeholder처리**
소비내역 3개 진입점중 카테고리에서 진입했을 경우 수정하기뷰에 기존 입력한 정보들이 placeholder처리되어 있지 않았다.
그래서 AddInputFormView에 onAppear로 카테고리 별 지출목록을 불러와 정보를 전달하도록 구현하였다.
```swift
 if let spendingDetail = spendingCategoryViewModel.dailyDetailSpendings.first {
                            viewModel.amountSpentText = String(spendingDetail.amount)
                            spendingId = spendingDetail.id
                            viewModel.selectedCategory = SpendingCategoryData(
                                id: spendingDetail.category.id,
                                isCustom: spendingDetail.category.isCustom,
                                name: spendingDetail.category.name,
                                icon: convertToSpendingCategoryData(from: spendingDetail.category)?.icon ?? CategoryIconName(baseName: .etc, state: .on)
                            )
                            viewModel.clickDate = DateFormatterUtil.dateFromString(spendingDetail.spendAt)
                            viewModel.consumerText = spendingDetail.accountName
                            viewModel.memoText = spendingDetail.memo
                            viewModel.validateForm()
                        }
``` 
spendingHistoryViewModel은 전달받은 clickDate값을 넘겨주면 됐지만 카테고리 뷰모델을 사용할 땐 spendAt을 넘겨줘서 날짜를 나타내야 하기 때문에 Formatter를 사용하여 값을 넘겨주었다.

### **2️⃣ 아이디/비밀번호 찾기 에러 핸들링**
```
- 해당 전화번호로 회원가입한 사용자 정보가 아예 없으면 404
- 있긴 한데 소셜 계정으로만 가입했으면 401
- 데이터도 있고, 일반 회원 가입 이력도 있으면 200
``` 
아래 사용자가 없는 경우를 판별하는 변수를 두고, 인증코드를 판별하는 코드를 두어 api 연결에 실패했다면 에러코드에 맞게 핸들링하여 예외처리를 해주었다.
```swift
//아이디 찾기
if showNotFoundUserPopUp == true { ... }
if showCodeErrorPopUp { ... }

//비밀번호 찾기
if showCodeErrorPopUp { ... }
if phoneVerificationViewModel.showErrorExistingUser { ... }
``` 

왜인지 비밀번호 찾기에서 showNotFoundUserPopUp이 동작하지 않아서 바로 뷰모델에 있는 showErrorExistingUser에 접근해서 판단하도록 구현하였다. 
동작과정은 디코에 보내놨습니다!


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
1번 피드백 반영했고 2번은 디코로 사진 보내놓겠습니다!
그리고 detailSpendingView에 드롭다운도 커스텀 드롭다운으로 같이 적용해서 리펙토링 했습니다~

<br/>

## 발견한 이슈
spendingHistoryViewModel을 사용하여 소비내역을 조회할 때 지난달에 대한 내역이 조회가 안되는걸 발견했다 ..
-> spendingCategoryViewModel을 사용한 경우는 문제 없음!
이건 시간이 조금 걸릴거같아서 이슈등록후 처리해야 할 거 같다. 