### PR TITLE
🎨📍알람 조회시 시간문구 변경

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
@@ -37,4 +37,35 @@ enum DateFormatterUtil {
         yearFormatter.dateFormat = "yyyy"
         return yearFormatter.string(from: date)
     }
+
+    static func formatRelativeDate(from dateString: String) -> String {
+        guard let date = dateFromString(dateString) else {
+            return dateString
+        }
+
+        // 현재 시간
+        let now = Date()
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .weekOfYear, .day, .hour, .minute], from: date, to: now)
+
+        if let year = components.year, year > 0 {
+            return "\(year)년 전"
+        } else if let month = components.month, month > 0 {
+            return "\(month)달 전"
+        } else if let week = components.weekOfYear, week > 0 {
+            return "\(week)주일 전"
+        } else if let day = components.day, day > 0 {
+            switch day {
+            case 1: return "어제"
+            case 2 ... 6: return "\(day)일 전"
+            default: return "1주일 전"
+            }
+        } else if let hour = components.hour, hour > 0 {
+            return "\(hour)시간 전"
+        } else if let minute = components.minute, minute > 0 {
+            return "\(minute)분 전"
+        } else {
+            return "오늘"
+        }
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpView.swift
@@ -67,9 +67,9 @@ struct SignUpView: View {
             
             NavigationLink(destination: destinationView(), tag: 3, selection: $viewModel.selectedText) {}.hidden()
         }
-        
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(true)
+        .navigationBarColor(UIColor(named: "White01"), title: "")
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 HStack {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileAlarmView/ArrivedAlarmView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileAlarmView/ArrivedAlarmView.swift
@@ -65,7 +65,7 @@ struct AlarmRow: View {
                     .font(.B1MediumFont())
                     .platformTextColor(color: Color("Gray07"))
 
-                Text(alarm.createdAt)
+                Text(DateFormatterUtil.formatRelativeDate(from: alarm.createdAt))
                     .font(.B1MediumFont())
                     .platformTextColor(color: Color("Gray04"))
             }


### PR DESCRIPTION
## 작업 이유
- 알람 조회시 시간 문구 반영

<br/>

## 작업 사항
### **1️⃣ 알람 조회시 시간 문구 반영**
디자인팀한테 답변받은 문구는 아래와 같다.

<img width="497" alt="스크린샷 2024-08-13 오후 12 38 23" src="https://github.com/user-attachments/assets/b9a0f276-cd72-454e-b87c-e5703e73fff2">


원래는 api에서 응답받은 creadtedAt을 그대로 받고 있었는데 이걸 적절한 시간 문구로 보여줄 포멧터가 필요하여 DateFormatterUtil에 구현하였다.

1. createdAt시간은 문자열로 반환되고 있기때문에 이 문자열을 Date로 변환해줘야 했다. 그래서 받아온 날짜가 string이기 때문에 날짜 문자열을 Date객체로 변환하는 dateFromString를 사용해서 변환시켰다.
```swift
guard let date = dateFromString(dateString) else {
            return dateString
        }
``` 

2. 현재 날짜를 계산해서 비교해야 하기 때문에 현재 날짜를 구하는 로직을 추가시켰다.
3. 현재날짜와 입력으로 받아온 createdAt를 비교하여 적절한 문구가 나오게 맵핑시켜주는 로직을 추가하였다.
```swift
        if let year = components.year, year > 0 {
            return "\(year)년 전"
        } else if let month = components.month, month > 0 {
            return "\(month)달 전"
        } else if let week = components.weekOfYear, week > 0 {
            return "\(week)주일 전"
        } else if let day = components.day, day > 0 {
            switch day {
            case 1: return "어제"
            case 2 ... 6: return "\(day)일 전"
            default: return "1주일 전"
            }
        } else if let hour = components.hour, hour > 0 {
            return "\(hour)시간 전"
        } else if let minute = components.minute, minute > 0 {
            return "\(minute)분 전"
        } else {
            return "오늘"
        }
``` 

**동작과정**

<img src ="https://github.com/user-attachments/assets/e612c678-4db0-4cee-814f-6b90fcf54f9d" width = "350" heigth ="500">


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
알람 조회시 시간 문구 디자인팀한테 답변받은거 반영했습니다!

그리고 회원가입 화면에서 네비게이션바가 설정되어 있지않은 문제도 해결했습니다!

<br/>

## 발견한 이슈
x