### PR TITLE
📍 목표 금액 뷰에서 상세 소비 내역 뷰 이동 오류 해결 + 라이트 모드 설정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -2555,6 +2555,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2595,6 +2596,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -42,7 +42,7 @@ struct MySpendingListView: View {
                                                     clickDate = DateFormatterUtil.parseDate(from: date)
                                                     spendingHistoryViewModel.selectedDate = clickDate
                                                     selectedSpendingId = item.id
-                                                    Log.debug("Id: \(selectedSpendingId)")
+                                                    Log.debug("Id: \(selectedSpendingId), clickDate: \(clickDate)")
                                                     showDetailSpendingView = true
                                                 }, label: {
                                                     CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct PastSpendingListView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     @State private var navigateToMySpendingList = false
-    @State private var selectDate: Date = Date()
+    @State var currentMonth: Date = Date()
+    @State var clickDate: Date?
     
     var body: some View {
         ZStack {
@@ -44,7 +45,7 @@ struct PastSpendingListView: View {
                         .onTapGesture {
                             let components = DateComponents(year: content.year, month: content.month)
                             if let date = Calendar.current.date(from: components) {
-                                selectDate = date
+                                currentMonth = date
                             }
                             navigateToMySpendingList = true
                         }
@@ -74,7 +75,7 @@ struct PastSpendingListView: View {
             }
         }
         
-        NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: $selectDate, clickDate: .constant(nil)), isActive: $navigateToMySpendingList) {
+        NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: $currentMonth, clickDate: $clickDate), isActive: $navigateToMySpendingList) {
             EmptyView()
         }
         .hidden()


### PR DESCRIPTION
## 작업 이유

- 목표 금액 뷰에서 상세 소비 내역 뷰 이동 오류 해결


<br/>

## 작업 사항

### 1️⃣ 목표 금액 뷰에서 상세 소비 내역 뷰 이동 오류 해결

목표 금액 뷰에서 상세 소비 내역 뷰로 이동할 때 빈화면이 나오는 오류를 해결하였다.

PastSpendingListView에서 clickDate를 `.constant(nil)`으로 전달한 것이 문제였다.
`.constant(nil)`이렇게 전달하니 MySpendingListView에서 해당 지출 내역을 클릭했을 때 clickDate의 값이 업데이트가 되지 않고 계속 nil값으로 나오고 있었다.

그래서 .constant()가 아닌 @State로 clickDate변수를 선언하여 그 값을 넘겨주도록 수정하니 해결되었다.

```
NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: $currentMonth, clickDate: $clickDate, isActive: $navigateToMySpendingList) {
    EmptyView()
}
```

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-13 at 00 36 20](https://github.com/user-attachments/assets/dcdec067-f1c9-446d-8500-4ff80c3f26f3)

<br/>

### 2️⃣ 라이트 모드 설정

info 파일에 Appearance를 Light로 설정하여 다크모드는 제외하도록 설정했습니다!


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

목표 금액 뷰에서 상세 소비 내역 뷰 이동 오류 해결 했습니다~


<br/>

## 발견한 이슈
없음