### PR TITLE
🎨🛠️ 지난 사용 금액 리스트 뷰 UI 구현 + 목표금액 뷰 오류 수정 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -286,13 +286,13 @@
 		D8E637502C06303D00D43BB6 /* MySpendingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E6374F2C06303D00D43BB6 /* MySpendingListViewModel.swift */; };
 		D8F9D7342C57E297005416FC /* handleDeleteButtonUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */; };
 		D8F9D7362C593B71005416FC /* PreparedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7352C593B71005416FC /* PreparedView.swift */; };
+		D8F9D73A2C59576B005416FC /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7392C59576B005416FC /* ImagePicker.swift */; };
 		D8F9D73D2C59FDFD005416FC /* UnreadAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D73C2C59FDFD005416FC /* UnreadAlarmView.swift */; };
 		D8F9D73F2C59FE12005416FC /* ReadAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D73E2C59FE12005416FC /* ReadAlarmView.swift */; };
 		D8F9D7412C59FE22005416FC /* NoAlarmArrivedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7402C59FE22005416FC /* NoAlarmArrivedView.swift */; };
 		D8F9D7432C5A0596005416FC /* ProfileAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7422C5A0596005416FC /* ProfileAlarmView.swift */; };
 		D8F9D7452C5A09ED005416FC /* ArrivedAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7442C5A09EC005416FC /* ArrivedAlarmView.swift */; };
 		D8F9D7472C5A1177005416FC /* AlarmList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7462C5A1177005416FC /* AlarmList.swift */; };
-		D8F9D73A2C59576B005416FC /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7392C59576B005416FC /* ImagePicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -578,13 +578,13 @@
 		D8E6374F2C06303D00D43BB6 /* MySpendingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpendingListViewModel.swift; sourceTree = "<group>"; };
 		D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = handleDeleteButtonUtil.swift; sourceTree = "<group>"; };
 		D8F9D7352C593B71005416FC /* PreparedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PreparedView.swift; path = "pennyway-client-iOS/View/TabView/PreparedView.swift"; sourceTree = SOURCE_ROOT; };
+		D8F9D7392C59576B005416FC /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		D8F9D73C2C59FDFD005416FC /* UnreadAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D73E2C59FE12005416FC /* ReadAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D7402C59FE22005416FC /* NoAlarmArrivedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoAlarmArrivedView.swift; sourceTree = "<group>"; };
 		D8F9D7422C5A0596005416FC /* ProfileAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D7442C5A09EC005416FC /* ArrivedAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrivedAlarmView.swift; sourceTree = "<group>"; };
 		D8F9D7462C5A1177005416FC /* AlarmList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmList.swift; sourceTree = "<group>"; };
-		D8F9D7392C59576B005416FC /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		F0F9541D34A887D64D713E30 /* Pods_pennyway_client_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pennyway_client_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		4AD0D8422BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */; };
 		4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */; };
 		4AD0D84A2BFDF80D00A0808F /* AddSpendingHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8492BFDF80D00A0808F /* AddSpendingHistoryViewModel.swift */; };
+		4AD5733C2C5B973C00A4E192 /* PastSpendingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5733B2C5B973C00A4E192 /* PastSpendingListView.swift */; };
 		4AD70E1B2BE0109D0058A52A /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E1A2BE0109D0058A52A /* WelcomeView.swift */; };
 		4AD70E222BE013C10058A52A /* ProfileMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E212BE013C10058A52A /* ProfileMainView.swift */; };
 		4AD70E252BE0153F0058A52A /* ProfileUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E242BE0153F0058A52A /* ProfileUserInfoView.swift */; };
@@ -490,6 +491,7 @@
 		4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTabBarVisibilityExtension.swift; sourceTree = "<group>"; };
 		4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifierExtension.swift; sourceTree = "<group>"; };
 		4AD0D8492BFDF80D00A0808F /* AddSpendingHistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSpendingHistoryViewModel.swift; sourceTree = "<group>"; };
+		4AD5733B2C5B973C00A4E192 /* PastSpendingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastSpendingListView.swift; sourceTree = "<group>"; };
 		4AD70E1A2BE0109D0058A52A /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		4AD70E212BE013C10058A52A /* ProfileMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileMainView.swift; sourceTree = "<group>"; };
 		4AD70E242BE0153F0058A52A /* ProfileUserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUserInfoView.swift; sourceTree = "<group>"; };
@@ -1486,6 +1488,7 @@
 				4AE8F3B02C3309680014F0D4 /* TotalTargetAmountView */,
 				4AE8F3B32C330A0B0014F0D4 /* TargetAmountSettingView.swift */,
 				4A6A9D102C331A9500394771 /* TargetAmountSetCompleteView.swift */,
+				4AD5733B2C5B973C00A4E192 /* PastSpendingListView.swift */,
 			);
 			path = TargetAmountView;
 			sourceTree = "<group>";
@@ -2115,6 +2118,7 @@
 				4AC3205D2C11F33200DDB4B6 /* GenerateCurrentMonthDummyDataRequestDto.swift in Sources */,
 				4A6A9D112C331A9500394771 /* TargetAmountSetCompleteView.swift in Sources */,
 				4A4703942BCEB21500AEE04E /* StatusError.swift in Sources */,
+				4AD5733C2C5B973C00A4E192 /* PastSpendingListView.swift in Sources */,
 				D8880E192BCEBEE700922894 /* DynamicFontSize.swift in Sources */,
 				4A3701CF2C08F7F600F0AEBA /* AddSpendingHistoryRequestDto.swift in Sources */,
 				4AC320512C11D5AC00DDB4B6 /* SpendingCheckBoxView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_gray03.imageset/Contents.json
+++ b/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_gray03.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_arrow_front_small_gray03.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_gray03.imageset/icon_arrow_front_small_gray03.svg
+++ b/pennyway-client-iOS/pennyway-client-iOS/Assets.xcassets/Icons/arrow_icon/icon_arrow_front_small_gray03.imageset/icon_arrow_front_small_gray03.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 16L14 12L10 8" stroke="#DDE0E5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
@@ -1,0 +1,86 @@
+
+import SwiftUI
+
+struct PastSpendingListView: View {
+    @ObservedObject var viewModel: TotalTargetAmountViewModel
+    
+    var body: some View {
+        ZStack {
+            ScrollView {
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                
+                ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
+                    VStack(alignment: .leading) {
+                        Text("\(String(content.year))년 \(content.month)월")
+                            .font(.B2MediumFont())
+                            .platformTextColor(color: Color("Gray05"))
+                        
+                        Spacer().frame(height: 8)
+                        HStack {
+                            HStack(spacing: 6 * DynamicSizeFactor.factor()) {
+                                Text("\(content.totalSpending)원")
+                                    .font(.ButtonH4SemiboldFont())
+                                    .platformTextColor(color: Color("Gray07"))
+                                
+                                if content.targetAmountDetail.amount != -1 {
+                                    DiffAmountDynamicWidthView(
+                                        text: determineText(for: content.diffAmount),
+                                        backgroundColor: determineBackgroundColor(for: content.diffAmount),
+                                        textColor: determineTextColor(for: content.diffAmount)
+                                    )
+                                }
+                            }
+                            
+                            Spacer()
+                            
+                            Image("icon_arrow_front_small_gray03")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                        }
+                    }
+                }
+                .frame(height: 60 * DynamicSizeFactor.factor())
+                .padding(.horizontal, 20)
+                
+                Spacer().frame(height: 14 * DynamicSizeFactor.factor())
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color("White01"))
+        .navigationBarColor(UIColor(named: "White01"), title: "지난 사용 금액")
+        .edgesIgnoringSafeArea(.bottom)
+        .setTabBarVisibility(isHidden: true)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                HStack {
+                    NavigationBackButton()
+                        .padding(.leading, 5)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+
+                }.offset(x: -10)
+            }
+        }
+    }
+    
+    /// Color 설정
+    func determineBackgroundColor(for diffAmount: Int64) -> Color {
+        return diffAmount > 0 ? Color("Red01") : Color("Ashblue01")
+    }
+    
+    func determineTextColor(for diffAmount: Int64) -> Color {
+        return diffAmount > 0 ? Color("Red03") : Color("Mint03")
+    }
+
+    func determineText(for diffAmount: Int64) -> String {
+        let diffAmountValue = (NumberFormatterUtil.formatIntToDecimalString(abs(diffAmount)))
+        
+        if diffAmount != 0 {
+            return diffAmount < 0 ? "\(diffAmountValue)원 절약했어요" : "\(diffAmountValue)원 더 썼어요"
+        } else {
+            return "짝짝 소비 천재네요!"
+        }
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TotalTargetAmountContentView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
+    @Binding var isnavigateToPastSpendingView: Bool
     
     var body: some View {
         VStack {
@@ -45,11 +46,15 @@ struct TotalTargetAmountContentView: View {
                     
                     Spacer()
                     
-                    Image("icon_arrow_front_small")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                        .padding(.trailing, 10)
+                    Button(action: {
+                        isnavigateToPastSpendingView = true
+                    }, label: {
+                        Image("icon_arrow_front_small")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                            .padding(.trailing, 10)
+                    })
                 }
                 .padding(.top, 18)
                 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -59,7 +59,7 @@ struct TotalTargetAmountContentView: View {
                 
                 Spacer().frame(height: 36 * DynamicSizeFactor.factor())
                 
-                ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
+                ForEach(Array(viewModel.targetAmounts.prefix(6).enumerated()), id: \.offset) { _, content in
                     VStack(alignment: .leading) {
                         Text("\(String(content.year))년 \(content.month)월")
                             .font(.B2MediumFont())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -7,7 +7,8 @@ struct TotalTargetAmountView: View {
     @State private var isClickMenu = false
     @State private var selectedMenu: String? = nil // 선택한 메뉴
     @State private var listArray: [String] = ["목표금액 수정", "초기화하기"]
-    @State private var navigateToEditTarget = false
+    @State private var isnavigateToEditTargetView = false
+    @State private var isnavigateToPastSpendingView = false
     @State private var showingDeletePopUp = false
     @State private var showToastPopup = false
     
@@ -17,7 +18,7 @@ struct TotalTargetAmountView: View {
                 VStack(spacing: 0) {
                     TotalTargetAmountHeaderView(viewModel: viewModel)
                     
-                    TotalTargetAmountContentView(viewModel: viewModel)
+                    TotalTargetAmountContentView(viewModel: viewModel, isnavigateToPastSpendingView: $isnavigateToPastSpendingView)
                     
                     Spacer().frame(height: 29 * DynamicSizeFactor.factor())
                 }
@@ -31,7 +32,7 @@ struct TotalTargetAmountView: View {
                             listArray: listArray,
                             onItemSelected: { item in
                                 if item == "목표금액 수정" {
-                                    navigateToEditTarget = true
+                                    isnavigateToEditTargetView = true
                                 } else {
                                     showingDeletePopUp = true
                                 }
@@ -114,7 +115,9 @@ struct TotalTargetAmountView: View {
             }
         }
         
-        NavigationLink(destination: TargetAmountSettingView(currentData: $viewModel.currentData), isActive: $navigateToEditTarget) {}
+        NavigationLink(destination: TargetAmountSettingView(currentData: $viewModel.currentData), isActive: $isnavigateToEditTargetView) {}
+        
+        NavigationLink(destination: PastSpendingListView(viewModel: viewModel), isActive: $isnavigateToPastSpendingView) {}
     }
 
     private func deleteTargetAmountApi() {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
@@ -21,7 +21,13 @@ class TotalTargetAmountViewModel: ObservableObject {
 
                         self.targetAmounts = response.data.targetAmounts
 
-                        self.sortTargetAmounts = self.targetAmounts.sorted(by: { $0.month < $1.month })
+                        self.sortTargetAmounts = self.targetAmounts.sorted {//먼저 year 기준으로 나눈 후 month 오름차순
+                            if $0.year == $1.year {
+                                return $0.month < $1.month
+                            } else {
+                                return $0.year < $1.year
+                            }
+                        }
                         if let firstTargetAmount = self.targetAmounts.first {
                             self.currentData = firstTargetAmount
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
@@ -21,7 +21,7 @@ class TotalTargetAmountViewModel: ObservableObject {
 
                         self.targetAmounts = response.data.targetAmounts
 
-                        self.sortTargetAmounts = self.targetAmounts.sorted {//먼저 year 기준으로 나눈 후 month 오름차순
+                        self.sortTargetAmounts = self.targetAmounts.sorted { // 먼저 year 기준으로 나눈 후 month 오름차순
                             if $0.year == $1.year {
                                 return $0.month < $1.month
                             } else {


### PR DESCRIPTION
## 작업 이유

- 목표금액 뷰 오류 수정
- 지난 사용 금액 리스트 뷰 UI 구현


<br/>

## 작업 사항

### 1️⃣ 목표금액 뷰 오류 수정

목표금액 뷰의 그래프에서 월 데이터 이상하게 나오는 걸 확인했다.

<img src ="https://github.com/user-attachments/assets/fc89dc32-de0e-4051-8bfa-89e33abcfaa7" width = "300"/>

TotalTargetAmountViewModel의 sortTargetAmounts를 처리할 때 month 기준으로만 정렬했던게 문제였다.
기준 1순위를 year로 두고 2순위 month로 변경하니 해결되었다.

```swift
self.sortTargetAmounts = self.targetAmounts.sorted { // 먼저 year 기준으로 나눈 후 month 오름차순
    if $0.year == $1.year {
        return $0.month < $1.month
    } else {
        return $0.year < $1.year
    }
}
```

<br/>

### 2️⃣ 지난 사용 금액 리스트 뷰 UI 구현

지난 사용 금액 리스트 뷰는 아래와 같이 구현하였고 TotalTargetAmountView의 targetAmounts를 그대로 사용해서 api 호출 없이 데이터를 보여주고 있다.

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-01 at 19 43 33](https://github.com/user-attachments/assets/a683a7ae-8c21-44fd-a247-5b6e977af5ac)

### 3️⃣ 목표 금액 뷰 상위 6개 데이터 처리

목표 금액 뷰에서는 그래프 월에 맞게 상위 6개의 데이터만 보여주도록 처리해야 해서 수정하였다. 

`ForEach(Array(viewModel.targetAmounts.prefix(6).enumerated()), id: \.offset) { _, content in`



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

오류 발견하고 수정하였고 지난 사용 금액 리스트 뷰 ui도 구현했습니다!!
현재 > 버튼을 눌렀을 때 뷰 이동은 되지 않는 상태고 디자인팀에 질문 남겨놓아서 나중에 답변 받으면 처리해야할 것 같아요!


<br/>

## 발견한 이슈

지출 내역 팝업 뷰에서 지출 내역 리스트를 클릭했는데 빈 화면이 나오더라고요!!
저만 이러나요..?

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-01 at 19 50 16](https://github.com/user-attachments/assets/8eea9540-a259-4e95-aeaa-760b7a683442)

