### PR TITLE
📍Refresh 오류/네트워크 에러 핸들링

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -48,11 +48,11 @@
 		4A2882092C64CD1500AE50C7 /* ProfileNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2882082C64CD1500AE50C7 /* ProfileNotificationViewModel.swift */; };
 		4A28820C2C64CD5F00AE50C7 /* GetNotificationResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A28820A2C64CD5F00AE50C7 /* GetNotificationResponseDto.swift */; };
 		4A28820D2C64CD5F00AE50C7 /* NotificationContentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A28820B2C64CD5F00AE50C7 /* NotificationContentData.swift */; };
-		4A2882212C654BB500AE50C7 /* ReloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2882202C654BB500AE50C7 /* ReloadView.swift */; };
 		4A2882172C65178400AE50C7 /* UploadProfileImageRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2882162C65178400AE50C7 /* UploadProfileImageRequestDto.swift */; };
 		4A2882192C6517A700AE50C7 /* UploadProfileImageResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2882182C6517A700AE50C7 /* UploadProfileImageResponseDto.swift */; };
 		4A28821B2C65184300AE50C7 /* ProfileImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A28821A2C65184300AE50C7 /* ProfileImageViewModel.swift */; };
 		4A28821F2C652D3600AE50C7 /* GetNotificationRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A28821E2C652D3600AE50C7 /* GetNotificationRequestDto.swift */; };
+		4A2882212C654BB500AE50C7 /* ReloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2882202C654BB500AE50C7 /* ReloadView.swift */; };
 		4A3560762BEB9C8200BA58F3 /* OAuthUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3560752BEB9C8200BA58F3 /* OAuthUserData.swift */; };
 		4A3560782BEBA1D000BA58F3 /* UserAuthAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3560772BEBA1CF00BA58F3 /* UserAuthAlamofire.swift */; };
 		4A35607A2BEBA25100BA58F3 /* UserAuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3560792BEBA25100BA58F3 /* UserAuthRouter.swift */; };
@@ -166,6 +166,7 @@
 		4AA13C692C63F27400D8DEE7 /* StorePresignedUrlRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA13C682C63F27400D8DEE7 /* StorePresignedUrlRequestDto.swift */; };
 		4AA13C6B2C63F6F800D8DEE7 /* GeneratePresignedUrlResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA13C6A2C63F6F800D8DEE7 /* GeneratePresignedUrlResponseDto.swift */; };
 		4AA52F3F2C05C3AD00B21521 /* RoundedCornerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */; };
+		4AA969752C6D2B8F00CA889C /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA969742C6D2B8F00CA889C /* NotificationName.swift */; };
 		4AB0B13A2C4E56C900A475F5 /* EntryPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */; };
 		4AB0B13C2C4F497400A475F5 /* MapCategoryIconUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */; };
 		4AB0B13E2C50256300A475F5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B13D2C50256300A475F5 /* LoadingView.swift */; };
@@ -367,11 +368,11 @@
 		4A2882082C64CD1500AE50C7 /* ProfileNotificationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileNotificationViewModel.swift; sourceTree = "<group>"; };
 		4A28820A2C64CD5F00AE50C7 /* GetNotificationResponseDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetNotificationResponseDto.swift; sourceTree = "<group>"; };
 		4A28820B2C64CD5F00AE50C7 /* NotificationContentData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationContentData.swift; sourceTree = "<group>"; };
-		4A2882202C654BB500AE50C7 /* ReloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReloadView.swift; sourceTree = "<group>"; };
 		4A2882162C65178400AE50C7 /* UploadProfileImageRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadProfileImageRequestDto.swift; sourceTree = "<group>"; };
 		4A2882182C6517A700AE50C7 /* UploadProfileImageResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadProfileImageResponseDto.swift; sourceTree = "<group>"; };
 		4A28821A2C65184300AE50C7 /* ProfileImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageViewModel.swift; sourceTree = "<group>"; };
 		4A28821E2C652D3600AE50C7 /* GetNotificationRequestDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetNotificationRequestDto.swift; sourceTree = "<group>"; };
+		4A2882202C654BB500AE50C7 /* ReloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReloadView.swift; sourceTree = "<group>"; };
 		4A3560752BEB9C8200BA58F3 /* OAuthUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthUserData.swift; sourceTree = "<group>"; };
 		4A3560772BEBA1CF00BA58F3 /* UserAuthAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthAlamofire.swift; sourceTree = "<group>"; };
 		4A3560792BEBA25100BA58F3 /* UserAuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthRouter.swift; sourceTree = "<group>"; };
@@ -487,6 +488,7 @@
 		4AA13C682C63F27400D8DEE7 /* StorePresignedUrlRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePresignedUrlRequestDto.swift; sourceTree = "<group>"; };
 		4AA13C6A2C63F6F800D8DEE7 /* GeneratePresignedUrlResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratePresignedUrlResponseDto.swift; sourceTree = "<group>"; };
 		4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornerUtil.swift; sourceTree = "<group>"; };
+		4AA969742C6D2B8F00CA889C /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryPoint.swift; sourceTree = "<group>"; };
 		4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCategoryIconUtil.swift; sourceTree = "<group>"; };
 		4AB0B13D2C50256300A475F5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -1442,6 +1444,7 @@
 				4A0FFBFA2BCDA74000EFEC56 /* EncodableExtension.swift */,
 				D8880E232BD17FD000922894 /* TapGestureRecognizer.swift */,
 				D8F9D7392C59576B005416FC /* ImagePicker.swift */,
+				4AA969742C6D2B8F00CA889C /* NotificationName.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2126,6 +2129,7 @@
 				4A3701D12C08F7F600F0AEBA /* AddSpendingCustomCategoryResponseDto.swift in Sources */,
 				4A2882002C64CC5900AE50C7 /* CategoryDetailsView.swift in Sources */,
 				4A5789712BDC1ADC00AFEB26 /* UnauthorizedErrorCode.swift in Sources */,
+				4AA969752C6D2B8F00CA889C /* NotificationName.swift in Sources */,
 				D8B0A9242C4E5D6400716ECB /* AddSpendingFormFieldsView.swift in Sources */,
 				4AC4FD0C2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift in Sources */,
 				4A12BC912C038D1200AACBCA /* CategoryIconListItem.swift in Sources */,
@@ -2317,7 +2321,6 @@
 				4AC3204F2C11D5AC00DDB4B6 /* SpendingWeekCalendarView.swift in Sources */,
 				4AB5AB4A2BB4A37600D2C9EA /* AuthRouter.swift in Sources */,
 				4A058EFF2BD03E01004B6F89 /* AuthResponseDto.swift in Sources */,
-				B599E4D82C68A76B006051E9 /* AuthAnalyticsEvents.swift in Sources */,
 				4AC320502C11D5AC00DDB4B6 /* RecentTargetAmountSuggestionView.swift in Sources */,
 				4A4703A72BCEDD9800AEE04E /* VerificationCodeRequestDto.swift in Sources */,
 				4AA13C622C63E4DF00D8DEE7 /* GeneratePresigendUrlRequestDto.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
@@ -71,15 +71,4 @@ class BaseInterceptor: RequestInterceptor {
             completion(.doNotRetry)
         }
     }
-
-    private func handleRetry(for request: Request, response: HTTPURLResponse, completion: @escaping (RetryResult) -> Void) {
-        Log.error("[BaseInterceptor] Network error with status code: \(response.statusCode)")
-        if request.retryCount < 1 {
-            Log.info("Retrying request once due to status code: \(response.statusCode)")
-            completion(.retry)
-        } else {
-            Log.info("Not retrying after error with status code: \(response.statusCode)")
-            completion(.doNotRetry)
-        }
-    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
@@ -23,27 +23,62 @@ class BaseInterceptor: RequestInterceptor {
     func retry(_ request: Request, for _: Session, dueTo _: Error, completion: @escaping (RetryResult) -> Void) {
         Log.info("BaseInterceptor - retry()")
 
-        if let response = request.task?.response as? HTTPURLResponse {
-            Log.debug(response.statusCode)
+        if let urlRequest = request.request {
+            Log.info("[BaseInterceptor] retry Request URL: \(urlRequest.url?.absoluteString ?? "No URL")")
         }
 
-        if let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 {
-            TokenRefreshHandler.shared.refreshSync { result, shouldRetry in
-                switch result {
-                case .success:
-                    Log.debug("Token refreshed, retrying request : \(request)")
+        guard let response = request.task?.response as? HTTPURLResponse else {
+            handleNetworkError(for: request, completion: completion) // netWork Error인 경우
+            return
+        }
+
+        switch response.statusCode {
+        case 401: // refresh 요청
+            handleUnauthorized(for: request, completion: completion)
+        case 400 ... 500:
+            Log.error("Request failed with status code: \(response.statusCode). Not retrying.")
+            completion(.doNotRetry)
+        default: // 400~500사이의 범위를 벗어나는 경우
+            handleRetry(for: request, response: response, completion: completion)
+        }
+    }
+
+    private func handleUnauthorized(for request: Request, completion: @escaping (RetryResult) -> Void) {
+        TokenRefreshHandler.shared.refreshSync { result, shouldRetry in
+            switch result {
+            case .success:
+                Log.debug("Token refreshed, retrying request: \(request)")
+                completion(.retry)
+            case .failure:
+                if shouldRetry && request.retryCount < 1 {
+                    Log.info("Retrying request due to failed token refresh")
                     completion(.retry)
-                case .failure:
-                    if shouldRetry {
-                        Log.debug("Retrying due to network error")
-                        completion(.retry)
-                    } else {
-                        completion(.doNotRetry)
-                    }
+                } else {
+                    Log.info("Not retrying request after failed token refresh")
+                    completion(.doNotRetry)
                 }
             }
+        }
+    }
+
+    private func handleNetworkError(for request: Request, completion: @escaping (RetryResult) -> Void) {
+        Log.error("[BaseInterceptor] Network error occurred")
+        if request.retryCount < 1 {
+            Log.info("Retrying request once due to network error")
+            completion(.retry)
         } else {
-            // 기타 오류에 대한 재시도 처리
+            Log.info("Not retrying after network error")
+            completion(.doNotRetry)
+        }
+    }
+
+    private func handleRetry(for request: Request, response: HTTPURLResponse, completion: @escaping (RetryResult) -> Void) {
+        Log.error("[BaseInterceptor] Network error with status code: \(response.statusCode)")
+        if request.retryCount < 1 {
+            Log.info("Retrying request once due to status code: \(response.statusCode)")
+            completion(.retry)
+        } else {
+            Log.info("Not retrying after error with status code: \(response.statusCode)")
             completion(.doNotRetry)
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
@@ -38,8 +38,8 @@ class BaseInterceptor: RequestInterceptor {
         case 400 ... 500:
             Log.error("Request failed with status code: \(response.statusCode). Not retrying.")
             completion(.doNotRetry)
-        default: // 400~500사이의 범위를 벗어나는 경우
-            handleRetry(for: request, response: response, completion: completion)
+        default:
+            Log.error("[BaseInterceptor] Network error occurred")
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/BaseInterceptor.swift
@@ -2,6 +2,8 @@
 import Alamofire
 import Foundation
 
+// MARK: - BaseInterceptor
+
 class BaseInterceptor: RequestInterceptor {
     func adapt(_ urlRequest: URLRequest, for _: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         Log.info("BaseInterceptor - adapt()")
@@ -32,6 +34,10 @@ class BaseInterceptor: RequestInterceptor {
                     Log.debug("Token refreshed, retrying request : \(request)")
                     completion(.retry)
                 case .failure:
+                    
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .logoutNotification, object: nil)
+                    }
                     completion(.doNotRetry)
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenHandler.swift
@@ -13,7 +13,7 @@ class TokenHandler {
                     Log.info("Cookie name: \(cookie.name), value: \(cookie.value)")
                     let nsCookie = HTTPCookie(properties: [
                         HTTPCookiePropertyKey.name: cookie.name,
-                        HTTPCookiePropertyKey.value: cookie.value,
+                        HTTPCookiePropertyKey.value: "aaa",
                         HTTPCookiePropertyKey.domain: cookie.domain,
                         HTTPCookiePropertyKey.path: cookie.path,
                         HTTPCookiePropertyKey.version: NSNumber(value: cookie.version),
@@ -25,7 +25,7 @@ class TokenHandler {
                     }
                 }
             }
-            KeychainHelper.saveAccessToken(accessToken: accessToken)
+            KeychainHelper.saveAccessToken(accessToken: "aa")
             Log.info("accessToken: \(accessToken)")
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenHandler.swift
@@ -13,7 +13,7 @@ class TokenHandler {
                     Log.info("Cookie name: \(cookie.name), value: \(cookie.value)")
                     let nsCookie = HTTPCookie(properties: [
                         HTTPCookiePropertyKey.name: cookie.name,
-                        HTTPCookiePropertyKey.value: "aaa",
+                        HTTPCookiePropertyKey.value: cookie.value,
                         HTTPCookiePropertyKey.domain: cookie.domain,
                         HTTPCookiePropertyKey.path: cookie.path,
                         HTTPCookiePropertyKey.version: NSNumber(value: cookie.version),
@@ -25,7 +25,7 @@ class TokenHandler {
                     }
                 }
             }
-            KeychainHelper.saveAccessToken(accessToken: "aa")
+            KeychainHelper.saveAccessToken(accessToken: accessToken)
             Log.info("accessToken: \(accessToken)")
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenRefreshHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenRefreshHandler.swift
@@ -10,11 +10,11 @@ import Foundation
 class TokenRefreshHandler {
     static let shared = TokenRefreshHandler()
     private var isRefreshing = false
-    private var pendingRequests: [(Result<Data?, Error>) -> Void] = []
+    private var pendingRequests: [(Result<Data?, Error>, Bool) -> Void] = []
     
     private init() {}
     
-    func refreshSync(completion: @escaping (Result<Data?, Error>) -> Void) {
+    func refreshSync(completion: @escaping (Result<Data?, Error>, Bool) -> Void) {
         Log.debug("TokenRefreshManager - refreshSync() called - isRefreshing: \(isRefreshing)")
         
         if isRefreshing {
@@ -42,32 +42,44 @@ class TokenRefreshHandler {
                             AnalyticsConstants.Parameter.oauthType: "none",
                             AnalyticsConstants.Parameter.isRefresh: true
                         ])
+                        
                     } catch {
                         Log.fault("Error parsing response JSON: \(error)")
-                        self.notifyPendingRequests(result: .failure(error))
-                        completion(.failure(error))
+                        self.notifyPendingRequests(result: .failure(error), shouldRetry: false)
+                        completion(.failure(error), false)
                     }
                 }
-                        
-                self.notifyPendingRequests(result: .success(data))
-                completion(.success(data))
+                self.notifyPendingRequests(result: .success(data), shouldRetry: false)
+                completion(.success(data), false)
+                
             case let .failure(error):
+                var shouldRetry = false
+                
                 if let statusSpecificError = error as? StatusSpecificError {
+                    if statusSpecificError.domainError == .unauthorized, statusSpecificError.code == UnauthorizedErrorCode.expiredOrRevokedToken.rawValue || statusSpecificError.domainError == .forbidden, statusSpecificError.code == ForbiddenErrorCode.accessForbidden.rawValue {
+                        // 401, 403 에러인 경우 로그아웃
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .logoutNotification, object: nil)
+                        }
+                    }
+                    
                     Log.info("StatusSpecificError occurred: \(statusSpecificError)")
                 } else {
                     Log.error("Network request failed: \(error)")
+                    // 네트워크 오류 발생 시 재시도 플래그 설정
+                    shouldRetry = true
                 }
                 
-                self.notifyPendingRequests(result: .failure(error))
-                completion(.failure(error))
+                self.notifyPendingRequests(result: .failure(error), shouldRetry: shouldRetry)
+                completion(.failure(error), shouldRetry)
             }
-                    
+            
             self.isRefreshing = false
         }
     }
     
-    private func notifyPendingRequests(result: Result<Data?, Error>) {
-        pendingRequests.forEach { $0(result) }
+    private func notifyPendingRequests(result: Result<Data?, Error>, shouldRetry: Bool) {
+        pendingRequests.forEach { $0(result, shouldRetry) }
         pendingRequests.removeAll()
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenRefreshHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenRefreshHandler.swift
@@ -62,10 +62,9 @@ class TokenRefreshHandler {
                             NotificationCenter.default.post(name: .logoutNotification, object: nil)
                         }
                     }
-                    
                     Log.info("StatusSpecificError occurred: \(statusSpecificError)")
                 } else {
-                    Log.error("Network request failed: \(error)")
+                    Log.error("Network request failedd: \(error)")
                     // 네트워크 오류 발생 시 재시도 플래그 설정
                     shouldRetry = true
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/NotificationName.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/NotificationName.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Notification 이름 확장
+extension Notification.Name {
+    static let logoutNotification = Notification.Name("logoutNotification")
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -1,4 +1,5 @@
 
+import Combine
 import SwiftUI
 
 // MARK: - AppViewModel
@@ -8,8 +9,17 @@ class AppViewModel: ObservableObject {
     @Published var isSplashShown: Bool = false
     @Published var checkLoginState = false
 
+    private var cancellables = Set<AnyCancellable>()
+
     init() {
         checkLoginStateApi()
+
+        // Combine을 사용하여 NotificationCenter 알림 구독
+        NotificationCenter.default.publisher(for: .logoutNotification)
+            .sink { [weak self] _ in
+                self?.logout()
+            }
+            .store(in: &cancellables)
     }
 
     func checkLoginStateApi() {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/LoginViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AuthViewModel/LoginViewModel.swift
@@ -44,7 +44,7 @@ class LoginViewModel: ObservableObject {
                     if let errorWithDomainErrorAndMessage = error as? StatusSpecificError {
                         Log.info("Failed to verify: \(errorWithDomainErrorAndMessage)")
                     } else {
-                        Log.error("Failed to verify: \(error)")
+                        Log.error("[LoginViewModel] Failed to verify: \(error)")
                     }
                     completion(false)
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserLogoutViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/UserViewModel/UserLogoutViewModel.swift
@@ -58,7 +58,7 @@ class UserLogoutViewModel: ObservableObject {
             case let .failure(error):
 
                 if let StatusSpecificError = error as? StatusSpecificError {
-                    Log.info("Failed to verify: \(StatusSpecificError)")
+                    Log.info("[UserLogoutViewModel] Failed to verify: \(StatusSpecificError)")
 
                     if StatusSpecificError.domainError == .notFound && StatusSpecificError.code == NotFoundErrorCode.resourceNotFound.rawValue {
                         // 404에러시 로그아웃 로직 실행


### PR DESCRIPTION
## 작업 이유

- 탈취 or 토큰 만료 에러 핸들링
- 네트워크 에러 핸들링


<br/>

## 작업 사항

## 1️⃣ 탈취 or 토큰 만료 에러 핸들링

탈취 에러 => 4011
토큰 에러 => 4030

위와 같은 에러코드가 나온 경우에는 로그아웃을 해서 로그인 화면으로 돌아가도록 해야한다.
이걸 구현하기 위해서 Combine과 NotificationCenter를 사용하였다.

https://jryoun1.github.io/combine/CombineChapter2-1/ 를 참고하였다.

AppViewModel에서 로그아웃을 처리하고 있는데 BaseInterceptor에서 401, 403 에러코드를 받은 경우 로그아웃 처리를 해줘야한다.

BaseInterceptor와 AppViewModel을 연결해줘야 하는데 방법이 없었다. 그래서 Combine과 NotificationCenter를 사용했다.!

동작과정은 아래와 같다.

<br/>

### 1. Notification 이름 설정

방송 이름을 설정한다고 보면 된다.

```swift
/// Notification 이름 확장
extension Notification.Name {
    static let logoutNotification = Notification.Name("logoutNotification")
}
```

<br/>

### 2. 구독자 등록

AppViewModel이 logoutNotification이라는 방송을 구독하도록 설정한다.
만약 해당 방송이 시작하면 sink{}안의 로직이 실행된다. 즉, logout 로직을 실행하게 된다. 

cancellables은 AppViewModel의 인스턴스가 메모리에서 해제될 때 cancellables에 저장된 모든 구독을 자동으로 취소하여 메모리 누수를 방지하기 위해 사용했다.

```swift
class AppViewModel: ObservableObject {
    ...
    private var cancellables = Set<AnyCancellable>()

    init() {
        ...

        // Combine을 사용하여 NotificationCenter 알림 구독
        NotificationCenter.default.publisher(for: .logoutNotification)
            .sink { [weak self] _ in
                self?.logout()
            }
            .store(in: &cancellables)
    }
```

<br/>

### 3. 방송 게시

401, 403 에러가 발생한 경우, 아래와 같이 logoutNotification 방송을 구독한 Observer에게 알림을 보내고 Observer들은 방송을 수신한다. (sink 로직이 실행된다)

```swift
DispatchQueue.main.async {
    NotificationCenter.default.post(name: .logoutNotification, object: nil)
}
```


<br/>

### 2️⃣ 네트워크 에러 핸들링

네트워크 에러인 경우는 미리 정의해놓은 에러코드를 벗어나는 경우이다.
미리 정의한 코드는 노션에 있다.

<br/>

### 1. refresh 에러 핸들링

TokenRefreshHandler에서 shouldRetry 변수를 두어 네트워크 오류 발생 시 재시도 여부를 판단하였다.
notifyPendingRequests()함수에 shouldRetry 매개변수를 추가하여 BaseInterceptor에서 실패인 경우 shouldRetry가 true라면 재시도를 하도록 설정하였다.

```swift
case let .failure(error):
    var shouldRetry = false
    
    if let statusSpecificError = error as? StatusSpecificError {
        ...
    } else {
        Log.error("Network request failed: \(error)")
        // 네트워크 오류 발생 시 재시도 플래그 설정
        shouldRetry = true
    }
    
    self.notifyPendingRequests(result: .failure(error), shouldRetry: shouldRetry)
    completion(.failure(error), shouldRetry)
}
```

<br/>

### 2. 인터셉터 에러 핸들링

네트워크 오류인 경우 응답 객체가 없이 아래와 같이 오류가 발생한다. 

![스크린샷 2024-08-15 오후 7 46 25](https://github.com/user-attachments/assets/1c54a3de-d07a-4170-88ba-d288057e8c0e)

그래서 HTTP 응답 객체가 없는 경우 네트워크 오류라고 판단하였다.(인터넷 연결이 끊긴 경우)

```swift
guard let response = request.task?.response as? HTTPURLResponse else {
    handleNetworkError(for: request, completion: completion)
    return
}
```

- 401인 경우 refresh 요청
- 400~500범위인 경우 재요청을 하지 않는다.
- 400~500범위를 벗어나는 경우 네트워크 에러라고 판단하여 한 번만 재시도하고 그 이후에는 요청하지 않도록 하였다.

```swift
switch response.statusCode {
case 401://토큰 갱신
    handleUnauthorized(for: request, completion: completion)
case 400 ... 500:
    Log.error("Request failed with status code: \(response.statusCode). Not retrying.")
    completion(.doNotRetry)
default://오류 범위 벗어나는 경우 한 번만 재시도
    handleRetry(for: request, response: response, completion: completion)
}
```

일단 인터셉터와 refresh 요청만 에러에 따라서 재시도를 하도록 구현하였고 추후에 모든 api에 적용할 수 있도록 해야겠다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

1️⃣번과 2️⃣번 설명에서 이해 안되는 부분 있으면 말씀해주세요~~



<br/>

## 발견한 이슈
없음
