### PR TITLE
🎨 inputfield에  x버튼이 필요한 뷰들 적용

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
@@ -20,7 +20,7 @@ struct pennyway_client_iOSApp: App {
         WindowGroup {
             if appViewModel.isLoggedIn || appViewModel.checkLoginState {
                 MainTabView()
-//                    .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
+                    .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
                     .onOpenURL { url in
                         GIDSignIn.sharedInstance.handle(url)
                     }
@@ -36,6 +36,8 @@ struct pennyway_client_iOSApp: App {
 
                 } else {
                     MainView()
+                        .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
+
                         .onOpenURL { url in
                             GIDSignIn.sharedInstance.handle(url)
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
@@ -20,7 +20,7 @@ struct pennyway_client_iOSApp: App {
         WindowGroup {
             if appViewModel.isLoggedIn || appViewModel.checkLoginState {
                 MainTabView()
-                    .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
+//                    .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
                     .onOpenURL { url in
                         GIDSignIn.sharedInstance.handle(url)
                     }
@@ -29,7 +29,6 @@ struct pennyway_client_iOSApp: App {
             } else {
                 if appViewModel.isSplashShown {
                     LoginView()
-                        .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
                         .onOpenURL { url in
                             GIDSignIn.sharedInstance.handle(url)
                         }
@@ -37,7 +36,6 @@ struct pennyway_client_iOSApp: App {
 
                 } else {
                     MainView()
-                        .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
                         .onOpenURL { url in
                             GIDSignIn.sharedInstance.handle(url)
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
@@ -28,44 +28,17 @@ struct InputFormView: View {
             }
 
             VStack(spacing: 9 * DynamicSizeFactor.factor()) {
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color("Gray01"))
-                        .frame(height: 46 * DynamicSizeFactor.factor())
+                CustomInputView(inputText: $loginViewModel.username, placeholder: "아이디 입력", onCommit: {
+                }, isSecureText: false, showDeleteButton: true,
+                deleteAction: {
+                    loginViewModel.username = ""
+                })
 
-                    if loginViewModel.username.isEmpty {
-                        Text("아이디 입력")
-                            .platformTextColor(color: Color("Gray03"))
-                            .padding(.leading, 13 * DynamicSizeFactor.factor())
-                            .font(.H4MediumFont())
-                    }
-                    TextField("", text: $loginViewModel.username)
-                        .padding(.horizontal, 13 * DynamicSizeFactor.factor())
-                        .font(.H4MediumFont())
-                        .AutoCorrectionExtensions()
-                        .TextAutocapitalization()
-                        .ignoresSafeArea(.keyboard)
-                }
-                .padding(.horizontal, 20)
-
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color("Gray01"))
-                        .frame(height: 46 * DynamicSizeFactor.factor())
-
-                    if loginViewModel.password.isEmpty {
-                        Text("비밀번호 입력")
-                            .platformTextColor(color: Color("Gray03"))
-                            .padding(.leading, 13 * DynamicSizeFactor.factor())
-                            .font(.H4MediumFont())
-                    }
-                    SecureField("", text: $loginViewModel.password)
-                        .padding(.horizontal, 13 * DynamicSizeFactor.factor())
-                        .font(.H4MediumFont())
-                        .textContentType(.password)
-                        .ignoresSafeArea(.keyboard)
-                }
-                .padding(.horizontal, 20)
+                CustomInputView(inputText: $loginViewModel.password, placeholder: "비밀번호 입력", onCommit: {
+                }, isSecureText: true, showDeleteButton: true,
+                deleteAction: {
+                    loginViewModel.password = ""
+                })
 
                 Spacer().frame(height: 4 * DynamicSizeFactor.factor())
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
@@ -28,17 +28,15 @@ struct InputFormView: View {
             }
 
             VStack(spacing: 9 * DynamicSizeFactor.factor()) {
-                CustomInputView(inputText: $loginViewModel.username, placeholder: "아이디 입력", onCommit: {
-                }, isSecureText: false, showDeleteButton: true,
-                deleteAction: {
-                    loginViewModel.username = ""
-                })
+                CustomInputView(inputText: $loginViewModel.username, placeholder: "아이디 입력", onCommit: {}, isSecureText: false, showDeleteButton: true,
+                                deleteAction: {
+                                    loginViewModel.username = ""
+                                })
 
-                CustomInputView(inputText: $loginViewModel.password, placeholder: "비밀번호 입력", onCommit: {
-                }, isSecureText: true, showDeleteButton: true,
-                deleteAction: {
-                    loginViewModel.password = ""
-                })
+                CustomInputView(inputText: $loginViewModel.password, placeholder: "비밀번호 입력", onCommit: {}, isSecureText: true, showDeleteButton: true,
+                                deleteAction: {
+                                    loginViewModel.password = ""
+                                })
 
                 Spacer().frame(height: 4 * DynamicSizeFactor.factor())
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpFormView.swift
@@ -46,7 +46,12 @@ struct SignUpFormView: View {
             CustomInputView(inputText: $formViewModel.name, titleText: "이름", onCommit: {
                 formViewModel.validateName()
                 formViewModel.validateForm()
-            }, isSecureText: false)
+            }, isSecureText: false, showDeleteButton: true,
+            deleteAction: {
+                formViewModel.name = ""
+                formViewModel.showErrorName = false
+                formViewModel.validateForm()
+            })
             
             if formViewModel.showErrorName {
                 ErrorText(message: "한글과 영문 대, 소문자만 가능해요", color: Color("Red03"))
@@ -63,7 +68,12 @@ struct SignUpFormView: View {
                         formViewModel.validateForm()
                     }
                 }
-            }, isSecureText: false)
+            }, isSecureText: false, showDeleteButton: true,
+            deleteAction: {
+                formViewModel.id = ""
+                formViewModel.validateForm()
+                formViewModel.showErrorID = false
+            })
             
             if formViewModel.showErrorID {
                 ErrorText(message: "영문 소문자, 특수기호 (-), (_), (.) 만 사용하여,\n5~20자의 아이디를 입력해 주세요", color: Color("Red03"))
@@ -81,7 +91,12 @@ struct SignUpFormView: View {
             CustomInputView(inputText: $formViewModel.password, titleText: "비밀번호", onCommit: {
                 formViewModel.validatePassword()
                 formViewModel.validateForm()
-            }, isSecureText: true)
+            }, isSecureText: true, showDeleteButton: true,
+            deleteAction: {
+                formViewModel.password = ""
+                formViewModel.showErrorPassword = false
+                formViewModel.validateForm()
+            })
             
             if formViewModel.showErrorPassword {
                 ErrorText(message: "숫자와 영문 소문자를 하나 이상 사용하여\n8~16자의 비밀번호를 만들어주세요", color: Color("Red03"))
@@ -95,7 +110,12 @@ struct SignUpFormView: View {
             CustomInputView(inputText: $formViewModel.confirmPw, titleText: "비밀번호 확인", onCommit: {
                 formViewModel.validateConfirmPw()
                 formViewModel.validateForm()
-            }, isSecureText: true)
+            }, isSecureText: true, showDeleteButton: true,
+            deleteAction: {
+                formViewModel.confirmPw = ""
+                formViewModel.validateForm()
+                formViewModel.showErrorConfirmPw = false
+            })
             
             if formViewModel.showErrorConfirmPw {
                 ErrorText(message: "비밀번호가 일치하지 않아요", color: Color("Red03"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputPhoneView/PhoneNumberInputField.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputPhoneView/PhoneNumberInputField.swift
@@ -4,6 +4,11 @@ import SwiftUI
 struct PhoneNumberInputField: View {
     @Binding var phoneNumber: String
     let onPhoneNumberChange: (String) -> Void
+    var onCommit: (() -> Void)?
+    var showDeleteButton: Bool = false
+    var deleteAction: (() -> Void)?
+
+    @State private var isDeleteButtonVisible: Bool = false
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -18,12 +23,25 @@ struct PhoneNumberInputField: View {
                     .font(.H4MediumFont())
             }
 
-            TextField("", text: $phoneNumber)
-                .padding(.leading, 13 * DynamicSizeFactor.factor())
-                .font(.H4MediumFont())
-                .keyboardType(.numberPad)
-                .platformTextColor(color: Color("Gray07"))
-                .onChange(of: phoneNumber, perform: onPhoneNumberChange)
+            TextField("", text: $phoneNumber, onCommit: {
+                onCommit?()
+                isDeleteButtonVisible.toggle()
+            })
+            .padding(.leading, 13 * DynamicSizeFactor.factor())
+            .font(.H4MediumFont())
+            .keyboardType(.numberPad)
+            .platformTextColor(color: Color("Gray07"))
+            .onChange(of: phoneNumber, perform: onPhoneNumberChange)
+
+            if showDeleteButton {
+                handleDeleteButtonUtil(isVisible: !phoneNumber.isEmpty && isDeleteButtonVisible, action: {
+                    phoneNumber = ""
+                    isDeleteButtonVisible = false
+                    deleteAction?()
+                })
+                .offset(x: 10 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
+                .zIndex(1)
+            }
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -65,6 +65,7 @@ struct CustomInputView: View {
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .padding(.leading, 12 * DynamicSizeFactor.factor())
+                        .padding(.trailing, 35 * DynamicSizeFactor.factor())
                         .padding(.vertical, 16 * DynamicSizeFactor.factor())
                         .font(.H4MediumFont())
                         .onChange(of: inputText) { newValue in
@@ -79,7 +80,7 @@ struct CustomInputView: View {
 
                             AnalyticsManager.shared.trackEvent(AuthEvents.cancelBtnTapped, additionalParams: [AnalyticsConstants.Parameter.btnName: titleText ?? "미설정"])
                         })
-                        .offset(x: 120 * DynamicSizeFactor.factor(), y: 1 * DynamicSizeFactor.factor())
+                        .offset(x: 130 * DynamicSizeFactor.factor() /* , y: 1 * DynamicSizeFactor.factor() */ )
                     }
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -80,7 +80,7 @@ struct CustomInputView: View {
 
                             AnalyticsManager.shared.trackEvent(AuthEvents.cancelBtnTapped, additionalParams: [AnalyticsConstants.Parameter.btnName: titleText ?? "미설정"])
                         })
-                        .offset(x: 130 * DynamicSizeFactor.factor() /* , y: 1 * DynamicSizeFactor.factor() */ )
+                        .offset(x: 130 * DynamicSizeFactor.factor())
                     }
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -17,16 +17,18 @@ struct CustomInputView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
-            if isCustom ?? false {
-                titleText?.toAttributesText(base: baseAttribute, stringAttribute)
-                    .padding(.horizontal, 20)
-                    .font(.B1RegularFont())
-                    .platformTextColor(color: Color("Gray04"))
-            } else {
-                Text(titleText!)
-                    .padding(.horizontal, 20)
-                    .font(.B1RegularFont())
-                    .platformTextColor(color: Color("Gray04"))
+            if titleText != nil {
+                if isCustom ?? false {
+                    titleText?.toAttributesText(base: baseAttribute, stringAttribute)
+                        .padding(.horizontal, 20)
+                        .font(.B1RegularFont())
+                        .platformTextColor(color: Color("Gray04"))
+                } else {
+                    Text(titleText!)
+                        .padding(.horizontal, 20)
+                        .font(.B1RegularFont())
+                        .platformTextColor(color: Color("Gray04"))
+                }
             }
 
             HStack(spacing: 11 * DynamicSizeFactor.factor()) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
@@ -6,7 +6,8 @@ struct InquiryView: View {
     @State private var isSelectedCategory: Bool = false
     @State private var isSelectedAgreeBtn: Bool = false
     @State private var showAgreement: Bool = false
-    
+    @State private var isDeleteButtonVisible: Bool = false
+
     @Environment(\.presentationMode) var presentationMode
 
     let placeholder: String = "문의 내용을 입력해주세요"
@@ -25,7 +26,6 @@ struct InquiryView: View {
                         Text("문의가 필요해요")
                             .platformTextColor(color: Color("Gray05"))
                             .font(.H4MediumFont())
-//                            .padding(.leading, 15 * DynamicSizeFactor.factor())
                             .multilineTextAlignment(.leading)
                     }
                 }
@@ -38,13 +38,20 @@ struct InquiryView: View {
                 CustomInputView(inputText: $viewModel.email, titleText: "이메일", placeholder: "이메일 입력", onCommit: {
                     viewModel.validateEmail()
                     viewModel.validateForm()
-                }, isSecureText: false)
-                            
-                if viewModel.showErrorEmail {
-                    Spacer().frame(height: 9 * DynamicSizeFactor.factor())
-                    
-                    ErrorText(message: "유효하지 않는 이메일 형식이에요", color: Color("Red03"))
-                        .offset(x: -72.5 * DynamicSizeFactor.factor())
+                    isDeleteButtonVisible = false
+
+                }, isSecureText: false, showDeleteButton: true, deleteAction: {
+                    viewModel.email = ""
+                    viewModel.validateForm()
+                    isDeleteButtonVisible = false
+                })
+                      
+                ZStack(alignment: .leading) {
+                    if viewModel.showErrorEmail {
+                        Spacer().frame(height: 9 * DynamicSizeFactor.factor())
+                        
+                        ErrorText(message: "유효하지 않는 이메일 형식이에요", color: Color("Red03"))
+                    }
                 }
                                                     
                 Spacer().frame(height: 24 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditIdView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditIdView.swift
@@ -5,29 +5,45 @@ import SwiftUI
 struct EditIdView: View {
     @Environment(\.presentationMode) var presentationMode
     @StateObject var editIdViewModel = EditViewModel()
-    
+    @State private var isDeleteButtonVisible: Bool = false
+
+    private let maxLength = 20
+
     var body: some View {
         VStack(alignment: .leading) {
             Spacer().frame(height: 35 * DynamicSizeFactor.factor())
-            
+
             CustomInputView(inputText: $editIdViewModel.inputId, titleText: "아이디", placeholder: "", onCommit: {
                 editIdViewModel.validateId()
-            }, isSecureText: false, isCustom: false)
-            
+                isDeleteButtonVisible = false
+            }, isSecureText: false, isCustom: false, showDeleteButton: true, deleteAction: {
+                editIdViewModel.inputId = ""
+                editIdViewModel.showErrorId = false
+                editIdViewModel.isDuplicateId = false
+                editIdViewModel.isFormValid = false
+                isDeleteButtonVisible = false
+            })
+            .onChange(of: editIdViewModel.inputId) { newValue in
+                if newValue.count > maxLength {
+                    editIdViewModel.inputId = String(newValue.prefix(maxLength))
+                }
+                isDeleteButtonVisible = !newValue.isEmpty
+            }
+
             if editIdViewModel.showErrorId {
                 ErrorText(message: "영문 소문자, 특수기호 (-), (_), (.) 만 사용하여,\n5~20자의 아이디를 입력해 주세요", color: Color("Red03"))
             }
-            
+
             if editIdViewModel.isDuplicateId {
                 ErrorText(message: "이미 사용 중인 아이디예요", color: Color("Red03"))
             }
-            
+
             if editIdViewModel.isFormValid {
                 ErrorText(message: "사용 가능한 아이디예요", color: Color("Mint03"))
             }
-            
+
             Spacer()
-            
+
             CustomBottomButton(action: {
                 if editIdViewModel.isFormValid {
                     editIdViewModel.editUserIdApi { success in

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -6,6 +6,7 @@ struct EditPhoneNumberView: View {
     @StateObject var viewModel = PhoneVerificationViewModel()
     @State private var showCodeErrorPopUp = false // 인증번호 오류
     @State private var showManyRequestPopUp = false // api 요청 오류
+    @State private var isDeleteButtonVisible: Bool = false
 
     var timerString: String {
         let minutes = viewModel.timerSeconds / 60
@@ -101,7 +102,14 @@ struct EditPhoneNumberView: View {
                 .platformTextColor(color: Color("Gray04"))
 
             HStack(spacing: 11 * DynamicSizeFactor.factor()) {
-                PhoneNumberInputField(phoneNumber: $viewModel.phoneNumber, onPhoneNumberChange: handlePhoneNumberChange)
+                PhoneNumberInputField(phoneNumber: $viewModel.phoneNumber, onPhoneNumberChange: handlePhoneNumberChange, onCommit: {
+                    isDeleteButtonVisible = false
+
+                }, showDeleteButton: true, deleteAction: {
+                    viewModel.phoneNumber = ""
+                    viewModel.showErrorExistingUser = false
+                    viewModel.showErrorPhoneNumberFormat = false
+                })
                 VerificationButton(isEnabled: !viewModel.isDisabledButton && viewModel.phoneNumber.count == 11 && viewModel.phoneNumber != viewModel.firstPhoneNumber, action: handleVerificationButtonTap)
             }
             .padding(.horizontal, 20)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditUsernameView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditUsernameView.swift
@@ -14,20 +14,24 @@ struct EditUsernameView: View {
 
                 CustomInputView(inputText: $formViewModel.name, titleText: "이름 입력", placeholder: "최대 8자로 입력해주세요", onCommit: {
                     formViewModel.validateName()
-                }, isSecureText: false, isCustom: false)
-                    .onChange(of: formViewModel.name) { newValue in
-                        if newValue.count > maxLength {
-                            formViewModel.name = String(newValue.prefix(maxLength))
-                        }
-                        formViewModel.validateName()
+                }, isSecureText: false, isCustom: false, showDeleteButton: true, deleteAction: {
+                    formViewModel.name = ""
+                })
+                .onChange(of: formViewModel.name) { newValue in
+                    if newValue.count > maxLength {
+                        formViewModel.name = String(newValue.prefix(maxLength))
                     }
+                    formViewModel.validateName()
+                }
 
                 Spacer().frame(height: 12 * DynamicSizeFactor.factor())
 
                 HStack {
-                    Text("현재 이름 : \(getUserData()!.name)")
-                        .font(.B1MediumFont())
-                        .platformTextColor(color: Color("Gray05"))
+                    if let userData = getUserData() {
+                        Text("현재 이름 : \(userData.name)")
+                            .font(.B1MediumFont())
+                            .platformTextColor(color: Color("Gray05"))
+                    }
 
                     Spacer()
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
@@ -4,9 +4,9 @@ import SwiftUI
 
 struct AmountInputView: View {
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
-
     var title: String
     var placeholder: String
+    @State private var isDeleteButtonVisible: Bool = false
 
     let baseAttribute: BaseAttribute
     let stringAttribute: StringAttribute
@@ -16,32 +16,20 @@ struct AmountInputView: View {
             title.toAttributesText(base: baseAttribute, stringAttribute)
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Gray07"))
-            HStack(spacing: 11 * DynamicSizeFactor.factor()) {
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color("Gray01"))
-                        .frame(height: 46 * DynamicSizeFactor.factor())
+                .padding(.horizontal, 20)
 
-                    if viewModel.amountSpentText.isEmpty {
-                        Text(placeholder)
-                            .platformTextColor(color: Color("Gray03"))
-                            .padding(.leading, 13 * DynamicSizeFactor.factor())
-                            .font(.H4MediumFont())
-                    }
-
-                    TextField("", text: $viewModel.amountSpentText)
-                        .padding(.leading, 13 * DynamicSizeFactor.factor())
-                        .font(.H4MediumFont())
-                        .keyboardType(.numberPad)
-                        .platformTextColor(color: Color("Gray07"))
-                        .onChange(of: viewModel.amountSpentText) { _ in
-                            viewModel.amountSpentText = NumberFormatterUtil.formatStringToDecimalString(viewModel.amountSpentText)
-                            viewModel.validateForm()
-                        }
-                }
+            CustomInputView(inputText: $viewModel.amountSpentText, placeholder: placeholder, onCommit: {
+                isDeleteButtonVisible = false
+            }, isSecureText: false, isCustom: false, showDeleteButton: true, deleteAction: {
+                viewModel.amountSpentText = ""
+                isDeleteButtonVisible = false
+            })
+            .keyboardType(.numberPad)
+            .onChange(of: viewModel.amountSpentText) { _ in
+                viewModel.amountSpentText = NumberFormatterUtil.formatStringToDecimalString(viewModel.amountSpentText)
+                viewModel.validateForm()
             }
         }
-        .padding(.horizontal, 20)
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
@@ -7,6 +7,7 @@ struct AddSpendingInputFormView: View {
     @ObservedObject var viewModel: AddSpendingHistoryViewModel
     @ObservedObject var spendingHistoryViewModel: SpendingHistoryViewModel
     @ObservedObject var spendingCategoryViewModel: SpendingCategoryViewModel
+    @State private var isDeleteButtonVisible: Bool = false
 
     @Binding var clickDate: Date?
     var entryPoint: EntryPoint
@@ -154,7 +155,10 @@ struct AddSpendingInputFormView: View {
             Spacer().frame(height: 14 * DynamicSizeFactor.factor())
             
             // 소비처
-            CustomInputView(inputText: $viewModel.consumerText, titleText: "소비처", placeholder: "카페인 수혈, 주식투자 등등", isSecureText: false, isCustom: true)
+            CustomInputView(inputText: $viewModel.consumerText, titleText: "소비처", placeholder: "카페인 수혈, 주식투자 등등", isSecureText: false, isCustom: true, showDeleteButton: true, deleteAction: {
+                viewModel.consumerText = ""
+                isDeleteButtonVisible = false
+            })
 
             Spacer().frame(height: 28 * DynamicSizeFactor.factor())
             


### PR DESCRIPTION
## 작업 이유
- inputfield에  x버튼이 필요한 뷰들 적용

<br/>

## 작업 사항
### **1️⃣  inputfield에  x버튼이 필요한 뷰들 적용**
빈 스크린 터치시에 return 처리 되게 하는 것은 텍스트 필드가 하나일때는 터치 영역을 넓혀서 인지할 수 있지만 텍스트필드가 여러개일 경우 구현이 불가능하다고 판단하였다. 
그래서 사용자가 return을 누르지 않으면 키보드가 내려가지 않게 하려고 했지만 그랬을 경우에 숫자키패드가 나오는 inputform에선 return 처리하는 키가 없어서 빈스크린 터치시 키보드가 내려가야 다음 폼을 입력할 수 있는데 키보드가 안내려가서 다음 폼을 입력할 수 없게 되는 문제가 발생한다.

따라서 x버튼은 그냥 남겨두기로 했다.(네이버, 카카오톡도 이렇게 사용되고 있음)

**x버튼이 적용해야 하는 뷰**
- [x] 지출 내역 추가하기(메모 박스 제외)
- [x] 문의하기 (문의 내용 제외)
- [x] 아이디 변경
- [x] 마이페이지 닉네임 변경
- [x] 회원가입
- [x] 로그인
-------
- [ ] 마이페이지 내정보 수정(휴대폰 번호 변경)
- [ ] 아이디 찾기 (인증번호 제외)
- [ ] 회원가입 번호인증(인증번호 제외)
- [ ] 비밀번호 찾기 (인증번호 제외)
- [ ] 목표금액 설정
- [ ] 카테고리 커스텀

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
x버튼 필요한 inputform에 거의 적용했는데 휴대폰 번호 입력하는 PhoneNumberInputField랑 목표금액, 카테고리 커스텀 뷰는 textfield조건이 까다롭더라고여….. 그래서 나뒀는데 이 부분 희진님이 UI 구현하셔서 나머지 부분 부탁드려도 될까요??
PhoneNumberInputField에 적용하면 휴대폰 번호에 일괄 적용되고 목표금액 설정이랑 카테고리 커스텀만 작업해주시면 됩니다!

<br/>

## 발견한 이슈
x