### PR TITLE
📍 세로모드 고정 + 앱 이름 설정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -2567,8 +2567,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2608,8 +2607,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -2562,6 +2562,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "pennyway-client-iOS/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Pennyway;
 				INFOPLIST_KEY_NSCameraUsageDescription = "camera 접근 권한 주세요";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "album 권한 접근 주세요";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -2602,6 +2603,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "pennyway-client-iOS/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Pennyway;
 				INFOPLIST_KEY_NSCameraUsageDescription = "camera 접근 권한 주세요";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "album 권한 접근 주세요";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;


### PR DESCRIPTION
## 작업 이유

- 세로모드 고정
- 앱 이름 설정


<br/>

## 작업 사항


### 1️⃣ 세로모드 고정

Targets -> General -> Deployment Info -> iPhone Orientation, iPad Orientation 항목에서 Portrait만 설정해서 세로모드로 고정되도록 하였다.

![스크린샷 2024-08-20 오전 1 08 42](https://github.com/user-attachments/assets/d2a55709-9ebc-4d20-bcdb-9a08ae0f9bf7)

### 2️⃣ 앱 이름 설정

Targets -> 프로젝트명 -> Generals -> Identity 항목에서 Display Name 항목을 Pennyway로 설정했다.

![스크린샷 2024-08-20 오전 1 09 35](https://github.com/user-attachments/assets/cc0c9f13-7684-484f-b8d9-076d0770f90a)



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

세로모드 고정과 앱 이름 설정도 했습니다!!
테스트 해보니까 둘 다 정상적으로 잘 작동되는 거 확인했습니다~

<br/>

## 발견한 이슈
없음