### PR TITLE
📍 AT 존재 여부에 따른 API 요청 + 사용자 알림 허용 로직 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
@@ -7,8 +7,14 @@ class BaseInterceptor: RequestInterceptor {
         Log.info("BaseInterceptor - adapt()")
 
         var adaptedRequest = urlRequest
-        let accessToken = KeychainHelper.loadAccessToken()
-        adaptedRequest.setValue("Bearer " + (accessToken ?? ""), forHTTPHeaderField: "Authorization")
+
+        guard let accessToken = KeychainHelper.loadAccessToken(), !accessToken.isEmpty else {
+            Log.error("[BaseInterceptor]: Access token이 존재하지 않음")
+            completion(.failure(NSError(domain: "", code: 499, userInfo: [NSLocalizedDescriptionKey: "Missing Access Token"])))
+            return
+        }
+
+        adaptedRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
 
         if let url = adaptedRequest.url, let cookies = HTTPCookieStorage.shared.cookies(for: url) {
             let cookieHeader = HTTPCookie.requestHeaderFields(with: cookies)

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -63,31 +63,6 @@ extension AppDelegate: MessagingDelegate {
         if let fcmToken = fcmToken {
             AppDelegate.currentFCMToken = fcmToken // fcm 토큰 저장
             Log.info("fcmToken: \(fcmToken)")
-            registDeviceTokenApi(fcmToken: fcmToken)
-        }
-    }
-
-    private func registDeviceTokenApi(fcmToken: String) {
-        let fcmTokenDto = FcmTokenDto(token: fcmToken)
-
-        UserAccountAlamofire.shared.registDeviceToken(fcmTokenDto) { result in
-            switch result {
-            case let .success(data):
-                if let responseData = data {
-                    do {
-                        let response = try JSONDecoder().decode(ErrorResponseDto.self, from: responseData)
-                        Log.debug(response)
-                    } catch {
-                        Log.fault("Error parsing response JSON: \(error)")
-                    }
-                }
-            case let .failure(error):
-                if let statusSpecificError = error as? StatusSpecificError {
-                    Log.info("StatusSpecificError occurred: \(statusSpecificError)")
-                } else {
-                    Log.error("Network request failed: \(error)")
-                }
-            }
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -23,20 +23,23 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         FirebaseApp.configure()
 
-        // Setting Up Notifications...
-        // 원격 알림 등록
-        if #available(iOS 10.0, *) {
-            UNUserNotificationCenter.current().delegate = self
+        // 알림 허용 여부
+        UNUserNotificationCenter.current().delegate = self
 
-            let authOption: UNAuthorizationOptions = [.alert, .badge, .sound]
-            UNUserNotificationCenter.current().requestAuthorization(
-                options: authOption,
-                completionHandler: { _, _ in })
-        } else {
-            let settings: UIUserNotificationSettings =
-                UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
-            application.registerUserNotificationSettings(settings)
-        }
+        let authOption: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: authOption,
+            completionHandler: { granted, error in
+                if granted { // 알림 허용
+                    Log.info("알림 허용")
+                } else { // 알림 거부
+                    Log.info("알림 거부")
+                }
+
+                if let error = error {
+                    Log.error("Error requesting notification authorization: \(error.localizedDescription)")
+                }
+            })
 
         application.registerForRemoteNotifications()
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -12,6 +12,16 @@ class AppViewModel: ObservableObject {
         checkLoginStateApi()
     }
 
+    func logout() {
+        isLoggedIn = false
+        checkLoginState = false
+    }
+
+    func login() {
+        registDeviceTokenApi()
+        isLoggedIn = true
+    }
+    
     func checkLoginStateApi() {
         UserAuthAlamofire.shared.checkLoginState { [weak self] result in
             switch result {
@@ -22,9 +32,10 @@ class AppViewModel: ObservableObject {
                         Log.debug(response)
                         self?.checkLoginState = true
                         self?.isLoggedIn = true
-
+                        
+                        self?.registDeviceTokenApi()
                         Log.debug("accessToken: \(KeychainHelper.loadAccessToken())")
-
+                        
                     } catch {
                         Log.fault("Error parsing response JSON: \(error)")
                         self?.checkLoginState = false
@@ -36,18 +47,37 @@ class AppViewModel: ObservableObject {
                 } else {
                     Log.error("Network request failed: \(error)")
                 }
-
+                
                 self?.checkLoginState = false
             }
         }
     }
-
-    func logout() {
-        isLoggedIn = false
-        checkLoginState = false
-    }
-
-    func login() {
-        isLoggedIn = true
+    
+    func registDeviceTokenApi() {
+        if let fcmToken = AppDelegate.currentFCMToken {
+            let fcmTokenDto = FcmTokenDto(token: fcmToken)
+                    
+            UserAccountAlamofire.shared.registDeviceToken(fcmTokenDto) { result in
+                switch result {
+                case let .success(data):
+                    if let responseData = data {
+                        do {
+                            let response = try JSONDecoder().decode(ErrorResponseDto.self, from: responseData)
+                            Log.debug(response)
+                        } catch {
+                            Log.fault("Error parsing response JSON: \(error)")
+                        }
+                    }
+                case let .failure(error):
+                    if let statusSpecificError = error as? StatusSpecificError {
+                        Log.info("StatusSpecificError occurred: \(statusSpecificError)")
+                    } else {
+                        Log.error("Network request failed: \(error)")
+                    }
+                }
+            }
+        } else {
+            Log.fault("fcm Token 존재 x")
+        }
     }
 }


### PR DESCRIPTION
## 작업 이유

- AT가 빈값인 경우 api 요청 x
- Fcm 토큰 전송 api 실행 위치 수정
- 사용자 알림 허용 로직 수정


<br/>

## 작업 사항

### 1️⃣ AT가 빈값인 경우 api 요청 x

AT가 빈값인 경우는 세 가지이다. 그러니 AT가 빈값이라면 유효하지 않은 사용자이니 api 요청을 보내지 않아야 한다.
현재는 AT가 빈 값이어서 401에러가 발생하는데 계속 api에 요청이 가고 있다. 필요없는 요청이 많이가고 있던게 문제다.

```
<AT 빈값>
1. 로그인하지 않은 사용자인 경우
2. 로그아웃한 사용자인 경우
3. 계정 탈퇴한 사용자인 경우
```

그래서 BaseInterceptor에서 키체인에 저장된 accessToken이 빈 값이면 api 요청이 가지 않도록 막았다.
임시로 status code 499를 사용했는데 이 부분은 얘기를 해봐야할 것 같다.

```swift
guard let accessToken = KeychainHelper.loadAccessToken(), !accessToken.isEmpty else {
            Log.error("[BaseInterceptor]: Access token이 존재하지 않음")
            completion(.failure(NSError(domain: "", code: 499, userInfo: [NSLocalizedDescriptionKey: "Missing Access Token"])))
            return
        }
```

<br/>

### 2️⃣ Fcm 토큰 전송 api 실행 위치 수정

이전에는 Fcm 토큰 전송을 앱 실행할 때 바로 요청을 하도록 했다.
그래서 가입하지 않은 사용자도 fcm 토큰 전송을 하는 문제가 발생하여서 [로그인, 자동 로그인]을 했을 경우에만 fcm 토큰 전송할 수 있도록 수정하였다.

AppDelegate에 있던 토큰 전송 api를 AppViewModel로 옮겨서 [로그인, 자동 로그인]한 경우에 호출하도록 처리했다.

<br/>

### 3️⃣ 사용자 알림 허용 로직 수정

이전에 알림 허용 로직이 아래와 같이 구현되어 있었다. 근데 프로젝트의 최소 타겟은 iOS 14이기 때문에 10이상일때 코드만 사용하도록 수정했다.

사용자 알림 허용은 앱을 설치하고 실행했을 때 단 한번만 나오고 그 이후에는 사용자가 직접 설정에서 수정해야 한다.

```swift
if #available(iOS 10.0, *) {
      UNUserNotificationCenter.current().delegate = self
      ...
}else{
...
}
```

> 왼쪽 시뮬레이터, 오른쪽 내 폰

<img src = "https://github.com/user-attachments/assets/9b60850d-eeca-4ef6-9324-ea79846d5f41" width = "300"/>
<img src = "https://github.com/user-attachments/assets/deeb49f6-4a17-42bc-be04-d7b01a56cf40" width = "300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

구현 완료했습니다~~
1️⃣에서 임시로 클라이언트 쪽에서 요청을 취소했다는 에러코드로 499 처리했는데 어떻게 처리하는게 좋을까요?


<br/>

## 발견한 이슈
없음