### PR TITLE
📍 네비게이션 바 폰트 지정 + 카테고리 이동 뷰 스크롤 범위 지정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/View/NavigationBarModifierExtension.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/View/NavigationBarModifierExtension.swift
@@ -13,8 +13,10 @@ struct NavigationBarModifierExtension: ViewModifier {
         let coloredAppearance = UINavigationBarAppearance()
         coloredAppearance.configureWithTransparentBackground()
         coloredAppearance.backgroundColor = .clear
-        coloredAppearance.titleTextAttributes = [.foregroundColor: UIColor(named: "Gray07") as Any]
-        coloredAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(named: "Gray07") as Any]
+        coloredAppearance.titleTextAttributes = [.foregroundColor: UIColor(named: "Gray07") as Any,
+                                                 .font: UIFont(name: "Pretendard-Medium", size: 14 * DynamicSizeFactor.factor()) as Any]
+        coloredAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(named: "Gray07") as Any,
+                                                      .font: UIFont(name: "Pretendard-Medium", size: 14 * DynamicSizeFactor.factor()) as Any]
 
         UINavigationBar.appearance().standardAppearance = coloredAppearance
         UINavigationBar.appearance().compactAppearance = coloredAppearance

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/MoveCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategoryManagementView/MoveCategoryView.swift
@@ -11,23 +11,26 @@ struct MoveCategoryView: View {
     @State var navigateToAddCategoryView = false
 
     var body: some View {
-        VStack {
+        VStack(alignment: .leading) {
+            Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+
+            Group {
+                Text("\(spendingCategoryViewModel.spedingHistoryTotalCount)개의 소비 내역")
+                    .font(.B1MediumFont())
+                    .platformTextColor(color: Color("Gray07"))
+
+                Spacer().frame(height: 4 * DynamicSizeFactor.factor())
+
+                Text("변경할 카테고리를 선택해 주세요")
+                    .font(.H3SemiboldFont())
+                    .platformTextColor(color: Color("Gray07"))
+            }
+            .padding(.horizontal, 20)
+
+            Spacer().frame(height: 25 * DynamicSizeFactor.factor())
+
             ScrollView {
-                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("\(spendingCategoryViewModel.spedingHistoryTotalCount)개의 소비 내역")
-                        .font(.B1MediumFont())
-                        .platformTextColor(color: Color("Gray07"))
-
-                    Spacer().frame(height: 4 * DynamicSizeFactor.factor())
-
-                    Text("변경할 카테고리를 선택해 주세요")
-                        .font(.H3SemiboldFont())
-                        .platformTextColor(color: Color("Gray07"))
-
-                    Spacer().frame(height: 25 * DynamicSizeFactor.factor())
-
                     ForEach(Array(spendingCategoryViewModel.spendingCategories.enumerated()), id: \.element.id) { _, category in
                         HStack(spacing: 10) {
                             Image(getCategoryIcon(category: category, isSelected: category.id == spendingCategoryViewModel.selectedMoveCategoryId))


### PR DESCRIPTION
## 작업 이유

- 네비게이션 바 폰트 지정
- 카테고리 이동 뷰 스크롤 범위 지정

<br/>

## 작업 사항

### 1️⃣ 네비게이션 바 폰트 지정

병합 오류로 코드가 없어졌는 줄 알았는데 알고보니 draft pr로 올려놓아서 아직 병합 안 된거였다 ㅎㅎ
#126 
그래서 다시 줍줍,,,

네비게이션 바의 폰트 지정이 빠져있어서 NavigationBarModifierExtension에서 폰트 지정하는 로직을 추가하였다.
navigation bar의 title을 지정하기 위해 uikit의 네비게이션 바를 가져와서 사용하기 때문에 UIFont로 지정해야 해서 아래와 같이 구현하였다.
`.font: UIFont(name: "Pretendard-Medium", size: 14 * DynamicSizeFactor.factor()) as Any`

<br/>


### 2️⃣ 카테고리 이동 뷰 스크롤 범위 지정

- 상단의 문구 박스와 하단의 버튼은 고정으로 두고 카테고리 리스트만 스크롤 되도록 수정하였다.

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-06 at 17 22 10](https://github.com/user-attachments/assets/42316956-a02b-448b-8afd-d4ae14a65a13)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

구현 완료했습니다~~ 
이상있으면 말씀해주세요~~

<br/>

## 발견한 이슈
