### PR TITLE
📍 OAuth 계정 연동/해제 오류 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
@@ -4,9 +4,14 @@ import SwiftUI
 struct ProfileMenuBarListView: View {
     @State private var showLogoutPopUp = false
     @State private var showDeleteUserPopUp = false
+    @State private var showUnLinkPopUp = false
+    @State private var provider = ""
     @EnvironmentObject var authViewModel: AppViewModel
     @StateObject var userProfileViewModel = UserLogoutViewModel()
     @StateObject var userAccountViewModel = UserAccountViewModel()
+    @StateObject var kakaoOAuthViewModel: KakaoOAuthViewModel = KakaoOAuthViewModel()
+    @StateObject var googleOAuthViewModel: GoogleOAuthViewModel = GoogleOAuthViewModel()
+    @StateObject var appleOAuthViewModel: AppleOAuthViewModel = AppleOAuthViewModel()
 
     @State private var navigateCompleteView = false
 
@@ -14,7 +19,7 @@ struct ProfileMenuBarListView: View {
         ZStack {
             ScrollView {
                 VStack {
-                    ProfileOAuthButtonView()
+                    ProfileOAuthButtonView(kakaoOAuthViewModel: kakaoOAuthViewModel, googleOAuthViewModel: googleOAuthViewModel, appleOAuthViewModel: appleOAuthViewModel, showUnLinkPopUp: $showUnLinkPopUp, provider: $provider)
 
                     Spacer().frame(height: 9 * DynamicSizeFactor.factor())
 
@@ -35,6 +40,19 @@ struct ProfileMenuBarListView: View {
 
                     }.offset(x: -10)
                 }
+            }
+
+            if showUnLinkPopUp {
+                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                CustomPopUpView(showingPopUp: $showLogoutPopUp,
+                                titleLabel: "계정 연동을 해제할까요?",
+                                subTitleLabel: "해제하더라도 다시 연동할 수 있어요",
+                                firstBtnAction: { self.showUnLinkPopUp = false },
+                                firstBtnLabel: "취소",
+                                secondBtnAction: handleUnLinkAccount,
+                                secondBtnLabel: "해제하기",
+                                secondBtnColor: Color("Gray05")
+                )
             }
 
             if showLogoutPopUp {
@@ -95,6 +113,20 @@ struct ProfileMenuBarListView: View {
                 }
             }
         }
+    }
+
+    func handleUnLinkAccount() {
+        switch provider {
+        case "kakao":
+            kakaoOAuthViewModel.signIn()
+        case "google":
+            googleOAuthViewModel.signIn()
+        case "apple":
+            appleOAuthViewModel.signIn()
+        default:
+            Log.debug("계정 연동 해제 실패")
+        }
+        showUnLinkPopUp = false
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileOAuthButtonView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileOAuthButtonView.swift
@@ -49,5 +49,8 @@ struct ProfileOAuthButtonView: View {
 
         .frame(maxWidth: .infinity)
         .background(Color("White01"))
+        .onAppear{
+            
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileOAuthButtonView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileOAuthButtonView.swift
@@ -8,10 +8,6 @@ struct ProfileOAuthButtonView: View {
 
     @EnvironmentObject var authViewModel: AppViewModel
 
-    private var existKakaoOAuthAccount: Bool = getUserData()?.oauthAccount.kakao ?? false
-    private var existGoogleOAuthAccount: Bool = getUserData()?.oauthAccount.google ?? false
-    private var existAppleOAuthAccount: Bool = getUserData()?.oauthAccount.apple ?? false
-
     var body: some View {
         VStack(alignment: .center) {
             Spacer().frame(height: 24 * DynamicSizeFactor.factor())
@@ -23,9 +19,9 @@ struct ProfileOAuthButtonView: View {
             Spacer().frame(height: 16 * DynamicSizeFactor.factor())
 
             OAuthButtonView(
-                isKakaoLoggedIn: existKakaoOAuthAccount,
-                isGoogleLoggedIn: existGoogleOAuthAccount,
-                isAppleLoggedIn: existAppleOAuthAccount,
+                isKakaoLoggedIn: kakaoOAuthViewModel.existOAuthAccount,
+                isGoogleLoggedIn: googleOAuthViewModel.existOAuthAccount,
+                isAppleLoggedIn: appleOAuthViewModel.existOAuthAccount,
 
                 kakaoAction: { // Kakao 로그인 액션 처리
                     kakaoOAuthViewModel.isLoggedIn = authViewModel.isLoggedIn
@@ -49,8 +45,5 @@ struct ProfileOAuthButtonView: View {
 
         .frame(maxWidth: .infinity)
         .background(Color("White01"))
-        .onAppear{
-            
-        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileOAuthButtonView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileOAuthButtonView.swift
@@ -2,10 +2,12 @@
 import SwiftUI
 
 struct ProfileOAuthButtonView: View {
-    @StateObject var kakaoOAuthViewModel: KakaoOAuthViewModel = KakaoOAuthViewModel()
-    @StateObject var googleOAuthViewModel: GoogleOAuthViewModel = GoogleOAuthViewModel()
-    @StateObject var appleOAuthViewModel: AppleOAuthViewModel = AppleOAuthViewModel()
+    @ObservedObject var kakaoOAuthViewModel: KakaoOAuthViewModel
+    @ObservedObject var googleOAuthViewModel: GoogleOAuthViewModel
+    @ObservedObject var appleOAuthViewModel: AppleOAuthViewModel
 
+    @Binding var showUnLinkPopUp: Bool
+    @Binding var provider: String
     @EnvironmentObject var authViewModel: AppViewModel
 
     var body: some View {
@@ -25,18 +27,34 @@ struct ProfileOAuthButtonView: View {
 
                 kakaoAction: { // Kakao 로그인 액션 처리
                     kakaoOAuthViewModel.isLoggedIn = authViewModel.isLoggedIn
-                    kakaoOAuthViewModel.signIn()
                     OAuthRegistrationManager.shared.provider = Provider.kakao.rawValue
+                    if kakaoOAuthViewModel.existOAuthAccount {
+                        showUnLinkPopUp = true
+                        provider = "kakao"
+                    } else {
+                        kakaoOAuthViewModel.signIn()
+                    }
                 },
                 googleAction: { // Google 로그인 액션 처리
                     googleOAuthViewModel.isLoggedIn = authViewModel.isLoggedIn
-                    googleOAuthViewModel.signIn()
                     OAuthRegistrationManager.shared.provider = Provider.google.rawValue
+
+                    if googleOAuthViewModel.existOAuthAccount {
+                        showUnLinkPopUp = true
+                        provider = "google"
+                    } else {
+                        googleOAuthViewModel.signIn()
+                    }
                 },
                 appleAction: { // Apple 로그인 액션 처리
                     appleOAuthViewModel.isLoggedIn = authViewModel.isLoggedIn
-                    appleOAuthViewModel.signIn()
                     OAuthRegistrationManager.shared.provider = Provider.apple.rawValue
+                    if appleOAuthViewModel.existOAuthAccount {
+                        showUnLinkPopUp = true
+                        provider = "apple"
+                    } else {
+                        appleOAuthViewModel.signIn() // 계정 연동
+                    }
                 }
             )
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -21,6 +21,7 @@ class AppViewModel: ObservableObject {
                         let response = try JSONDecoder().decode(AuthResponseDto.self, from: responseData)
                         Log.debug(response)
                         self?.checkLoginState = true
+                        self?.isLoggedIn = true
 
                         Log.debug(KeychainHelper.loadAccessToken())
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/AppleOAuthViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/AppleOAuthViewModel.swift
@@ -11,7 +11,7 @@ class AppleOAuthViewModel: NSObject, ObservableObject {
     @Published var isLoggedIn: Bool = false // 로그인 여부
     @Published var isLoginSuccessful = false
     
-    private var existOAuthAccount: Bool = getUserData()?.oauthAccount.apple ?? false
+    @Published var existOAuthAccount: Bool = getUserData()?.oauthAccount.apple ?? false
     var oauthUserData = OAuthUserData(oauthId: "", idToken: "", nonce: "")
     let oauthAccountViewModel = OAuthAccountViewModel()
     

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/GoogleOAuthViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/GoogleOAuthViewModel.swift
@@ -9,7 +9,7 @@ class GoogleOAuthViewModel: ObservableObject {
     @Published var isLoggedIn: Bool = false // 로그인 여부 
     @Published var isLoginSuccessful = false
     
-    private var existOAuthAccount: Bool = getUserData()?.oauthAccount.google ?? false
+    @Published var existOAuthAccount: Bool = getUserData()?.oauthAccount.google ?? false
     private var oauthUserData = OAuthUserData(oauthId: "", idToken: "", nonce: "")
     let oauthAccountViewModel = OAuthAccountViewModel()
     

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/KakaoOAuthViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/KakaoOAuthViewModel.swift
@@ -9,7 +9,7 @@ class KakaoOAuthViewModel: ObservableObject {
     @Published var isLoggedIn: Bool = false // 로그인 여부
     @Published var isLoginSuccessful = false
 
-    private var existOAuthAccount: Bool = getUserData()?.oauthAccount.kakao ?? false
+    @Published var existOAuthAccount: Bool = getUserData()?.oauthAccount.kakao ?? false
     private var oauthUserData = OAuthUserData(oauthId: "", idToken: "", nonce: "")
     let oauthAccountViewModel = OAuthAccountViewModel()
 
@@ -79,7 +79,7 @@ class KakaoOAuthViewModel: ObservableObject {
             oauthUserData.nonce = CryptoHelper.sha256(randomNonce)
 
             // 카카오 로그인 실행
-            UserApi.shared.loginWithKakaoAccount(prompts: [.Login], nonce: oauthUserData.nonce) { oauthToken, error in
+            UserApi.shared.loginWithKakaoAccount(prompts: [.SelectAccount], nonce: oauthUserData.nonce) { oauthToken, error in
                 if let error = error {
                     print(error)
                 } else {


### PR DESCRIPTION
## 작업 이유

- OAuth 계정 연동/해제 오류 

<br/>

## 작업 사항

### 1️⃣ OAuth 계정 연동/해제 오류 

OAuth 계정 연동/해제 오류가 발생하는 이유를 찾아보니 자동 로그인하는 경우 로그인 AppViewModel의 isLoggedIn 변수를 true로 바꿔주지 않았던 것이 문제였다. ㅎㅎ

그래서 자동 로그인 성공하면 isLoggedIn true로 바꿔주니 계정 연동/해제 로직은 잘 실행된다!

<br/>

### 2️⃣ OAuth 계정 연동/해제 오류 UI 반영

계정 연동과 해제 성공해도 UI에 바로 반영되지 않아서 GoogleOAuthViewModel, AppleOAuthViewModel, KakaoOAuthViewModel의 
existOAuthAccount 변수를 사용하여 변경되면 뷰에 바로 반영되도록 @Published로 선언하였다.


<br/>

### 3️⃣ 카카오 로그인 간편 로그인 적용

카카오 로그인할 때 한번 로그인한 계정을 기억 못해서 찾아보다가 prompts 파라미터에 [.SelectAccount]를 넣어주니 해결되었다~~

<img src = "https://github.com/user-attachments/assets/2091ebe9-c070-4c30-8842-8371e124e8dc" height = "300"/>

아래와 같이 간편 로그인 저장 체크 박스가 보이고 한번 로그인 하면 계정이 남아있다~

<img src = "https://github.com/user-attachments/assets/af9e380d-6e64-4767-a4a0-f5ad5eec247d" height = "350"/>

<br/>


### 4️⃣ 계정 연동 해제 팝업 구현

ProfileMenuBarListView에서 팝업창을 보여주기 위해 showUnLinkPopUp으로 팝업 표시 여부를 판단했다. 
해당 OAuthViewModel의 existOAuthAccount 변수가 true인 경우는 계정 연동된 상태이기 때문에 existOAuthAccount == true일 때 아이콘을 클릭하면 팝업창을 보여주도록 했다.

<img src = "https://github.com/user-attachments/assets/679d4e17-9040-48bd-9e4c-d21e623964db" width = "300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

OAuth 계정 연동/해제 오류 구현하였습니다~~
이상있으면 말씀해주세요!

> 동작 여부는 디코에 올려두겠습니다!

<br/>

## 발견한 이슈
없음