### PR TITLE
🛠️ 구글 idToken 디코딩 에러 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/GoogleOAuthViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/OAuthLoginViewModel/GoogleOAuthViewModel.swift
@@ -25,8 +25,11 @@ class GoogleOAuthViewModel: ObservableObject {
             self.givenName = givenName ?? ""
             
             let jwtParts = user.idToken?.tokenString.components(separatedBy: ".")
-            guard jwtParts?.count == 3, let payloadData = Data(base64Encoded: jwtParts?[1] ?? "", options: .ignoreUnknownCharacters) else {
-                print("Invalid JWT format")
+            let payloadBase64 = jwtParts?[1].replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+            let payloadPadded = payloadBase64!.padding(toLength: ((payloadBase64!.count + 3) / 4) * 4, withPad: "=", startingAt: 0)
+
+            guard jwtParts?.count == 3, let payloadData = Data(base64Encoded: payloadPadded) else {
+                Log.fault("[GoogleOAuthViewModel] Invalid JWT format")
                 return
             }
             do {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/TargetAmountViewModel/TargetAmountViewModel.swift
@@ -20,11 +20,11 @@ class TargetAmountViewModel: ObservableObject {
                         let response = try JSONDecoder().decode(GetTargetAmountForDateResponseDto.self, from: responseData)
                         let validTargetAmount = response.data.targetAmount
                         self.targetAmountData = validTargetAmount
-                       
+                        
                         if validTargetAmount.targetAmountDetail.isRead == true {
                             // 추천 금액 보여주기 x
                             self.isHiddenSuggestionView = true
-
+                            
                         } else {
                             self.isHiddenSuggestionView = false
                             self.getTargetAmountForPreviousMonthApi()
@@ -36,7 +36,7 @@ class TargetAmountViewModel: ObservableObject {
                         } else {
                             self.isPresentTargetAmount = true
                         }
-    
+                        
                         if let jsonString = String(data: responseData, encoding: .utf8) {
                             Log.debug("당월 목표 금액 조회 \(jsonString)")
                         }
@@ -47,7 +47,7 @@ class TargetAmountViewModel: ObservableObject {
                     }
                 }
             case let .failure(error):
-    
+                
                 if let StatusSpecificError = error as? StatusSpecificError {
                     Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
                     
@@ -59,12 +59,13 @@ class TargetAmountViewModel: ObservableObject {
                             if success {
                                 // 당월 목표 금액 재조회
                                 self.getTargetAmountForDateApi { _ in }
+                            }
                         }
+                    } else {
+                        Log.error("Network request failed: \(error)")
                     }
-                } else {
-                    Log.error("Network request failed: \(error)")
+                    completion(false)
                 }
-                completion(false)
             }
         }
     }


### PR DESCRIPTION
## 작업 이유

- 구글 idToken 디코딩 에러 해결


<br/>

## 작업 사항


### 1️⃣ 구글 idToken 디코딩 에러 해결


GoogleOAuthViewModel의 checkUserInfo() 함수에서 ` let payloadData = Data(base64Encoded: payloadPadded)`의 결과가 nil값으로 출력되는 문제가 있었다. 

원인은 아래와 같이 두가지였고, 코드를 수정해서 해결하였다.

패딩 문제: Base64 디코딩 시 문자열의 길이가 4의 배수가 아닐 경우 문제가 발생할 수 있으므로, =으로 패딩값을 채워줌.
URL-safe Base64 인코딩:JWT는 일반적으로 URL-safe Base64 인코딩을 사용하므로, -, + 특수 기호가 포함된 경우를 처리해주어야 함.

```swift
let jwtParts = user.idToken?.tokenString.components(separatedBy: ".")
let payloadBase64 = jwtParts?[1].replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
let payloadPadded = payloadBase64!.padding(toLength: ((payloadBase64!.count + 3) / 4) * 4, withPad: "=", startingAt: 0)

guard jwtParts?.count == 3, let payloadData = Data(base64Encoded: payloadPadded) else {
    Log.fault("[GoogleOAuthViewModel] Invalid JWT format")
    return
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

에러 해결한 코드로 변경하였습니다~

<br/>

## 발견한 이슈
close #178