### PR TITLE
🛠️ 초기 API 요청 코드 completion 적용 및 수정 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -92,7 +92,9 @@ struct PhoneVerificationView: View {
                     oauthAccountLinkingViewModel.linkOAuthToAccountApi { success in
                         if success {
                             profileInfoViewModel.getUserProfileApi { success in
-                                authViewModel.login()
+                                if success {
+                                    authViewModel.login()
+                                }
                             }
                         }
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -89,7 +89,12 @@ struct PhoneVerificationView: View {
                 OAuthRegistrationManager.shared.phone = phoneVerificationViewModel.phoneNumber
                 OAuthRegistrationManager.shared.code = phoneVerificationViewModel.code
                 if OAuthRegistrationManager.shared.isExistUser {
-                    oauthAccountLinkingViewModel.linkOAuthToAccountApi()
+                    oauthAccountLinkingViewModel.linkOAuthToAccountApi { success in           
+                        if success {
+                            authViewModel.login()
+                            profileInfoViewModel.getUserProfileApi { _ in }
+                        }
+                    }
                 }
             } else {
                 RegistrationManager.shared.phoneNumber = phoneVerificationViewModel.phoneNumber
@@ -108,17 +113,18 @@ struct PhoneVerificationView: View {
             OAuthAccountLinkingView(signUpViewModel: viewModel)
 
         } else if OAuthRegistrationManager.shared.isOAuthRegistration && OAuthRegistrationManager.shared.isExistUser { // 이미 계정이 있는 경우
-            handleExistUserLogin()
+//            handleExistUserLogin()
         } else {
             SignUpView(viewModel: viewModel)
         }
     }
     
-    func handleExistUserLogin() -> some View {
-        authViewModel.login()
-        profileInfoViewModel.getUserProfileApi { _ in }
-        return EmptyView()
-    }
+//    func handleExistUserLogin() -> some View {
+    ////        oauthAccountLinkingViewModel.linkOAuthToAccountApi()
+    ////        authViewModel.login()
+    ////        profileInfoViewModel.getUserProfileApi { _ in }
+//        return EmptyView()
+//    }
 }
 
 #Preview {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -89,7 +89,7 @@ struct PhoneVerificationView: View {
                 OAuthRegistrationManager.shared.phone = phoneVerificationViewModel.phoneNumber
                 OAuthRegistrationManager.shared.code = phoneVerificationViewModel.code
                 if OAuthRegistrationManager.shared.isExistUser {
-                    oauthAccountLinkingViewModel.linkOAuthToAccountApi { success in           
+                    oauthAccountLinkingViewModel.linkOAuthToAccountApi { success in
                         if success {
                             authViewModel.login()
                             profileInfoViewModel.getUserProfileApi { _ in }
@@ -113,18 +113,10 @@ struct PhoneVerificationView: View {
             OAuthAccountLinkingView(signUpViewModel: viewModel)
 
         } else if OAuthRegistrationManager.shared.isOAuthRegistration && OAuthRegistrationManager.shared.isExistUser { // 이미 계정이 있는 경우
-//            handleExistUserLogin()
         } else {
             SignUpView(viewModel: viewModel)
         }
     }
-    
-//    func handleExistUserLogin() -> some View {
-    ////        oauthAccountLinkingViewModel.linkOAuthToAccountApi()
-    ////        authViewModel.login()
-    ////        profileInfoViewModel.getUserProfileApi { _ in }
-//        return EmptyView()
-//    }
 }
 
 #Preview {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -91,8 +91,9 @@ struct PhoneVerificationView: View {
                 if OAuthRegistrationManager.shared.isExistUser {
                     oauthAccountLinkingViewModel.linkOAuthToAccountApi { success in
                         if success {
-                            authViewModel.login()
-                            profileInfoViewModel.getUserProfileApi { _ in }
+                            profileInfoViewModel.getUserProfileApi { success in
+                                authViewModel.login()
+                            }
                         }
                     }
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpView.swift
@@ -106,7 +106,9 @@ struct SignUpView: View {
         linkAccountToOAuthViewModel.linkAccountToOAuthApi { success in
             if success {
                 profileInfoViewModel.getUserProfileApi { success in
-                    authViewModel.login()
+                    if success {
+                        authViewModel.login()
+                    }
                 }
             } else {
                 Log.error("기존 계정에 소셜 계정 연동 실패")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/SignUpView/SignUpView.swift
@@ -105,8 +105,9 @@ struct SignUpView: View {
     func handleLinkAccountToOAuth() {
         linkAccountToOAuthViewModel.linkAccountToOAuthApi { success in
             if success {
-                authViewModel.login()
-                profileInfoViewModel.getUserProfileApi { _ in }
+                profileInfoViewModel.getUserProfileApi { success in
+                    authViewModel.login()
+                }
             } else {
                 Log.error("기존 계정에 소셜 계정 연동 실패")
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/WelcomeView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/WelcomeView.swift
@@ -30,7 +30,6 @@ struct WelcomeView: View {
 
             CustomBottomButton(action: {
                 isnavigateToEditTargetView = true
-                profileInfoViewModel.getUserProfileApi { _ in }
             }, label: "확인", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/WelcomeView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/WelcomeView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct WelcomeView: View {
-    let profileInfoViewModel = UserAccountViewModel()
     var name = OAuthRegistrationManager.shared.isOAuthRegistration ? OAuthRegistrationManager.shared.name : RegistrationManager.shared.name
     @State private var isnavigateToEditTargetView = false
     @State var initTargetAmount = TargetAmount(year: 0, month: 0, targetAmountDetail: AmountDetail(id: -1, amount: -1, isRead: false), totalSpending: 0, diffAmount: 0)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/AddSpendingCategoryView.swift
@@ -167,9 +167,15 @@ struct AddSpendingCategoryView: View {
                         spendingCategoryViewModel.initPage()
                         
                         // 카테고리 수정 후 카테고리 관련 데이터 다시 조회
-                        spendingCategoryViewModel.getCategorySpendingHistoryApi { _ in }
-                        spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in }
-                        presentationMode.wrappedValue.dismiss()
+                        spendingCategoryViewModel.getCategorySpendingHistoryApi { success in
+                            if success {
+                                spendingCategoryViewModel.getSpendingCustomCategoryListApi { success in
+                                    if success {
+                                        presentationMode.wrappedValue.dismiss()
+                                    }
+                                }
+                            }
+                        }
                             
                     } else {
                         Log.debug("카테고리 수정 실패")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -140,8 +140,9 @@ struct MySpendingListView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 0) {
                     Button(action: {
-                        navigateToCategoryGridView = true
-                        spendingCategoryViewModel.getSpendingCustomCategoryListApi { _ in }
+                        spendingCategoryViewModel.getSpendingCustomCategoryListApi { success in
+                            navigateToCategoryGridView = true
+                        }
                     }, label: {
                         Text("카테고리")
                             .font(.B2MediumFont())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -154,10 +154,12 @@ struct CategoryDetailsView: View {
                     secondBtnAction: { 
                         viewModel.deleteCategoryApi { success in
                             if success {
-                                viewModel.getSpendingCustomCategoryListApi { _ in
-                                    self.showDeletePopUp = false
-                                    self.presentationMode.wrappedValue.dismiss()
-                                    self.showDeleteCategoryToastPopUp = true
+                                viewModel.getSpendingCustomCategoryListApi { success in    
+                                    if success {
+                                        self.showDeletePopUp = false
+                                        self.presentationMode.wrappedValue.dismiss()
+                                        self.showDeleteCategoryToastPopUp = true
+                                    }
                                 }
                             }
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/RecentTargetAmountSuggestionView.swift
@@ -17,8 +17,9 @@ struct RecentTargetAmountSuggestionView: View {
                 Spacer()
                 
                 Button(action: {
-                    isHidden = true
-                    viewModel.deleteCurrentMonthTargetAmountApi { _ in }
+                    viewModel.deleteCurrentMonthTargetAmountApi { success in
+                        isHidden = true
+                    }
                 }, label: {
                     Image("icon_close_white")
                         .resizable()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
@@ -5,6 +5,8 @@ struct TargetAmountSetCompleteView: View {
     @ObservedObject var viewModel: TargetAmountSettingViewModel
     @EnvironmentObject var authViewModel: AppViewModel
     
+    let profileInfoViewModel = UserAccountViewModel()
+    
     var entryPoint: TargetAmountEntryPoint
     
     private var buttonText: String {
@@ -43,6 +45,7 @@ struct TargetAmountSetCompleteView: View {
                 CustomBottomButton(action: {
                     if entryPoint == .signUp {
                         authViewModel.login() // 메인화면으로 entryPoint 나누기
+                        profileInfoViewModel.getUserProfileApi { _ in }
                     } else {
                         goToTotalTargetAmountView()
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
@@ -45,7 +45,9 @@ struct TargetAmountSetCompleteView: View {
                 CustomBottomButton(action: {
                     if entryPoint == .signUp {
                         profileInfoViewModel.getUserProfileApi { success in
-                            authViewModel.login()// 메인화면으로 entryPoint 나누기
+                            if success {
+                                authViewModel.login() // 메인화면으로 entryPoint 나누기
+                            }
                         }
                     } else {
                         goToTotalTargetAmountView()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSetCompleteView.swift
@@ -44,8 +44,9 @@ struct TargetAmountSetCompleteView: View {
                 
                 CustomBottomButton(action: {
                     if entryPoint == .signUp {
-                        authViewModel.login() // 메인화면으로 entryPoint 나누기
-                        profileInfoViewModel.getUserProfileApi { _ in }
+                        profileInfoViewModel.getUserProfileApi { success in
+                            authViewModel.login()// 메인화면으로 entryPoint 나누기
+                        }
                     } else {
                         goToTotalTargetAmountView()
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
@@ -7,8 +7,9 @@ struct TargetAmountSettingView: View {
     @StateObject var targetAmountViewModel = TargetAmountViewModel()
     @State private var navigateToCompleteTarget = false
     
+    let profileInfoViewModel = UserAccountViewModel()
+    
     @EnvironmentObject var authViewModel: AppViewModel
-
     var entryPoint: TargetAmountEntryPoint
     
     init(currentData: Binding<TargetAmount>, entryPoint: TargetAmountEntryPoint) {
@@ -69,6 +70,7 @@ struct TargetAmountSettingView: View {
                                 if success {
                                     Log.debug("목표 금액 삭제 성공")
                                     authViewModel.login()
+                                    profileInfoViewModel.getUserProfileApi { _ in }
                                 }
                             }
                         }, label: {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
@@ -69,8 +69,9 @@ struct TargetAmountSettingView: View {
                             targetAmountViewModel.deleteCurrentMonthTargetAmountApi { success in
                                 if success {
                                     Log.debug("목표 금액 삭제 성공")
-                                    authViewModel.login()
-                                    profileInfoViewModel.getUserProfileApi { _ in }
+                                    profileInfoViewModel.getUserProfileApi { success in
+                                        authViewModel.login()
+                                    }
                                 }
                             }
                         }, label: {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TargetAmountSettingView.swift
@@ -70,7 +70,9 @@ struct TargetAmountSettingView: View {
                                 if success {
                                     Log.debug("목표 금액 삭제 성공")
                                     profileInfoViewModel.getUserProfileApi { success in
-                                        authViewModel.login()
+                                        if success {
+                                            authViewModel.login()
+                                        }
                                     }
                                 }
                             }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/LinkOAuthToAccountViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/OAuthViewModel/LinkOAuthToAccountViewModel.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 class LinkOAuthToAccountViewModel: ObservableObject {
-    func linkOAuthToAccountApi() { // 바로 로그인 처리
+    func linkOAuthToAccountApi(completion: @escaping (Bool) -> Void) { // 바로 로그인 처리
         let linkOAuthToAccountDto = LinkOAuthToAccountRequestDto(oauthId: KeychainHelper.loadOAuthUserData()?.oauthId ?? "", idToken: KeychainHelper.loadOAuthUserData()?.idToken ?? "", nonce: KeychainHelper.loadOAuthUserData()?.nonce ?? "", phone: OAuthRegistrationManager.shared.formattedPhoneNumber ?? "", code: OAuthRegistrationManager.shared.code, provider: OAuthRegistrationManager.shared.provider)
 
         OAuthAlamofire.shared.linkOAuthToAccount(linkOAuthToAccountDto) { result in
@@ -19,6 +19,8 @@ class LinkOAuthToAccountViewModel: ObservableObject {
                         ])
 
                         print(response)
+
+                        completion(true)
                     } catch {
                         print("Error parsing response JSON: \(error)")
                     }
@@ -29,6 +31,7 @@ class LinkOAuthToAccountViewModel: ObservableObject {
                 } else {
                     print("Failed to verify: \(error)")
                 }
+                completion(false)
             }
         }
     }


### PR DESCRIPTION
## 작업 이유

- 초기 API 요청 코드 completion 적용 및 수정 


<br/>

## 작업 사항

### 1️⃣ 소셜 계정 연동시 문제 해결

문제 원인: 소셜 계정 연동 API의 응답을 받기 전에 메인 뷰로 전환되고, 동시에 사용자 정보 조회 API와 메인 뷰에서 여러 API 호출이 이루어졌다. 이때, 소셜 계정 연동 API는 성공했지만, AT(Access Token)가 없어서 다른 API 요청들이 실패했고, 그 결과 데이터가 업데이트되지 않았다.

이 문제는 초기 PhoneVerificationView에서 소셜 계정을 연동하는 로직에서 발생했다.

이유: [소셜 계정 연동 API 호출 → 메인 뷰로 루트 뷰 전환 → 사용자 정보 조회 API 호출]의 순서로 실행되어야 했지만, 소셜 계정 연동 API의 응답(AT 발급) 전에 [메인 뷰로 루트 뷰 전환 → 사용자 정보 조회 API 호출]이 실행되면서 AT가 없다는 오류가 발생했다.

해결 방법: 소셜 계정 연동 API의 응답을 받은 후, 사용자 정보 조회 API를 호출하고, 그 후에 메인 뷰로 전환하는 순서로 로직을 수정했다. 

```swift
oauthAccountLinkingViewModel.linkOAuthToAccountApi { success in
    if success {
        profileInfoViewModel.getUserProfileApi { success in
              if success {
                  authViewModel.login()
              }
          }
    }
}
```


### 2️⃣ 초기 API 요청 코드 completion 적용 및 수정 

1️⃣ 문제로 인해 초기에 작성했던 코드를 다시 점검하였고 completion을 사용하는 로직 중 뷰를 변경하거나 다른 api를 요청해야 하는 경우들을 수정했다.

<br/>

- [사용자 정보 조회 api 요청 -> 메인 뷰로 루트 뷰 변경] 로직 수정

모든 [사용자 정보 조회 API 요청 -> 메인 뷰로 루트 뷰 변경] 로직을 아래와 같이 수정하여, 사용자 정보 조회가 완료되기 전에 메인 뷰로 이동하지 않도록 변경했다.

```swift
profileInfoViewModel.getUserProfileApi { success in
    if success {
        authViewModel.login()
    }
}
```

<br/>

- welcomView의 사용자 정보 조회 api 요청 

회원가입 하는 경우 무조건 TargetAmountSettingView와 TargetAmountSetCompleteView를 반드시 거치도록 되어있다. 기존에는 WelcomeView에서 사용자 정보 조회 API를 먼저 요청한 후 다음 뷰로 이동했지만, 이 과정을 TargetAmountSettingView와 TargetAmountSetCompleteView로 이동한 후에 처리하도록 수정했다.

따라서, 사용자 정보 조회 API는 TargetAmountSettingView와 TargetAmountSetCompleteView에서 처리되며, WelcomeView에서는 더 이상 API 요청을 하지 않도록 변경했다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

초기에 작성한 코드와 completion 사용하는 경우들을 찾아서 수정했습니다! 


<br/>

## 발견한 이슈
초기 나