### PR TITLE
📍 메인화면 캘린더 수정 + "넘게" 문구 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		4A85713A2BC6FFD30082CE47 /* CodeInputSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571392BC6FFD30082CE47 /* CodeInputSectionView.swift */; };
 		4A8571422BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571412BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift */; };
 		4A8571442BC7C5EB0082CE47 /* OAuthSignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571432BC7C5EB0082CE47 /* OAuthSignUpViewModel.swift */; };
+		4A8BDEE52C629C3600D21424 /* SpendingHistoryUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8BDEE42C629C3600D21424 /* SpendingHistoryUtil.swift */; };
 		4A9634B02C42E75A000A218A /* DeleteSpendingHistoryRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9634AF2C42E75A000A218A /* DeleteSpendingHistoryRequestDto.swift */; };
 		4A9634B22C42EAF6000A218A /* SpendingListGroupUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */; };
 		4A98BD7C2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */; };
@@ -441,6 +442,7 @@
 		4A8571392BC6FFD30082CE47 /* CodeInputSectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeInputSectionView.swift; sourceTree = "<group>"; };
 		4A8571412BC70E570082CE47 /* LinkOAuthToAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkOAuthToAccountViewModel.swift; sourceTree = "<group>"; };
 		4A8571432BC7C5EB0082CE47 /* OAuthSignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSignUpViewModel.swift; sourceTree = "<group>"; };
+		4A8BDEE42C629C3600D21424 /* SpendingHistoryUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingHistoryUtil.swift; sourceTree = "<group>"; };
 		4A9634AF2C42E75A000A218A /* DeleteSpendingHistoryRequestDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSpendingHistoryRequestDto.swift; sourceTree = "<group>"; };
 		4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingListGroupUtil.swift; sourceTree = "<group>"; };
 		4A98BD7B2C10F9AA0044A352 /* EditCurrentMonthTargetAmountRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCurrentMonthTargetAmountRequestDto.swift; sourceTree = "<group>"; };
@@ -1415,6 +1417,7 @@
 				4A9634B12C42EAF6000A218A /* SpendingListGroupUtil.swift */,
 				4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */,
 				D8F9D7332C57E296005416FC /* handleDeleteButtonUtil.swift */,
+				4A8BDEE42C629C3600D21424 /* SpendingHistoryUtil.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2274,6 +2277,7 @@
 				D8BDAF712C4928D10095D8E7 /* ProfileModifyPwView.swift in Sources */,
 				4AB5AB4E2BB4A60500D2C9EA /* URLRequestExtension.swift in Sources */,
 				4A3560832BEBF12D00BA58F3 /* OAuthAccountViewModel.swift in Sources */,
+				4A8BDEE52C629C3600D21424 /* SpendingHistoryUtil.swift in Sources */,
 				4AC3203F2C11D5AC00DDB4B6 /* AddSpendingCategoryView.swift in Sources */,
 				4A0BC6AD2BF5FA130036D900 /* NumberFormatterUtil.swift in Sources */,
 				4A058F012BD046C1004B6F89 /* OAuthLoginViewModel.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Logger/ApiStatusLogger.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Logger/ApiStatusLogger.swift
@@ -10,7 +10,7 @@ final class ApiStatusLogger: EventMonitor {
             return
         }
 
-        print("ApiStatusLogger - statusCode : \(statusCode)")
+        Log.info("ApiStatusLogger - statusCode : \(statusCode)")
         debugPrint(request)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Logger/RequestLogger.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Logger/RequestLogger.swift
@@ -6,12 +6,12 @@ final class RequestLogger: EventMonitor {
     let queue = DispatchQueue(label: "MyLogger")
 
     func requestDidResume(_ request: Request) {
-        print("RequestLogger - requestDidResume")
+        Log.info("RequestLogger - requestDidResume")
         debugPrint(request)
     }
 
     func request(_ request: DataRequest, didParseResponse _: DataResponse<Data?, AFError>) {
-        print("RequestLogger - request.didParseResponse()")
+        Log.info("RequestLogger - request.didParseResponse()")
         debugPrint(request)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/View/SpendingHistoryUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/View/SpendingHistoryUtil.swift
@@ -1,0 +1,13 @@
+
+import Foundation
+
+class SpendingHistoryUtil {
+    static func getSpendingAmount(for day: Int, from viewModel: SpendingHistoryViewModel) -> Int? {
+        return viewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
+    }
+
+    static func getSpendingAmount(for date: Date, using calendar: Calendar, from viewModel: SpendingHistoryViewModel) -> Int? {
+        let day = calendar.component(.day, from: date)
+        return getSpendingAmount(for: day, from: viewModel)
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -33,7 +33,7 @@ struct SpendingDetailSheetView: View {
                         
                     Spacer()
                         
-                    if let clickDate = clickDate, getSpendingAmount(for: clickDate) == nil || isDeleted {
+                    if let clickDate = clickDate, SpendingHistoryUtil.getSpendingAmount(for: clickDate, using: Calendar.current, from: spendingHistoryViewModel) == nil || isDeleted {
                         // 지출내역이 없을 경우 편집버튼 없음
                     } else {
                         Button(action: {
@@ -62,13 +62,13 @@ struct SpendingDetailSheetView: View {
                 .padding(.trailing, 17)
                 .padding(.top, 12)
                     
-                if let clickDate = clickDate, getSpendingAmount(for: clickDate) == nil || isDeleted {
+                if let clickDate = clickDate, SpendingHistoryUtil.getSpendingAmount(for: clickDate, using: Calendar.current, from: spendingHistoryViewModel) == nil || isDeleted {
                     NoSpendingHistorySheetView()
                 } else {
                     ScrollView {
                         VStack(alignment: .leading) {
                             Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-                            if let clickDate = clickDate, let dailyTotalAmount = getSpendingAmount(for: clickDate) {
+                            if let clickDate = clickDate, let dailyTotalAmount = SpendingHistoryUtil.getSpendingAmount(for: clickDate, using: Calendar.current, from: spendingHistoryViewModel) {
                                 Text("-\(dailyTotalAmount)원")
                                     .font(.H1SemiboldFont())
                                     .platformTextColor(color: Color("Gray07"))
@@ -130,11 +130,11 @@ struct SpendingDetailSheetView: View {
         .setTabBarVisibility(isHidden: true)
     }
     
-    private func getSpendingAmount(for date: Date) -> Int? {
-        let day = Calendar.current.component(.day, from: date)
-        Log.debug(day)
-        return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
-    }
+//    private func getSpendingAmount(for date: Date) -> Int? {
+//        let day = Calendar.current.component(.day, from: date)
+//        Log.debug(day)
+//        return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
+//    }
     
     private func getDailyHistoryData() {
         spendingHistoryViewModel.checkSpendingHistoryApi { success in

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
@@ -70,26 +70,26 @@ struct SpendingCalendarCellView: View {
                 .frame(width: 22 * DynamicSizeFactor.factor(), height: 22 * DynamicSizeFactor.factor())
 
             Spacer()
-                .frame(height: 1 * DynamicSizeFactor.factor())
+                .frame(height: 4 * DynamicSizeFactor.factor())
 
             if isCurrentMonthDay {
                 if let dailyTotalAmount = getSpendingAmount(for: day) {
-                    VStack(spacing: -3) {//텍스트 높이 조정
+                    VStack(spacing: -3) { // 텍스트 높이 조정
                         ForEach(truncatedText("\(dailyTotalAmount)").split(separator: "\n"), id: \.self) { line in
                             Text(line)
                                 .font(.B4MediumFont())
                                 .platformTextColor(color: isToday ? Color("Mint03") : Color("Gray07"))
                         }
                     }
-                    .frame(width: 35 * DynamicSizeFactor.factor(), height: 10 * DynamicSizeFactor.factor())
+                    .frame(width: 36 * DynamicSizeFactor.factor(), height: 12 * DynamicSizeFactor.factor())
 
                 } else {
                     Spacer()
-                        .frame(height: 10 * DynamicSizeFactor.factor())
+                        .frame(height: 12 * DynamicSizeFactor.factor())
                 }
             }
         }
-        .frame(height: 32 * DynamicSizeFactor.factor())
+        .frame(height: 34 * DynamicSizeFactor.factor())
         .edgesIgnoringSafeArea(.all)
     }
 
@@ -103,13 +103,31 @@ struct SpendingCalendarCellView: View {
 
     private func truncatedText(_ text: String) -> String {
         let maxLength = 6
-        if text.count <= maxLength {
-            let number = NumberFormatterUtil.formatStringToDecimalString(text)
+        let number = NumberFormatterUtil.formatStringToDecimalString(text)
+        
+        if number.count <= maxLength {//1,000,000보다 작으면 바로 반환
             return "-\(number)\n "
         }
+        
+        var truncatedNumber = number.prefix(8)
+        let commaCount = truncatedNumber.filter { $0 == "," }.count
 
-        let number = NumberFormatterUtil.formatStringToDecimalString(text).prefix(7)
+        var prefixLength: Int
+        switch commaCount {//, 개수
+        case 1:
+            prefixLength = 7
+        case 2:
+            prefixLength = 8
+        default:
+            prefixLength = 7
+        }
 
-        return "-\(number)\n..."
+        truncatedNumber = number.prefix(prefixLength)
+
+        if truncatedNumber.hasSuffix(",") {//가장 마지막 ,는 제거
+            truncatedNumber = truncatedNumber.dropLast()
+        }
+
+        return "-\(truncatedNumber)\n..."
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
@@ -73,7 +73,7 @@ struct SpendingCalendarCellView: View {
                 .frame(height: 4 * DynamicSizeFactor.factor())
 
             if isCurrentMonthDay {
-                if let dailyTotalAmount = getSpendingAmount(for: day) {
+                if let dailyTotalAmount = SpendingHistoryUtil.getSpendingAmount(for: day, from: spendingHistoryViewModel) {
                     VStack(spacing: -3) { // 텍스트 높이 조정
                         ForEach(truncatedText("\(dailyTotalAmount)").split(separator: "\n"), id: \.self) { line in
                             Text(line)
@@ -95,10 +95,6 @@ struct SpendingCalendarCellView: View {
 
     private func isSpendingDay(_ day: Int) -> Bool {
         return spendingHistoryViewModel.dailySpendings.contains { $0.day == day }
-    }
-
-    private func getSpendingAmount(for day: Int) -> Int? {
-        return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
     }
 
     private func truncatedText(_ text: String) -> String {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
@@ -74,10 +74,15 @@ struct SpendingCalendarCellView: View {
 
             if isCurrentMonthDay {
                 if let dailyTotalAmount = getSpendingAmount(for: day) {
-                    Text("-\(dailyTotalAmount)")
-                        .font(.B4MediumFont())
-                        .platformTextColor(color: isToday ? Color("Mint03") : Color("Gray07"))
-                        .frame(width: 34 * DynamicSizeFactor.factor(), height: 10 * DynamicSizeFactor.factor())
+                    VStack(spacing: -3) {//텍스트 높이 조정
+                        ForEach(truncatedText("\(dailyTotalAmount)").split(separator: "\n"), id: \.self) { line in
+                            Text(line)
+                                .font(.B4MediumFont())
+                                .platformTextColor(color: isToday ? Color("Mint03") : Color("Gray07"))
+                        }
+                    }
+                    .frame(width: 35 * DynamicSizeFactor.factor(), height: 10 * DynamicSizeFactor.factor())
+
                 } else {
                     Spacer()
                         .frame(height: 10 * DynamicSizeFactor.factor())
@@ -94,5 +99,17 @@ struct SpendingCalendarCellView: View {
 
     private func getSpendingAmount(for day: Int) -> Int? {
         return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
+    }
+
+    private func truncatedText(_ text: String) -> String {
+        let maxLength = 6
+        if text.count <= maxLength {
+            let number = NumberFormatterUtil.formatStringToDecimalString(text)
+            return "-\(number)\n "
+        }
+
+        let number = NumberFormatterUtil.formatStringToDecimalString(text).prefix(7)
+
+        return "-\(number)\n..."
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
@@ -104,16 +104,16 @@ struct SpendingCalendarCellView: View {
     private func truncatedText(_ text: String) -> String {
         let maxLength = 6
         let number = NumberFormatterUtil.formatStringToDecimalString(text)
-        
-        if number.count <= maxLength {//1,000,000보다 작으면 바로 반환
+
+        if number.count <= maxLength { // 1,000,000보다 작으면 바로 반환
             return "-\(number)\n "
         }
-        
+
         var truncatedNumber = number.prefix(8)
         let commaCount = truncatedNumber.filter { $0 == "," }.count
 
         var prefixLength: Int
-        switch commaCount {//, 개수
+        switch commaCount { // , 개수
         case 1:
             prefixLength = 7
         case 2:
@@ -124,7 +124,7 @@ struct SpendingCalendarCellView: View {
 
         truncatedNumber = number.prefix(prefixLength)
 
-        if truncatedNumber.hasSuffix(",") {//가장 마지막 ,는 제거
+        if truncatedNumber.hasSuffix(",") { // 가장 마지막 ,는 제거
             truncatedNumber = truncatedNumber.dropLast()
         }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarCellView.swift
@@ -105,15 +105,18 @@ struct SpendingCalendarCellView: View {
         let maxLength = 6
         let number = NumberFormatterUtil.formatStringToDecimalString(text)
 
-        if number.count <= maxLength { // 1,000,000보다 작으면 바로 반환
+        if number.count <= maxLength { // 1. 숫자 문자열의 길이가 최대 길이 이하인 경우 그대로 반환
             return "-\(number)\n "
         }
 
+        // 2. 초기로 8자리만큼 문자열을 자름
         var truncatedNumber = number.prefix(8)
+        // 3. 잘라낸 문자열에서 쉼표의 개수를 셈
         let commaCount = truncatedNumber.filter { $0 == "," }.count
 
+        // 4. 쉼표의 개수에 따라 prefix 길이를 설정
         var prefixLength: Int
-        switch commaCount { // , 개수
+        switch commaCount {
         case 1:
             prefixLength = 7
         case 2:
@@ -122,9 +125,11 @@ struct SpendingCalendarCellView: View {
             prefixLength = 7
         }
 
+        // 5. 다시 숫자 문자열에서 prefix 길이만큼 자름
         truncatedNumber = number.prefix(prefixLength)
 
-        if truncatedNumber.hasSuffix(",") { // 가장 마지막 ,는 제거
+        // 6. 잘라낸 문자열이 쉼표로 끝나는 경우 쉼표를 제거
+        if truncatedNumber.hasSuffix(",") {
             truncatedNumber = truncatedNumber.dropLast()
         }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
@@ -138,8 +138,6 @@ struct SpendingCalenderView: View {
                                 
                                 self.showSpendingDetailView = true
                             }
-                        } else {
-                            print(dateOnly, currentDate)
                         }
                     }
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
@@ -123,16 +123,23 @@ struct SpendingCalenderView: View {
                     }
                 }
                 .onTapGesture {
+                    let currentDate = Calendar.current.startOfDay(for: Date())//날짜만 가져오기
                     if 0 <= index && index < daysInMonth {
                         let date = getDate(for: index)
-                        clickedCurrentMonthDates = date
-                        isClickDay(Date.day(from: date))
-                        
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            clickDate = date
-                            spendingHistoryViewModel.selectedDate = date
-
-                            self.showSpendingDetailView = true
+                        let dateOnly = Calendar.current.startOfDay(for: date)
+                        // 현재 날짜 이후인 경우 동작하지 않도록 함
+                        if dateOnly <= currentDate {
+                            clickedCurrentMonthDates = date
+                            isClickDay(Date.day(from: date))
+                            
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                clickDate = date
+                                spendingHistoryViewModel.selectedDate = date
+                                
+                                self.showSpendingDetailView = true
+                            }
+                        } else {
+                            print(dateOnly, currentDate)
                         }
                     }
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
@@ -123,7 +123,7 @@ struct SpendingCalenderView: View {
                     }
                 }
                 .onTapGesture {
-                    let currentDate = Calendar.current.startOfDay(for: Date())//날짜만 가져오기
+                    let currentDate = Calendar.current.startOfDay(for: Date()) // 날짜만 가져오기
                     if 0 <= index && index < daysInMonth {
                         let date = getDate(for: index)
                         let dateOnly = Calendar.current.startOfDay(for: date)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
@@ -151,7 +151,7 @@ struct SpendingWeekCalendarView: View {
 
                         Spacer().frame(height: 4) // 동적 ui 적용하니 너무 넓어짐
 
-                        if let amount = getSpendingAmount(for: date) {
+                        if let amount = SpendingHistoryUtil.getSpendingAmount(for: date, using: Calendar.current, from: spendingHistoryViewModel) {
                             Text("-\(amount)")
                                 .font(.B4MediumFont())
                                 .platformTextColor(color: calendar.isDateInToday(date) ? Color("Mint03") : Color("Gray06"))
@@ -179,11 +179,6 @@ struct SpendingWeekCalendarView: View {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: date)
-    }
-
-    private func getSpendingAmount(for date: Date) -> Int? {
-        let day = calendar.component(.day, from: date)
-        return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
     }
 
     private func circleColor(for date: Date) -> Color {
@@ -228,10 +223,6 @@ struct SpendingWeekCalendarView: View {
             }
         }
         return dates
-    }
-
-    private func getSpendingAmount(for day: Int) -> Int? {
-        return spendingHistoryViewModel.dailySpendings.first(where: { $0.day == day })?.dailyTotalAmount
     }
 
     private func setToToday() {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -8,14 +8,19 @@ struct SpendingCheckBoxView: View {
 
     var formattedTotalSpent: String {
         if let targetAmountData = viewModel.targetAmountData {
-            return NumberFormatterUtil.formatIntToDecimalString(targetAmountData.totalSpending)
+            let totalSpending = targetAmountData.totalSpending
+            if totalSpending > 100_000_000 {
+                return "100,000,000원 넘게"
+            } else {
+                return NumberFormatterUtil.formatIntToDecimalString(totalSpending) + "원"
+            }
         } else {
-            return "0"
+            return "0원"
         }
     }
 
     var spentInfoText: String {
-        "반가워요 \(String(describing: getUserData()?.username ?? ""))님! \n이번 달에 \(formattedTotalSpent)원 썼어요"
+        "반가워요 \(String(describing: getUserData()?.username ?? ""))님! \n이번 달에 \(formattedTotalSpent) 썼어요"
     }
 
     var totalSpending: Int64 {
@@ -33,7 +38,7 @@ struct SpendingCheckBoxView: View {
             HStack {
                 spentInfoText.toAttributesText(base: baseAttribute,
                                                StringAttribute(
-                                                   text: "\(formattedTotalSpent)원",
+                                                   text: "\(formattedTotalSpent)",
                                                    font: .H3SemiboldFont(),
                                                    color: determineColor()
                                                ))


### PR DESCRIPTION
## 작업 이유

- 지출 총합 ~넘게 반영
- 캘린더 숫자 길어질 때 ... 행 처리
- 캘린더 오늘 이후 날짜 선택 방지


<br/>

## 작업 사항

### 1️⃣ 지출 총합 ~넘게 반영

```swift
 var formattedTotalSpent: String {
    if let targetAmountData = viewModel.targetAmountData {
        let totalSpending = targetAmountData.totalSpending
        if totalSpending > 100_000_000 {//1억원 넘은 경우
            return "100,000,000원 넘게"
        } else {
            return NumberFormatterUtil.formatIntToDecimalString(totalSpending) + "원"
        }
    } else {
        return "0원"
    }
}
```

- 목표금액 0원일 때
![스크린샷 2024-08-06 오후 6 06 04](https://github.com/user-attachments/assets/3ffa9dfc-27a7-4db4-9d83-8389f1da60d5)

- 목표금액 2억일 때
![스크린샷 2024-08-06 오후 6 08 43](https://github.com/user-attachments/assets/894a816d-b289-4306-a04a-0916f4fae476)

<br/>


### 2️⃣ 캘린더 숫자 길어질 때 ... 행 처리

- 지출 금액 1,000,000원부터 ...이 나오도록 처리하였다.

```
지출 금액에 쉼표를 제외한 숫자 6자까지만 보여지도록 하였다.
예를 들어, 아래와 같이 보여진다.

• "300,000,000"과 "300,000" -> "300,000"
• "2,000,000,000"과 "2,000,000" -> "2,000,00"
• "20,000,000" -> "20,000,0"
```

만약 백만원보다 작으면 바로 반환을 하고, 크면 쉼표의 개수에 따라 몇자까지 반환할지를 판단한다.

쉼표 개수에 따라 몇자까지 반환할지는 아래와 같이 정의해놓고 사용했다.

```swift
var prefixLength: Int
switch commaCount {
case 1:
    prefixLength = 7
case 2:
    prefixLength = 8
default:
    prefixLength = 7
}
```

위의 예시 중에 "300,000,000"을 예로들면 일단 기본으로 8자리만큼 자른다.

그럼 "300,000,"이 되는데 여기서 쉼표 개수는 2개이므로 8을 반환한다. 
여기서 8만큼 다시 자르면 마지막 쉼표가 남는데 이걸 제거해준다.

그럼 성공적으로 "300,000"을 반환할 수 있다.

<img src = "https://github.com/user-attachments/assets/3386d034-981a-4cd9-aca0-419e3f7699ac" width = "300"/>

<br/>

### 3️⃣ 캘린더 오늘 이후 날짜 선택 방지

SpendingCalenderView의 .onTapGesture에 현재 날짜와 선택한 날짜를 비교해서 현재 날짜 이후인 경우 로직이 동작하지 않도록 하였다.

```swift
 .onTapGesture {
          let currentDate = Calendar.current.startOfDay(for: Date()) // 현재 날짜만 가져오기
          if 0 <= index && index < daysInMonth {
              let date = getDate(for: index)
              let dateOnly = Calendar.current.startOfDay(for: date)//선택한 날짜만 가져오기
              // 현재 날짜 이후인 경우 동작하지 않도록 함
              if dateOnly <= currentDate {//날짜 비교
```


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

피드백 반영했습니다~~
질문 있으면 말씀해주세요!!

<br/>

## 발견한 이슈
없음