### PR TITLE
📍문의하기 api 요청시 디바운스 처리

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
@@ -176,7 +176,6 @@ struct InquiryView: View {
             viewModel.dismissAction = {
                 self.presentationMode.wrappedValue.dismiss()
             }
-            
             // 디바운스 타이머 트리거
             viewModel.debounceTimer.send(())
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/InquiryView.swift
@@ -1,4 +1,5 @@
 
+import Combine
 import SwiftUI
 
 struct InquiryView: View {
@@ -11,7 +12,7 @@ struct InquiryView: View {
     @Environment(\.presentationMode) var presentationMode
 
     let placeholder: String = "문의 내용을 입력해주세요"
-
+    
     var body: some View {
         VStack(alignment: .leading) {
             ScrollView {
@@ -172,11 +173,12 @@ struct InquiryView: View {
 
     private func continueButtonAction() {
         if viewModel.isFormValid {
-            viewModel.sendInquiryMailApi { success in
-                if success {
-                    self.presentationMode.wrappedValue.dismiss()
-                }
+            viewModel.dismissAction = {
+                self.presentationMode.wrappedValue.dismiss()
             }
+            
+            // 디바운스 타이머 트리거
+            viewModel.debounceTimer.send(())
         }
     }
     


### PR DESCRIPTION
## 작업 이유
- 문의하기 api요청시 디바운스 처리

<br/>

## 작업 사항
### **1️⃣ 문의하기 api 요청시 디바운스 처리**
문의하기 api요청시 응답이 몇초 늦게 돌아와 사용자가 계속 문의하기 버튼을 누를시 계속해서 요청이 보내지는 것이 문제였다.

따라서 주어진 시간동안 이벤트가 발생했을때 마지막 이벤트만 주어진 시간 이외에 실행되도록 디바운싱을 사용하여 api 요청을 줄였다.

문의하기 뷰에서 문의하기 버튼을 입력하였을 경우 폼이 유효하다면 디바운스 타이머를 트리거 시키도록 구현하였다.
```swift
    private func continueButtonAction() {
        if viewModel.isFormValid {
            viewModel.dismissAction = {
                self.presentationMode.wrappedValue.dismiss()
            }
            
            // 디바운스 타이머 트리거
            viewModel.debounceTimer.send(())
        }
    }
    
``` 
그리고 뷰모델에서 아래 로직을 통해서 디바운스 타이머가 트리거되면 뷰모델의 init()이 실행된다.
```swift
    var cancellables = Set<AnyCancellable>()
    let debounceInterval = 0.3
    var debounceTimer = PassthroughSubject<Void, Never>()

    var dismissAction: (() -> Void)?

    init() {
        debounceTimer
            .debounce(for: .seconds(debounceInterval), scheduler: RunLoop.main)
            .sink { [weak self] in
                self?.sendInquiryMailApi { success in
                    if success {
                        self?.dismissAction?()
                        Log.debug("디바운싱 문의하기 마지막 이벤트 보냄")
                    } else {
                        Log.debug("문의하기 디바운싱 실패")
                    }
                }
            }
            .store(in: &cancellables)
    }
``` 

- debounce를 통해 이벤트가 방출된 후 일정 시간동안 추가적인 이벤트가 발생하지 않을 때 마지막 이벤트만 전달된다.
- sink를 통해 이벤트를 구독하여 처리하고 만약 api요청에 성공했다면 dismissAction클로저를 넘겨줘서 문의하기 뷰에서 `self.presentationMode.wrappedValue.dismiss()`가 실행되도록 하였다.

보통 응답이 돌아오는 시간이 약 3초동안 걸린다하여 디바운싱 시간은 3초로 지정하였다.
<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
문의하기 api 디바운스 처리했고 10번 연타로 날렸을때 메일 1번 온거랑 로그도 확인했습니다!


<br/>

## 발견한 이슈
