### PR TITLE
🎨 목표 금액 뷰 그래프 비율 조정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
@@ -4,21 +4,21 @@ import SwiftUI
 struct TotalTargetAmountGraphView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     var body: some View {
-        let maxHeight = 140 * DynamicSizeFactor.factor()//최대 높이
+        let maxHeight = 120 * DynamicSizeFactor.factor() // 최대 높이
         let maxSpending = max(viewModel.maxTotalSpending, 100_000) // 최소값을 100000으로 설정
 
         HStack(spacing: 24 * DynamicSizeFactor.factor()) {
             ForEach(0 ..< 6) { index in
                 if index >= 6 - viewModel.sortTargetAmounts.count {
                     let content = viewModel.sortTargetAmounts[index - (6 - viewModel.sortTargetAmounts.count)]
-                    let adjustedHeight = (maxSpending > 0) ? CGFloat(content.totalSpending) / CGFloat(maxSpending) * maxHeight : 0//그래프 높이 조정
+                    let adjustedHeight = (maxSpending > 0) ? CGFloat(content.totalSpending) / CGFloat(maxSpending) * maxHeight : 0 // 그래프 높이 조정
 
                     VStack {
                         Text("\(content.totalSpending / 10000)")
                             .font(.B3MediumFont())
                             .platformTextColor(color: determineColorGray04(for: content))
                         Rectangle()
-                            .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: adjustedHeight)
+                            .frame(width: 16 * DynamicSizeFactor.factor(), height: adjustedHeight)
                             .platformTextColor(color: determineColorGray03(for: content))
                             .clipShape(RoundedCornerUtil(radius: 15, corners: [.topLeft, .topRight]))
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
@@ -4,14 +4,14 @@ import SwiftUI
 struct TotalTargetAmountGraphView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     var body: some View {
-        let maxHeight = 140 * DynamicSizeFactor.factor()
+        let maxHeight = 140 * DynamicSizeFactor.factor()//최대 높이
         let maxSpending = max(viewModel.maxTotalSpending, 100_000) // 최소값을 100000으로 설정
 
         HStack(spacing: 24 * DynamicSizeFactor.factor()) {
             ForEach(0 ..< 6) { index in
                 if index >= 6 - viewModel.sortTargetAmounts.count {
                     let content = viewModel.sortTargetAmounts[index - (6 - viewModel.sortTargetAmounts.count)]
-                    let adjustedHeight = (maxSpending > 0) ? CGFloat(content.totalSpending) / CGFloat(maxSpending) * maxHeight : 0
+                    let adjustedHeight = (maxSpending > 0) ? CGFloat(content.totalSpending) / CGFloat(maxSpending) * maxHeight : 0//그래프 높이 조정
 
                     VStack {
                         Text("\(content.totalSpending / 10000)")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
@@ -4,16 +4,21 @@ import SwiftUI
 struct TotalTargetAmountGraphView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     var body: some View {
+        let maxHeight = 140 * DynamicSizeFactor.factor()
+        let maxSpending = max(viewModel.maxTotalSpending, 100_000) // 최소값을 100000으로 설정
+
         HStack(spacing: 24 * DynamicSizeFactor.factor()) {
             ForEach(0 ..< 6) { index in
                 if index >= 6 - viewModel.sortTargetAmounts.count {
                     let content = viewModel.sortTargetAmounts[index - (6 - viewModel.sortTargetAmounts.count)]
+                    let adjustedHeight = (maxSpending > 0) ? CGFloat(content.totalSpending) / CGFloat(maxSpending) * maxHeight : 0
+
                     VStack {
                         Text("\(content.totalSpending / 10000)")
                             .font(.B3MediumFont())
                             .platformTextColor(color: determineColorGray04(for: content))
                         Rectangle()
-                            .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: CGFloat(content.totalSpending / 10000) * DynamicSizeFactor.factor())
+                            .frame(maxWidth: 16 * DynamicSizeFactor.factor(), maxHeight: adjustedHeight)
                             .platformTextColor(color: determineColorGray03(for: content))
                             .clipShape(RoundedCornerUtil(radius: 15, corners: [.topLeft, .topRight]))
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TotalTargetAmountViewModel.swift
@@ -7,6 +7,7 @@ import SwiftUI
 class TotalTargetAmountViewModel: ObservableObject {
     @Published var targetAmounts: [TargetAmount] = [] // 내림차순 데이터
     @Published var sortTargetAmounts: [TargetAmount] = [] // 오름차순 정렬
+    @Published var maxTotalSpending = 0
     @Published var currentData: TargetAmount = TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0) // 당월 데이터
 
     func getTotalTargetAmountApi(completion: @escaping (Bool) -> Void) {
@@ -21,7 +22,17 @@ class TotalTargetAmountViewModel: ObservableObject {
 
                         self.targetAmounts = response.data.targetAmounts
 
-                        self.sortTargetAmounts = self.targetAmounts.sorted(by: { $0.month < $1.month })
+                        self.sortTargetAmounts = self.targetAmounts.sorted { // 먼저 year 기준으로 나눈 후 month 오름차순
+                            if $0.year == $1.year {
+                                return $0.month < $1.month
+                            } else {
+                                return $0.year < $1.year
+                            }
+                        }
+                        // 뒤에서 6개의 데이터 중 최대값을 maxTotalSpending에 설정
+                        let lastSixTargetAmounts = Array(self.sortTargetAmounts.suffix(6))
+                        self.maxTotalSpending = lastSixTargetAmounts.map { Int($0.totalSpending) }.max() ?? 0
+
                         if let firstTargetAmount = self.targetAmounts.first {
                             self.currentData = firstTargetAmount
                         }


### PR DESCRIPTION
## 작업 이유

- 목표 금액 뷰 그래프 비율 조정

<br/>

## 작업 사항

### 1️⃣ 목표 금액 뷰 그래프 비율 조정

그래프가 보여질 높이를 120 * DynamicSizeFactor.factor()라고 지정하였다.


1. 그래프 비율 초기값은 100,000을 기준으로 한다.
`ratio = 지출 금액 / 100,000 * 그래프 최대 높이`

2. 만약 100,000보다 큰 지출 금액이 있다면, 그 금액을 최대값으로 설정하여 그래프 비율을 조정
`ratio = 지출 금액 / 최대 지출 금액 * 그래프 최대 높이`

TotalTargetAmountViewModel에서 최대 지출 금액인 maxTotalSpending를 구하고 TotalTargetAmountGraphView에서 위의 로직으로 처리한다.

<img src = "https://github.com/user-attachments/assets/14d07c91-c9d6-4ea6-add5-ad03716e15a3" width = "300"/>
 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

드디어 그래프 비율 조정했습니다~~~
확인하시고 이상있으면 말씀해주세요!!


<br/>

## 발견한 이슈
close #107 