### PR TITLE
📍 회원가입 후 목표 금액 생성 이후 목표 금액 플로우 오류

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -55,7 +55,10 @@ class TargetAmountViewModel: ObservableObject {
                         // 추천 금액 보여주기 x + 목표 금액 설정하기 UI
                         self.isHiddenSuggestionView = true
                         self.isPresentTargetAmount = false
-                        self.generateCurrentMonthDummyDataApi { _ in }
+                        self.generateCurrentMonthDummyDataApi { _ in
+                            // 당월 목표 금액 조회 재요청
+                            self.getTargetAmountForDateApi { _ in }
+                        }
                     }
                 } else {
                     Log.error("Network request failed: \(error)")

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -55,9 +55,11 @@ class TargetAmountViewModel: ObservableObject {
                         // 추천 금액 보여주기 x + 목표 금액 설정하기 UI
                         self.isHiddenSuggestionView = true
                         self.isPresentTargetAmount = false
-                        self.generateCurrentMonthDummyDataApi { _ in
-                            // 당월 목표 금액 조회 재요청
-                            self.getTargetAmountForDateApi { _ in }
+                        self.generateCurrentMonthDummyDataApi { success in
+                            if success{
+                                // 당월 이전 사용자 최신 목표 금액 조회
+                                self.getTargetAmountForPreviousMonthApi()
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
## 작업 이유

- 회원가입 후 목표 금액 생성 이후 목표 금액 플로우 오류

<br/>

## 작업 사항

### 1️⃣ 회원가입 후 목표 금액 생성 이후 목표 금액 플로우 오류

[회원가입 후]가 목표금액을 설정한 적이 없는 사용자를 의미한다.

문제가 목표 금액이 없어서 [당월 목표 금액 조회] -> [당월 목표 금액 더미값 생성] ->  [당월 이전 사용자 최신 목표 금액 조회] -> [당월 목표 금액 삭제]까지 실행이 되어야 하는데 [당월 목표 금액 더미값 생성] 까지만 실행되는게 문제였다.

실행이 되고 있지만 여기까지 실행되고 더 이상 로직이 실행되지 않는 것이 문제였다.

그래서 확인해보니 [당월 목표 금액 더미값 생성] 로직에서 [당월 이전 사용자 최신 목표 금액 조회]를 실행하지 않던게 문제였고 아래와 같이 수정하니 오류는 해결되었다.

```swift
if let StatusSpecificError = error as? StatusSpecificError {
    Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
    
    if StatusSpecificError.domainError == .notFound {
        // 추천 금액 보여주기 x + 목표 금액 설정하기 UI
        self.isHiddenSuggestionView = true
        self.isPresentTargetAmount = false
        self.generateCurrentMonthDummyDataApi { success in//당월 목표 금액 더미값 생성
            if success{
                // 당월 이전 사용자 최신 목표 금액 조회
                self.getTargetAmountForPreviousMonthApi()
            }
        }
    }
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

오류 확인하고 해결했습니다~

<br/>

## 발견한 이슈
