### PR TITLE
📍 이전달 지출내역 조회 및 NavigationLink hidden 처리와 캘린더 동기화

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -228,7 +228,6 @@
 		4ADE80252BF23D2F007FFB01 /* ProfileSettingListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADE80242BF23D2F007FFB01 /* ProfileSettingListItem.swift */; };
 		4ADE802C2BF29055007FFB01 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADE802B2BF29055007FFB01 /* MainTabView.swift */; };
 		4AE1A61A2BD2D57600E7687B /* DynamicSizeFactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE1A6192BD2D57600E7687B /* DynamicSizeFactor.swift */; };
-		4AE8F3A62C32AB5C0014F0D4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4AE8F3A52C32AB5C0014F0D4 /* GoogleService-Info.plist */; };
 		4AE8F3A82C32AB970014F0D4 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3A72C32AB970014F0D4 /* GetTargetAmountForPreviousMonthResponseDto.swift */; };
 		4AE8F3AA2C32ABA50014F0D4 /* GetTargetAmountForDateResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3A92C32ABA50014F0D4 /* GetTargetAmountForDateResponseDto.swift */; };
 		4AE8F3AD2C32AED30014F0D4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3AC2C32AED30014F0D4 /* AppDelegate.swift */; };
@@ -247,6 +246,7 @@
 		B599E4C82C58EB74006051E9 /* SpendingAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4C72C58EB74006051E9 /* SpendingAnalyticsEvents.swift */; };
 		B599E4CA2C58F1CC006051E9 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4C92C58F1CC006051E9 /* AnalyticsManager.swift */; };
 		B599E4CD2C59067C006051E9 /* FirebaseAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4CC2C59067C006051E9 /* FirebaseAnalyticsService.swift */; };
+		D801BEB72C6A52EA00C012E1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D801BEB62C6A52EA00C012E1 /* GoogleService-Info.plist */; };
 		D809412E2BF276460015CFF9 /* ResetPwFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809412D2BF276460015CFF9 /* ResetPwFormView.swift */; };
 		D80E6A0F2BB2A7F5009F2DFE /* AgreementSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */; };
 		D80E6A152BB2E0C4009F2DFE /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -544,7 +544,6 @@
 		4ADE80242BF23D2F007FFB01 /* ProfileSettingListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingListItem.swift; sourceTree = "<group>"; };
 		4ADE802B2BF29055007FFB01 /* MainTabView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		4AE1A6192BD2D57600E7687B /* DynamicSizeFactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicSizeFactor.swift; sourceTree = "<group>"; };
-		4AE8F3A52C32AB5C0014F0D4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4AE8F3A72C32AB970014F0D4 /* GetTargetAmountForPreviousMonthResponseDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForPreviousMonthResponseDto.swift; sourceTree = "<group>"; };
 		4AE8F3A92C32ABA50014F0D4 /* GetTargetAmountForDateResponseDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetTargetAmountForDateResponseDto.swift; sourceTree = "<group>"; };
 		4AE8F3AC2C32AED30014F0D4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -564,6 +563,8 @@
 		B599E4C72C58EB74006051E9 /* SpendingAnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingAnalyticsEvents.swift; sourceTree = "<group>"; };
 		B599E4C92C58F1CC006051E9 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		B599E4CC2C59067C006051E9 /* FirebaseAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsService.swift; sourceTree = "<group>"; };
+		D801BEB62C6A52EA00C012E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		D801BEB82C6A52ED00C012E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D809412D2BF276460015CFF9 /* ResetPwFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPwFormView.swift; sourceTree = "<group>"; };
 		D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementSectionView.swift; sourceTree = "<group>"; };
 		D8157E632BBEF2040083844B /* InputFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputFormView.swift; sourceTree = "<group>"; };
@@ -1337,9 +1338,9 @@
 		4A762AEB2B99A16B001C1188 /* pennyway-client-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				D801BEB82C6A52ED00C012E1 /* GoogleService-Info.plist */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
-				4AE8F3A52C32AB5C0014F0D4 /* GoogleService-Info.plist */,
 				4A1179B32BA958ED00A9CF4C /* Info.plist */,
 				4A8571332BC650FA0082CE47 /* Constants */,
 				4A1179822BA9522D00A9CF4C /* Resource */,
@@ -1789,6 +1790,7 @@
 			children = (
 				4A762AEC2B99A16B001C1188 /* pennyway_client_iOSApp.swift */,
 				4AE8F3AC2C32AED30014F0D4 /* AppDelegate.swift */,
+				D801BEB62C6A52EA00C012E1 /* GoogleService-Info.plist */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2022,12 +2024,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4AE8F3A62C32AB5C0014F0D4 /* GoogleService-Info.plist in Resources */,
 				4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */,
 				4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */,
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
+				D801BEB72C6A52EA00C012E1 /* GoogleService-Info.plist in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/AdditionalOptionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/AdditionalOptionView.swift
@@ -7,7 +7,6 @@ struct AdditionalOptionView: View {
             NavigationLink(destination: PhoneVerificationView()) {
                 Text("회원가입")
             }
-            .hidden()
             .font(.B3MediumFont())
             .platformTextColor(color: Color("Gray04"))
             .simultaneousGesture(TapGesture().onEnded {
@@ -26,7 +25,6 @@ struct AdditionalOptionView: View {
             NavigationLink(destination: FindIdFormView()) {
                 Text("아이디 찾기")
             }
-            .hidden()
             .font(.B3MediumFont())
             .platformTextColor(color: Color("Gray04"))
 
@@ -40,7 +38,6 @@ struct AdditionalOptionView: View {
             NavigationLink(destination: FindPwView()) {
                 Text("비밀번호 찾기")
             }
-            .hidden()
             .font(.B3MediumFont())
             .platformTextColor(color: Color("Gray04"))
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/LoginOAuthButtonView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/LoginOAuthButtonView.swift
@@ -53,7 +53,8 @@ struct LoginOAuthButtonView: View {
             }
             NavigationLink(destination: PhoneVerificationView(), isActive: $isActiveLink) {
                 EmptyView()
-            }.hidden()
+            }
+            .hidden()
         }
         .padding(.top, 14 * DynamicSizeFactor.factor())
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -11,7 +11,7 @@ struct MySpendingListView: View {
     @State private var navigateToCategoryGridView = false
     @State private var showDetailSpendingView = false
     @State private var selectedSpendingId: Int? = nil
-    @State private var refreshView = false
+//    @State private var refreshView = false
     @State private var showToastPopup = false
     @State private var isDeleted = false
 
@@ -99,7 +99,7 @@ struct MySpendingListView: View {
                     }
                 }
             }
-            .id(refreshView)
+//            .id(refreshView)
             .overlay(
                 Group {
                     if showToastPopup {
@@ -161,7 +161,7 @@ struct MySpendingListView: View {
             spendingHistoryViewModel.checkSpendingHistoryApi { success in
                 if success {
                     Log.debug("소비내역 조회 api 연동 성공")
-                    refreshView = true
+//                    refreshView = true
                 } else {
                     Log.debug("소비내역 조회 api 연동 실패")
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -67,7 +67,7 @@ struct MySpendingListView: View {
                         }
                         if !SpendingListGroupUtil.groupedSpendings(from: spendingHistoryViewModel.dailyDetailSpendings).isEmpty {
                             Button(action: {
-//                                changeMonth(by: -1)
+                                changeMonth(by: -1)
 
                             }, label: {
                                 ZStack {
@@ -186,6 +186,9 @@ struct MySpendingListView: View {
         currentMonth = spendingHistoryViewModel.currentDate
         spendingHistoryViewModel.currentDate = newDate
         currentMonth = newDate
+
+        spendingHistoryViewModel.selectedDate = nil
+        spendingHistoryViewModel.selectedDateId = 0
 
         spendingHistoryViewModel.checkSpendingHistoryApi { success in
             if success {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/SpendingDetailSheetView.swift
@@ -85,6 +85,7 @@ struct SpendingDetailSheetView: View {
                                 Button(action: {
                                     selectedSpendingId = item.id
                                     showDetailSpendingView = true
+                                    Log.debug("selectedSpendingId: \(selectedSpendingId)")
                                 }, label: {
                                     CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
                                         .contentShape(Rectangle())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
@@ -7,7 +7,6 @@ struct ChangeMonthContentView: View {
     @State private var months: [Date]
 
     private let calendars = Calendar.current
-//    private let months: [Date]
 
     init(viewModel: SpendingHistoryViewModel, isPresented: Binding<Bool>) {
         self.viewModel = viewModel
@@ -59,9 +58,7 @@ struct ChangeMonthContentView: View {
                         HStack {
                             Button(action: {
                                 selectedMonth = month
-//                                viewModel.currentDate = month
-                                //                                viewModel.selectedDate = nil
-                                //                                viewModel.selectedDateId = 0
+                                viewModel.currentDate = month
 
                                 viewModel.checkSpendingHistoryApi { success in
                                     if success {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
@@ -4,14 +4,17 @@ struct ChangeMonthContentView: View {
     @ObservedObject var viewModel: SpendingHistoryViewModel
     @Binding var isPresented: Bool
     @State private var selectedMonth: Date
-    @State private var months: [Date]
+//    @State private var months: [Date]
 
     private let calendars = Calendar.current
+    private var months: [Date]
 
     init(viewModel: SpendingHistoryViewModel, isPresented: Binding<Bool>) {
         self.viewModel = viewModel
         _isPresented = isPresented
-        _selectedMonth = State(initialValue: viewModel.selectedDate ?? viewModel.currentDate)
+        _selectedMonth = State(initialValue: viewModel.currentDate)
+
+        Log.debug("_selectedMonth: \(_selectedMonth)")
 
         months = {
             let startDate = Calendar.current.date(from: DateComponents(year: 2000, month: 1)) ?? Date()
@@ -58,15 +61,16 @@ struct ChangeMonthContentView: View {
                         HStack {
                             Button(action: {
                                 selectedMonth = month
-                                viewModel.currentDate = month
+//                                viewModel.currentDate = month
+                                viewModel.updateCurrentDate(to: month)
 
-                                viewModel.checkSpendingHistoryApi { success in
-                                    if success {
-                                        Log.debug("해당날짜 소비내역 가져오기 성공")
-                                    } else {
-                                        Log.debug("해당날짜 소비내역 가져오기 실패")
-                                    }
-                                }
+//                                viewModel.checkSpendingHistoryApi { success in
+//                                    if success {
+//                                        Log.debug("해당날짜 소비내역 가져오기 성공")
+//                                    } else {
+//                                        Log.debug("해당날짜 소비내역 가져오기 실패")
+//                                    }
+//                                }
                             }, label: {
                                 Text(monthTitle(from: month))
                                     .font(.H4MediumFont())
@@ -84,6 +88,9 @@ struct ChangeMonthContentView: View {
             }
         }
         .edgesIgnoringSafeArea(.all)
+        .onAppear {
+            selectedMonth = viewModel.currentDate
+        }
     }
 
     func monthTitle(from date: Date) -> String {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
@@ -4,14 +4,15 @@ struct ChangeMonthContentView: View {
     @ObservedObject var viewModel: SpendingHistoryViewModel
     @Binding var isPresented: Bool
     @State private var selectedMonth: Date
+    @State private var months: [Date]
 
     private let calendars = Calendar.current
-    private let months: [Date]
+//    private let months: [Date]
 
     init(viewModel: SpendingHistoryViewModel, isPresented: Binding<Bool>) {
         self.viewModel = viewModel
         _isPresented = isPresented
-        _selectedMonth = State(initialValue: viewModel.currentDate)
+        _selectedMonth = State(initialValue: viewModel.selectedDate ?? viewModel.currentDate)
 
         months = {
             let startDate = Calendar.current.date(from: DateComponents(year: 2000, month: 1)) ?? Date()
@@ -58,7 +59,10 @@ struct ChangeMonthContentView: View {
                         HStack {
                             Button(action: {
                                 selectedMonth = month
-                                viewModel.currentDate = month
+//                                viewModel.currentDate = month
+                                //                                viewModel.selectedDate = nil
+                                //                                viewModel.selectedDateId = 0
+
                                 viewModel.checkSpendingHistoryApi { success in
                                     if success {
                                         Log.debug("해당날짜 소비내역 가져오기 성공")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/ChangeMonthContentView.swift
@@ -4,7 +4,6 @@ struct ChangeMonthContentView: View {
     @ObservedObject var viewModel: SpendingHistoryViewModel
     @Binding var isPresented: Bool
     @State private var selectedMonth: Date
-//    @State private var months: [Date]
 
     private let calendars = Calendar.current
     private var months: [Date]
@@ -61,16 +60,7 @@ struct ChangeMonthContentView: View {
                         HStack {
                             Button(action: {
                                 selectedMonth = month
-//                                viewModel.currentDate = month
                                 viewModel.updateCurrentDate(to: month)
-
-//                                viewModel.checkSpendingHistoryApi { success in
-//                                    if success {
-//                                        Log.debug("해당날짜 소비내역 가져오기 성공")
-//                                    } else {
-//                                        Log.debug("해당날짜 소비내역 가져오기 실패")
-//                                    }
-//                                }
                             }, label: {
                                 Text(monthTitle(from: month))
                                     .font(.H4MediumFont())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingCalendarView.swift
@@ -220,6 +220,9 @@ private extension SpendingCalenderView {
   
     /// 월 변경
     func changeMonth(by value: Int) {
+        spendingHistoryViewModel.selectedDate = nil
+        spendingHistoryViewModel.selectedDateId = 0
+        
         spendingHistoryViewModel.currentDate = adjustedMonth(by: value)
         spendingHistoryViewModel.checkSpendingHistoryApi { success in
             if success {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
@@ -274,16 +274,6 @@ private extension SpendingWeekCalendarView {
             selectedDateToScroll = dateFormatter(date: firstDayOfMonth)
             spendingHistoryViewModel.selectedDateToScroll = dateFormatter(date: firstDayOfMonth)
         }
-        spendingHistoryViewModel.checkSpendingHistoryApi { success in
-            if success {
-                Log.debug("지출내역 조회 API 연동 성공")
-                DispatchQueue.main.async {
-                    self.selectedDate = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: newDate))!
-                }
-            } else {
-                Log.fault("지출내역 조회 API 연동 실패")
-            }
-        }
     }
 
     /// 요일 추출

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
@@ -262,9 +262,12 @@ private extension SpendingWeekCalendarView {
             return
         }
 
-        let newDate = Calendar.current.date(byAdding: .month, value: value, to: currentMonth) ?? currentMonth
-        currentMonth = newDate
-        spendingHistoryViewModel.currentDate = currentMonth
+        let newDate = Calendar.current.date(byAdding: .month, value: value, to: spendingHistoryViewModel.currentDate) ?? Date()
+        spendingHistoryViewModel.updateCurrentDate(to: newDate)
+
+//        let newDate = Calendar.current.date(byAdding: .month, value: value, to: currentMonth) ?? currentMonth
+//        currentMonth = newDate
+//        spendingHistoryViewModel.currentDate = currentMonth
 
         selectedDate = Date() // 초기화
         userSelectedDate = nil // 사용자가 선택한 날짜 초기화
@@ -319,20 +322,11 @@ private extension SpendingWeekCalendarView {
     /// 다음 월로 이동 가능한지 확인
     private func canMoveToNextMonth() -> Bool {
         let calendar = Calendar.current
-        let currentDate = Date()
-        let currentMonthComponents = calendar.dateComponents([.year, .month], from: currentDate)
-        guard let currentMonthDate = calendar.date(from: currentMonthComponents) else {
-            return false
-        }
+        let currentMonthComponents = calendar.dateComponents([.year, .month], from: Date())
+        let currentMonthDate = calendar.date(from: currentMonthComponents)!
 
-        let nextMonthDate = calendar.date(byAdding: .month, value: 1, to: selectedDate)!
-        let nextMonthComponents = calendar.dateComponents([.year, .month], from: nextMonthDate)
-        guard let nextMonthStartDate = calendar.date(from: nextMonthComponents) else {
-            return false
-        }
-
-        // 다음 달이 현재 달보다 미래이면 이동 불가
-        return nextMonthStartDate <= currentMonthDate
+        // 다음 달이 현재 월 이후인지 확인
+        return spendingHistoryViewModel.currentDate <= currentMonthDate
     }
 
     /// 변경하려는 월 반환

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCalendarView/SpendingWeekCalendarView.swift
@@ -265,10 +265,6 @@ private extension SpendingWeekCalendarView {
         let newDate = Calendar.current.date(byAdding: .month, value: value, to: spendingHistoryViewModel.currentDate) ?? Date()
         spendingHistoryViewModel.updateCurrentDate(to: newDate)
 
-//        let newDate = Calendar.current.date(byAdding: .month, value: value, to: currentMonth) ?? currentMonth
-//        currentMonth = newDate
-//        spendingHistoryViewModel.currentDate = currentMonth
-
         selectedDate = Date() // 초기화
         userSelectedDate = nil // 사용자가 선택한 날짜 초기화
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -95,7 +95,6 @@ struct SpendingCheckBoxView: View {
                         }
                         .frame(alignment: .trailing)
                     }
-//                    .hidden()
                 } else {
                     Spacer()
 
@@ -112,7 +111,6 @@ struct SpendingCheckBoxView: View {
                         }
                         .frame(width: 110 * DynamicSizeFactor.factor(), alignment: .trailing)
                     }
-//                    .hidden()
                 }
             }
             .padding(.leading, 22)

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
@@ -48,7 +48,8 @@ class SpendingHistoryViewModel: ObservableObject {
     func checkSpendingHistoryApi(completion: @escaping (Bool) -> Void) {
         let calendar = Calendar.current
         let year = calendar.component(.year, from: currentDate)
-        let month = calendar.component(.month, from: currentDate)
+        let month = calendar.component(.month, from: selectedDate ?? currentDate)
+//        let month = calendar.component(.month, from: currentDate)
 
         let yearString = String(year)
         let monthString = String(month)

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
@@ -21,6 +21,22 @@ class SpendingHistoryViewModel: ObservableObject {
         return String(Date.month(from: currentDate))
     }
 
+    func updateCurrentDate(to date: Date) {
+        currentDate = date
+        selectedDate = nil
+        fetchSpendingHistory()
+    }
+
+    private func fetchSpendingHistory() {
+        checkSpendingHistoryApi { success in
+            if success {
+                Log.debug("소비내역 조회 api 연동 성공")
+            } else {
+                Log.debug("소비내역 조회 api 연동 실패")
+            }
+        }
+    }
+
     /// 선택한 날짜에 해당하는 소비내역을 필터링
     func filteredSpendings(for date: Date?) -> [IndividualSpending] {
         guard let date = date else {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingHistoryViewModel.swift
@@ -65,7 +65,6 @@ class SpendingHistoryViewModel: ObservableObject {
         let calendar = Calendar.current
         let year = calendar.component(.year, from: currentDate)
         let month = calendar.component(.month, from: selectedDate ?? currentDate)
-//        let month = calendar.component(.month, from: currentDate)
 
         let yearString = String(year)
         let monthString = String(month)


### PR DESCRIPTION
## 작업 이유
- 이전달 지출내역 조회안되던거 처리
- NavigationLink hidden처리
- 캘린더 동기화
<br/>

## 작업 사항
### **1️⃣ 이전달 지출내역 조회**
현재 달에 대한 지출내역 조회만 가능하고 이전달에 대한 지출내역 조회는 안되는 이슈가 있었다.
확인해보니 지난달로 변경하고 api를 호출했을 때도 현재달인 8월에 대한 데이터를 조회하고 있어서 발생한 문제였다

**문제가 되었던 부분**
```swift
 @Published var currentDate: Date = Date() // 현재 날짜

let month = calendar.component(.month, from: currentDate)
``` 
api를 호출하는 로직에서 현재달에 대한 month만 전달해주고 있었기 때문에 전의 달에 대한 데이터는 당연히 나오지 않았다.

따라서 아래와 같이 코드를 수정하였다.
**- 수정한 코드**

```swift
 let month = calendar.component(.month, from: selectedDate ?? currentDate)
``` 

selectedData 즉 선택된 달을 api로 호출해주고, 만약 선택된 달이 없다면 currentData를 넘겨주도록 하였다

문제는 이렇게 수정하고 나니 이전달로 넘어가서 지출내역 상세조회를 한 뒤 다음달로 넘어가면 저번달에 대한 지출내역이 이번달에 또 덮여씌어져서.. 나타나는 현상이 발생하였다.
그래서 달이 변경될 때 초기화 해주는 로직이 필요했다.
```
// SpendingCalenderView
spendingHistoryViewModel.selectedDate = nil
spendingHistoryViewModel.selectedDateId = 0

// SpendingWeekCalendarView
selectedDate = Date() // 초기화
userSelectedDate = nil // 사용자가 선택한 날짜 초기화
``` 

캘린더를 사용하는 두 곳에서 달이 변경됐을 때 위 로직을 통해 선택한 날짜를 초기화 하는 과정을 추가했더니 해결되었다!

### **2️⃣ NavigationLink hidden 처리**
기존에 손쉬운 사용에서 버튼 모양 활성화를 누르면 NavigationLink에 연결된 뷰들이 아무대나 배치되어 있는 현상이 있어서 모든 NavigationLink를 hidden처리 하였다.

하지만 NavigationLink { } 사이에 EmptyView가 아니거나 { }빈 뷰가 아닐 경우(즉 텍스트가 있을 경우)에 텍스트가 같이 hidden처리 되어 버튼모양 활성화를 하지 않더라도 보이지 않는 이슈가 생겼었다.

따라서  NavigationLink { } 사이에 EmptyView이거나 빈 뷰를 반환하고 있을 경우에 대해서만 hidden처리를 해주었고 text가 들어있는곳엔 다 제외하였다.

### **3️⃣ 캘린더 동기화**
SpendingWeekCalendarView와 ChangeMonthContentView가 서로 연동되어 있지 않은 문제를 해결했다.
뷰모델에서 전달받은 date값을 currentDate로 업데이트하였다. 
SpendingWeekCalendarView와 ChangeMonthContentView에서 달을 변경할 때 사용되는 currentDate의 상태를 뷰모델에서 관리함으로써 연동되어 사용할 수 있게 하였다.
```swift
    func updateCurrentDate(to date: Date) {
        currentDate = date
        selectedDate = nil
        fetchSpendingHistory()
    }

    private func fetchSpendingHistory() {
        checkSpendingHistoryApi { success in
            if success {
                Log.debug("소비내역 조회 api 연동 성공")
            } else {
                Log.debug("소비내역 조회 api 연동 실패")
            }
        }
    }
``` 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
이슈발생 했던거 해결했습니다~ 
하지만 또 다른 이슈를 낳았어요

<br/>

## 발견한 이슈
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-11 at 14 51 57](https://github.com/user-attachments/assets/33d326b6-b3f7-4ceb-ae15-b57075d0117f)
달변경 바텀시트를 통해 달을 변경하고 난 후 -> 이전 상태를 유지해야 하는데 계속 되돌아갈 때마다 뷰가 초기화되서 현재달인 8월로 포커싱되는 문제가 있었다. 그래서 MySpendingListView에서 강제 새로고침하는 `.id(refreshView)`를 지우니 위에 캘린더랑 밑에 스크롤 뷰랑 따로 논다 ㅋ ㅋ ..... 
어떻게 해결하지