### PR TITLE
🛠️ 회원가입 후 목표 금액 생성 이후 목표 금액 플로우 오류 재수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -56,9 +56,9 @@ class TargetAmountViewModel: ObservableObject {
                         self.isHiddenSuggestionView = true
                         self.isPresentTargetAmount = false
                         self.generateCurrentMonthDummyDataApi { success in
-                            if success{
+                            if success {
                                 // 당월 이전 사용자 최신 목표 금액 조회
-                                self.getTargetAmountForPreviousMonthApi()
+                                self.getTargetAmountForDateApi { _ in }
                             }
                         }
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -55,7 +55,10 @@ class TargetAmountViewModel: ObservableObject {
                         // 추천 금액 보여주기 x + 목표 금액 설정하기 UI
                         self.isHiddenSuggestionView = true
                         self.isPresentTargetAmount = false
-                        self.generateCurrentMonthDummyDataApi { _ in }
+                        self.generateCurrentMonthDummyDataApi { _ in
+                            // 당월 목표 금액 조회 재요청
+                            self.getTargetAmountForDateApi { _ in }
+                        }
                     }
                 } else {
                     Log.error("Network request failed: \(error)")

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -57,7 +57,7 @@ class TargetAmountViewModel: ObservableObject {
                         self.isPresentTargetAmount = false
                         self.generateCurrentMonthDummyDataApi { success in
                             if success {
-                                // 당월 이전 사용자 최신 목표 금액 조회
+                                // 당월 목표 금액 재조회
                                 self.getTargetAmountForDateApi { _ in }
                             }
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -55,9 +55,11 @@ class TargetAmountViewModel: ObservableObject {
                         // 추천 금액 보여주기 x + 목표 금액 설정하기 UI
                         self.isHiddenSuggestionView = true
                         self.isPresentTargetAmount = false
-                        self.generateCurrentMonthDummyDataApi { _ in
-                            // 당월 목표 금액 조회 재요청
-                            self.getTargetAmountForDateApi { _ in }
+                        self.generateCurrentMonthDummyDataApi { success in
+                            if success{
+                                // 당월 이전 사용자 최신 목표 금액 조회
+                                self.getTargetAmountForPreviousMonthApi()
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
## 작업 이유

- #184 재수정


<br/>

## 작업 사항

### 1️⃣ 회원가입 후 목표 금액 생성 이후 목표 금액 플로우 오류


목표 금액이 없어서 [당월 목표 금액 조회] -> [당월 목표 금액 더미값 생성] -> [당월 목표 금액 조회] -> [당월 이전 사용자 최신 목표 금액 조회] -> [당월 목표 금액 삭제]까지 실행이 되어야 하는데 [당월 목표 금액 더미값 생성] 까지만 실행되는게 문제였다.

[당월 목표 금액 더미값 생성]을 완료한 후 [당월 목표 금액 조회]를 재 요청해서 반영하였다.

#184 에서 테스트 하던 코드를 올려버려서,,,, 다시 pr 올린다

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

다시 오류 수정했어요!!


<br/>

## 발견한 이슈
