### PR TITLE
📍 카테고리 이동시 삭제 반영 + percentEncodedQueryItems 오류 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		4AF69F642BFDF9E2001D49F8 /* BottomSheetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF69F632BFDF9E2001D49F8 /* BottomSheetExtension.swift */; };
 		4AFC7C9B2C581D9D003CFA8C /* TooManyRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */; };
 		4AFC7C9D2C581E1C003CFA8C /* TooManyRequestErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */; };
+		4AFF0C842C6A6B770040B192 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4AFF0C832C6A6B770040B192 /* GoogleService-Info.plist */; };
 		7C0E38D4CE51A896B5A498EE /* Pods_pennyway_client_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3E298D8A2B0690BBB7DB144 /* Pods_pennyway_client_iOS.framework */; };
 		B599E4BC2C58AE97006051E9 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4BB2C58AE97006051E9 /* AnalyticsService.swift */; };
 		B599E4BE2C58AF34006051E9 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4BD2C58AF34006051E9 /* AnalyticsEvent.swift */; };
@@ -247,7 +248,6 @@
 		B599E4CD2C59067C006051E9 /* FirebaseAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4CC2C59067C006051E9 /* FirebaseAnalyticsService.swift */; };
 		B599E4D82C68A76B006051E9 /* AuthAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4D72C68A76B006051E9 /* AuthAnalyticsEvents.swift */; };
 		B599E4DA2C68A8E6006051E9 /* TokenRefreshHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B599E4D92C68A8E6006051E9 /* TokenRefreshHandler.swift */; };
-		D801BEB72C6A52EA00C012E1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D801BEB62C6A52EA00C012E1 /* GoogleService-Info.plist */; };
 		D809412E2BF276460015CFF9 /* ResetPwFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809412D2BF276460015CFF9 /* ResetPwFormView.swift */; };
 		D80E6A0F2BB2A7F5009F2DFE /* AgreementSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */; };
 		D80E6A152BB2E0C4009F2DFE /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -554,6 +554,7 @@
 		4AF69F632BFDF9E2001D49F8 /* BottomSheetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetExtension.swift; sourceTree = "<group>"; };
 		4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooManyRequestError.swift; sourceTree = "<group>"; };
 		4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooManyRequestErrorCode.swift; sourceTree = "<group>"; };
+		4AFF0C832C6A6B770040B192 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A3E298D8A2B0690BBB7DB144 /* Pods_pennyway_client_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pennyway_client_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B599E4B92C555A01006051E9 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		B599E4BB2C58AE97006051E9 /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
@@ -565,8 +566,6 @@
 		B599E4CC2C59067C006051E9 /* FirebaseAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsService.swift; sourceTree = "<group>"; };
 		B599E4D72C68A76B006051E9 /* AuthAnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAnalyticsEvents.swift; sourceTree = "<group>"; };
 		B599E4D92C68A8E6006051E9 /* TokenRefreshHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRefreshHandler.swift; sourceTree = "<group>"; };
-		D801BEB62C6A52EA00C012E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		D801BEB92C6A540A00C012E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D809412D2BF276460015CFF9 /* ResetPwFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPwFormView.swift; sourceTree = "<group>"; };
 		D80E6A0E2BB2A7F5009F2DFE /* AgreementSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementSectionView.swift; sourceTree = "<group>"; };
 		D8157E632BBEF2040083844B /* InputFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputFormView.swift; sourceTree = "<group>"; };
@@ -612,7 +611,6 @@
 		D889F9F52C6484950055D045 /* CheckUnReadNotificationResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUnReadNotificationResponseDto.swift; sourceTree = "<group>"; };
 		D889F9F72C64BCC00055D045 /* DeleteProfileImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteProfileImageViewModel.swift; sourceTree = "<group>"; };
 		D889F9FB2C652CB50055D045 /* BasicButtonStyleUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicButtonStyleUtil.swift; sourceTree = "<group>"; };
-		D89F31C12C0049A100A51CFA /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../YU-LikeLion-iOS/YU-LikeLion-iOS/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameResponseDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Response/FindUserNameResponseDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameRequestDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Request/FindUserNameRequestDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7882BDA925F0019DE3C /* FindUserNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindUserNameViewModel.swift; sourceTree = "<group>"; };
@@ -1173,7 +1171,6 @@
 			isa = PBXGroup;
 			children = (
 				D89FB7882BDA925F0019DE3C /* FindUserNameViewModel.swift */,
-				D89F31C12C0049A100A51CFA /* GoogleService-Info.plist */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1341,7 +1338,7 @@
 		4A762AEB2B99A16B001C1188 /* pennyway-client-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				D801BEB92C6A540A00C012E1 /* GoogleService-Info.plist */,
+				4AFF0C832C6A6B770040B192 /* GoogleService-Info.plist */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
 				4A1179B32BA958ED00A9CF4C /* Info.plist */,
@@ -1793,7 +1790,6 @@
 			children = (
 				4A762AEC2B99A16B001C1188 /* pennyway_client_iOSApp.swift */,
 				4AE8F3AC2C32AED30014F0D4 /* AppDelegate.swift */,
-				D801BEB62C6A52EA00C012E1 /* GoogleService-Info.plist */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2032,7 +2028,7 @@
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
-				D801BEB72C6A52EA00C012E1 /* GoogleService-Info.plist in Resources */,
+				4AFF0C842C6A6B770040B192 /* GoogleService-Info.plist in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ObjectStorageDomain/ObjectStorageRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ObjectStorageDomain/ObjectStorageRouter.swift
@@ -69,7 +69,7 @@ enum ObjectStorageRouter: URLRequestConvertible {
                     URLQueryItem(name: "X-Amz-Signature", value: dto.signature)
                 ]
             
-            request = URLRequest.createURLRequest(url: baseURL, method: method, queryParameters: queryDatas, image: image)
+            request = URLRequest.createURLRequest(url: baseURL, method: method, queryParameters: queryDatas, image: image, percentEncoded: true)
         }
         return request
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/URLRequestExtension.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/URLRequestExtension.swift
@@ -4,7 +4,7 @@ import Foundation
 import OSLog
 
 extension URLRequest {
-    static func createURLRequest(url: URL, method: HTTPMethod, bodyParameters: [String: Any]? = nil, queryParameters: [URLQueryItem]? = nil, image: UIImage? = nil) -> URLRequest {
+    static func createURLRequest(url: URL, method: HTTPMethod, bodyParameters: [String: Any]? = nil, queryParameters: [URLQueryItem]? = nil, image: UIImage? = nil, percentEncoded: Bool? = false) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
 
@@ -25,7 +25,12 @@ extension URLRequest {
 
         if let queryParameters = queryParameters {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-            components?.percentEncodedQueryItems = queryParameters
+
+            if percentEncoded! {
+                components?.percentEncodedQueryItems = queryParameters
+            } else {
+                components?.queryItems = queryParameters
+            }
 
             if let urlWithQuery = components?.url {
                 request.url = urlWithQuery

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -10,12 +10,13 @@ struct CategoryDetailsView: View {
     @State private var selectedMenu: String? = nil // 선택한 메뉴
     @State private var listArray: [String] = ["수정하기", "카테고리 삭제"]
     @State private var showDeletePopUp = false
-    @State private var showToastPopup = false
+    @State private var showDeleteToastPopup = false
+    @State private var showMoveToastPopup = false // 카테고리 이동
     @State var isDeleted = false
     @State private var isNavigateToEditCategoryView = false
     @State private var isNavigateToMoveCategoryView = false
     
-    @Binding var showToastDeletePopUp: Bool
+    @Binding var showDeleteCategoryToastPopUp: Bool // 카테고리 삭제시
 
     var body: some View {
         ZStack {
@@ -49,7 +50,7 @@ struct CategoryDetailsView: View {
                         
                     Spacer().frame(height: 24 * DynamicSizeFactor.factor())
                         
-                    CategorySpendingListView(viewModel: viewModel, showToastPopup: $showToastPopup, isDeleted: $isDeleted)
+                    CategorySpendingListView(viewModel: viewModel, showDeleteToastPopup: $showDeleteToastPopup, isDeleted: $isDeleted)
                         
                     Spacer()
                 }
@@ -57,19 +58,24 @@ struct CategoryDetailsView: View {
             }
             .overlay(
                 Group {
-                    if showToastPopup {
-                        CustomToastView(message: "소비내역이 삭제되었어요")
+                    if showDeleteToastPopup || showMoveToastPopup {
+                        CustomToastView(message: showDeleteToastPopup ? "소비 내역을 삭제했어요" : "소비 내역을 이동시켰어요")
                             .transition(.move(edge: .bottom))
                             .animation(.easeInOut(duration: 0.2)) // 애니메이션 시간
                             .padding(.bottom, 34)
                             .onAppear {
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                    showToastPopup = false
+                                    if showDeleteToastPopup {
+                                        showDeleteToastPopup = false
+                                    } else {
+                                        showMoveToastPopup = false
+                                    }
                                 }
                             }
                     }
                 }, alignment: .bottom
             )
+            
             .overlay(
                 VStack(alignment: .leading) {
                     if isClickMenu {
@@ -131,7 +137,7 @@ struct CategoryDetailsView: View {
             .onChange(of: isDeleted) { newValue in
                 if newValue {
                     refreshView {
-                        showToastPopup = true
+                        showDeleteToastPopup = true
                     }
                     isDeleted = false
                 }
@@ -154,7 +160,7 @@ struct CategoryDetailsView: View {
                                 viewModel.getSpendingCustomCategoryListApi { _ in
                                     self.showDeletePopUp = false
                                     self.presentationMode.wrappedValue.dismiss()
-                                    self.showToastDeletePopUp = true
+                                    self.showDeleteCategoryToastPopUp = true
                                 }
                             }
                         }
@@ -166,7 +172,7 @@ struct CategoryDetailsView: View {
             NavigationLink(destination: AddSpendingCategoryView(viewModel: AddSpendingHistoryViewModel(), spendingCategoryViewModel: viewModel, entryPoint: .modify), isActive: $isNavigateToEditCategoryView) {}
                 .hidden()
             
-            NavigationLink(destination: MoveCategoryView(spendingCategoryViewModel: viewModel, addSpendingHistoryViewModel: AddSpendingHistoryViewModel()), isActive: $isNavigateToMoveCategoryView) {}
+            NavigationLink(destination: MoveCategoryView(spendingCategoryViewModel: viewModel, addSpendingHistoryViewModel: AddSpendingHistoryViewModel(), showMoveToastPopup: $showMoveToastPopup), isActive: $isNavigateToMoveCategoryView) {}
                 .hidden()
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -27,38 +27,36 @@ struct CategorySpendingListView: View {
                         }
 
                         Section(header: headerView(for: date)) {
-                            VStack(spacing: 0) {
-                                Spacer().frame(height: 12 * DynamicSizeFactor.factor())
-                                ForEach(spendings, id: \.id) { item in
-                                    let iconName = SpendingListViewCategoryIconList(rawValue: item.category.icon)?.iconName ?? ""
+                            Spacer().frame(height: 12 * DynamicSizeFactor.factor())
+                            ForEach(spendings, id: \.id) { item in
+                                let iconName = SpendingListViewCategoryIconList(rawValue: item.category.icon)?.iconName ?? ""
 
-                                    Button(action: {
-                                        spendingId = item.id
-                                        viewModel.dailyDetailSpendings = [item]
-                                        showDetailSpendingView = true
+                                Button(action: {
+                                    spendingId = item.id
+                                    viewModel.dailyDetailSpendings = [item]
+                                    showDetailSpendingView = true
 
-                                    }, label: {
-                                        CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
-                                            .contentShape(Rectangle())
-                                    })
-                                    .buttonStyle(PlainButtonStyle())
-                                    .buttonStyle(BasicButtonStyleUtil())
+                                }, label: {
+                                    CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
+                                        .contentShape(Rectangle())
+                                })
+                                .buttonStyle(PlainButtonStyle())
+                                .buttonStyle(BasicButtonStyleUtil())
 
-                                    Spacer().frame(height: 8 * DynamicSizeFactor.factor())
+                                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
 
-                                        .onAppear {
-                                            guard let index = viewModel.dailyDetailSpendings.firstIndex(where: { $0.id == item.id }) else {
-                                                return
-                                            }
-                                            // 해당 index가 마지막 index라면 데이터 추가
-                                            if index == viewModel.dailyDetailSpendings.count - 1 {
-                                                Log.debug("지출 내역 index: \(index)")
-                                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { // 임시 버퍼링
-                                                    viewModel.getCategorySpendingHistoryApi { _ in }
-                                                }
+                                    .onAppear {
+                                        guard let index = viewModel.dailyDetailSpendings.firstIndex(where: { $0.id == item.id }) else {
+                                            return
+                                        }
+                                        // 해당 index가 마지막 index라면 데이터 추가
+                                        if index == viewModel.dailyDetailSpendings.count - 1 {
+                                            Log.debug("지출 내역 index: \(index)")
+                                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { // 임시 버퍼링
+                                                viewModel.getCategorySpendingHistoryApi { _ in }
                                             }
                                         }
-                                }
+                                    }
                             }
                         }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -43,7 +43,7 @@ struct CategorySpendingListView: View {
                                 .buttonStyle(PlainButtonStyle())
                                 .buttonStyle(BasicButtonStyleUtil())
 
-                                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
+                                Spacer().frame(height: 12 * DynamicSizeFactor.factor())
 
                                     .onAppear {
                                         guard let index = viewModel.dailyDetailSpendings.firstIndex(where: { $0.id == item.id }) else {
@@ -59,8 +59,6 @@ struct CategorySpendingListView: View {
                                     }
                             }
                         }
-
-                        Spacer()
                     }
                 }
                 Spacer().frame(height: 18 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -45,19 +45,20 @@ struct CategorySpendingListView: View {
                                     .buttonStyle(PlainButtonStyle())
                                     .buttonStyle(BasicButtonStyleUtil())
 
-                                    .onAppear {
-                                        guard let index = viewModel.dailyDetailSpendings.firstIndex(where: { $0.id == item.id }) else {
-                                            return
-                                        }
-                                        // 해당 index가 마지막 index라면 데이터 추가
-                                        if index == viewModel.dailyDetailSpendings.count - 1 {
-                                            Log.debug("지출 내역 index: \(index)")
-                                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { // 임시 버퍼링
-                                                viewModel.getCategorySpendingHistoryApi { _ in }
+                                    Spacer().frame(height: 12 * DynamicSizeFactor.factor())
+
+                                        .onAppear {
+                                            guard let index = viewModel.dailyDetailSpendings.firstIndex(where: { $0.id == item.id }) else {
+                                                return
+                                            }
+                                            // 해당 index가 마지막 index라면 데이터 추가
+                                            if index == viewModel.dailyDetailSpendings.count - 1 {
+                                                Log.debug("지출 내역 index: \(index)")
+                                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { // 임시 버퍼링
+                                                    viewModel.getCategorySpendingHistoryApi { _ in }
+                                                }
                                             }
                                         }
-                                    }
-                                    Spacer().frame(height: 12 * DynamicSizeFactor.factor())
                                 }
                             }
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -5,8 +5,7 @@ struct CategorySpendingListView: View {
     @State private var clickDate: Date? = nil
     @State private var spendingId: Int? = nil
     @State private var showDetailSpendingView = false
-    @State private var needRefresh = false
-    @Binding var showToastPopup: Bool
+    @Binding var showDeleteToastPopup: Bool
     @Binding var isDeleted: Bool
 
     var currentYear = String(Date.year(from: Date()))
@@ -70,7 +69,7 @@ struct CategorySpendingListView: View {
             }
         }
 
-        NavigationLink(destination: DetailSpendingView(clickDate: $clickDate, spendingId: $spendingId, isDeleted: $isDeleted, showToastPopup: $showToastPopup, spendingCategoryViewModel: viewModel), isActive: $showDetailSpendingView) {}
+        NavigationLink(destination: DetailSpendingView(clickDate: $clickDate, spendingId: $spendingId, isDeleted: $isDeleted, showToastPopup: $showDeleteToastPopup, spendingCategoryViewModel: viewModel), isActive: $showDetailSpendingView) {}
             .hidden()
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -44,7 +44,7 @@ struct CategorySpendingListView: View {
                                     .buttonStyle(PlainButtonStyle())
                                     .buttonStyle(BasicButtonStyleUtil())
 
-                                    Spacer().frame(height: 12 * DynamicSizeFactor.factor())
+                                    Spacer().frame(height: 8 * DynamicSizeFactor.factor())
 
                                         .onAppear {
                                             guard let index = viewModel.dailyDetailSpendings.firstIndex(where: { $0.id == item.id }) else {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/MoveCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/MoveCategoryView.swift
@@ -7,6 +7,8 @@ struct MoveCategoryView: View {
     @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
     @ObservedObject var addSpendingHistoryViewModel: AddSpendingHistoryViewModel
     @Environment(\.presentationMode) var presentationMode
+    
+    @Binding var showMoveToastPopup: Bool
 
     @State var navigateToAddCategoryView = false
     @State var showingPopUp = false
@@ -133,6 +135,7 @@ struct MoveCategoryView: View {
                 spendingCategoryViewModel.selectedCategory = spendingCategoryViewModel.selectedMoveCategory // 이동할 카테고리로 변경
                 spendingCategoryViewModel.selectedCategory?.icon = MapCategoryIconUtil.mapToCategoryIcon(spendingCategoryViewModel.selectedMoveCategory!.icon, outputState: .on) // icon 회색으로 변경
                 spendingCategoryViewModel.selectedMoveCategory = nil // 선택한 카테고리 초기화
+                showMoveToastPopup = true
                 spendingCategoryViewModel.getCategorySpendingCountApi { _ in } // 총 개수 조회
                 spendingCategoryViewModel.getCategorySpendingHistoryApi { success in // 지출 내역 조회
                     if success {
@@ -145,5 +148,5 @@ struct MoveCategoryView: View {
 }
 
 #Preview {
-    MoveCategoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), addSpendingHistoryViewModel: AddSpendingHistoryViewModel())
+    MoveCategoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), addSpendingHistoryViewModel: AddSpendingHistoryViewModel(), showMoveToastPopup: .constant(false))
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/SpendingCategoryGridView.swift
@@ -10,7 +10,7 @@ struct SpendingCategoryGridView: View {
     
     @State var navigateToCategoryDetails = false
     @State var navigateToAddCategoryView = false
-    @State private var showToastDeletePopUp = false
+    @State private var showDeleteCategoryToastPopUp = false
 
     var body: some View {
         ZStack {
@@ -48,14 +48,14 @@ struct SpendingCategoryGridView: View {
             }
             .overlay(
                 Group {
-                    if showToastDeletePopUp {
+                    if showDeleteCategoryToastPopUp {
                         CustomToastView(message: "카테고리를 삭제했어요")
                             .transition(.move(edge: .bottom))
                             .animation(.easeInOut(duration: 0.2)) // 애니메이션 시간
                             .padding(.bottom, 34)
                             .onAppear {
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                    showToastDeletePopUp = false
+                                    showDeleteCategoryToastPopUp = false
                                 }
                             }
                     }
@@ -97,7 +97,7 @@ struct SpendingCategoryGridView: View {
             }
         }
 
-        NavigationLink(destination: CategoryDetailsView(viewModel: spendingCategoryViewModel, showToastDeletePopUp: $showToastDeletePopUp), isActive: $navigateToCategoryDetails) {}
+        NavigationLink(destination: CategoryDetailsView(viewModel: spendingCategoryViewModel, showDeleteCategoryToastPopUp: $showDeleteCategoryToastPopUp), isActive: $navigateToCategoryDetails) {}
             .hidden()
 
         NavigationLink(destination: AddSpendingCategoryView(viewModel: addSpendingHistoryViewModel, spendingCategoryViewModel: spendingCategoryViewModel, entryPoint: .create), isActive: $navigateToAddCategoryView) {}

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
@@ -227,9 +227,14 @@ class SpendingCategoryViewModel: ObservableObject {
             case let .success(data):
                 if let responseData = data {
                     if let jsonString = String(data: responseData, encoding: .utf8) {
-                        Log.debug("카테고리 이동 완료 \(jsonString)")
+                        self.deleteCategoryApi { success in
+                            if success {
+                                Log.debug("카테고리 이동 및 삭제 완료 \(jsonString)")
+                                self.customCategories.removeAll { $0.id == self.selectedCategory!.id }
+                                completion(true)
+                            }
+                        }
                     }
-                    completion(true)
                 }
             case let .failure(error):
                 if let StatusSpecificError = error as? StatusSpecificError {


### PR DESCRIPTION
## 작업 이유

- 카테고리 지출내역 이동한 후 카테고리 삭제하기
- 카테고리의 지출 내역 리스트 간격 수정
- percentEncodedQueryItems 오류 수정

<br/>

## 작업 사항

### 1️⃣ 카테고리 지출내역 이동한 후 카테고리 삭제하기

카테고리 이동 후 카테고리 삭제도 함께 작동하도록 구현하였다.

- 카테고리 이동에 성공하면 카테고리 삭제 api 요청

카테고리 삭제까지 성공하면 사용자 정의 카테고리 배열인 customCategories에서 삭제한 카테고리 id 값을 가진 데이터를 삭제하였다.
그래서 카테고리 삭제 후 다시 카테고리 조회 api요청을 하지 않도록 해서 api 요청을 줄였다.

```swift
SpendingCategoryAlamofire.shared.moveCategory(selectedCategory!.id, moveCategoryRequestDto) { result in
            switch result {
            case let .success(data):
                if let responseData = data {
                    if let jsonString = String(data: responseData, encoding: .utf8) {
                        self.deleteCategoryApi { success in
                            if success {
                                Log.debug("카테고리 이동 및 삭제 완료 \(jsonString)")
                                self.customCategories.removeAll { $0.id == self.selectedCategory!.id }//사용자 정의 카테고리에서 삭제
                                completion(true)
                            }
                        }
                    }
                }
```

CategoryDetailsView의 showMoveToastPopup를 사용하여 카테고리 이동이 완료되면 toastPopup을 보여주도록 했다.
이미 CategoryDetailsView에서 showDeleteToastPopup로 소비 내역 삭제도 판단하고 있기 때문에 조건문으로 어떤 문구를 보여줄지 구분하였다.

```
if showDeleteToastPopup || showMoveToastPopup {
                        CustomToastView(message: showDeleteToastPopup ? "소비 내역을 삭제했어요" : "소비 내역을 이동시켰어요")
```

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-13 at 01 56 28](https://github.com/user-attachments/assets/ea7fbfb2-9de9-461f-b15b-c2c7d7b2dc3c)


### 2️⃣ 카테고리의 지출 내역 리스트 간격 수정

카테고리의 지출 내역 리스트 사이의 간격이 넓어 아래와 같이 수정하였다

<img src = "https://github.com/user-attachments/assets/ad681414-11d2-40bf-9c53-69fdcb444452" width = "300"/>
<img src = "https://github.com/user-attachments/assets/02a2dc80-d7a0-4566-9660-d0e6f2dd6941" width = "300"/>

### 3️⃣ percentEncodedQueryItems 오류 수정

request를 보낼때 % 인코딩하는 문제 때문에 queryItems가 아니라 percentEncodedQueryItems로 변경했었다.
하지만 아래와 같이 percentEncodedQueryItems오류가 발생하여 presigned url 저장하는 api 요청에만 percentEncodedQueryItems를 사용하도록 하였다.

![스크린샷 2024-08-13 오전 1 28 46](https://github.com/user-attachments/assets/00a48133-18c2-409f-919d-a1ed262a0754)

createURLRequest() 함수에 percentEncoded를 bool 값으로 받아 percentEncodedQueryItems와 queryItems 사용 여부를 분기처리하였다.

 ```swift
if let queryParameters = queryParameters {
    var components = URLComponents(url: url, resolvingAgainstBaseURL: false)

    if percentEncoded! {
        components?.percentEncodedQueryItems = queryParameters
    } else {
        components?.queryItems = queryParameters
    }

    if let urlWithQuery = components?.url {
        request.url = urlWithQuery
    }
}
```


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

카테고리 이동 후 삭제 반영하였고 3️⃣번 오류 발생으로 수정한 거 확인부탁드립니다~


<br/>

## 발견한 이슈
없음