### PR TITLE
📍카테고리 리스트에서 진입하여 소비내역 수정한 경우 수정사항 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Dto/Response/Spending/AddSpendingHistoryResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/SpendingDomain/Dto/Response/Spending/AddSpendingHistoryResponseDto.swift
@@ -8,22 +8,6 @@ struct AddSpendingHistoryResponseDto: Codable {
     let data: SpendingData
 
     struct SpendingData: Codable {
-        let spending: Spending
-
-        struct Spending: Codable {
-            let id: Int
-            let amount: Int
-            let category: Category
-            let spendAt: String
-            let accountName: String
-            let memo: String
-
-            struct Category: Codable {
-                let isCustom: Bool
-                let id: Int
-                let name: String
-                let icon: String
-            }
-        }
+        let spending: IndividualSpending
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Model/Network/SpendingResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Model/Network/SpendingResponseDto.swift
@@ -18,11 +18,19 @@ struct DailySpending: Codable {
 
 struct IndividualSpending: Codable {
     let id: Int
-    let amount: Int
-    let category: SpendingCategory
-    let spendAt: String
-    let accountName: String
-    let memo: String
+    var amount: Int
+    var category: SpendingCategory
+    var spendAt: String
+    var accountName: String
+    var memo: String
+
+    mutating func update(spending: IndividualSpending) {
+        amount = spending.amount
+        category = spending.category
+        spendAt = spending.spendAt
+        accountName = spending.accountName
+        memo = spending.memo
+    }
 }
 
 // MARK: - SpendingCategory

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -19,109 +19,107 @@ struct ProfileMainView: View {
     var body: some View {
         NavigationAvailable {
             ZStack {
-
-                    ScrollView {
-                        VStack {
-                            ProfileUserInfoView(
-                                showPopUpView: $showPopUpView,
-                                navigateToEditUsername: $navigateToEditUsername,
-                                selectedUIImage: $selectedUIImage,
-                                imageUrl: $imageUrl,
-                                viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
-                            )
-                            
-                            Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-                            
-                            VStack {
-                                Text("내 게시글")
-                                    .font(.B1MediumFont())
-                                    .platformTextColor(color: Color("Gray07"))
-                                    .offset(x: -140, y: 0)
-                                
-                                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
-                                
-                                Image("icon_illust_empty")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
-                                
-                                Text("아직 작성된 글이 없어요")
-                                    .font(.H4MediumFont())
-                                    .platformTextColor(color: Color("Gray07"))
-                                    .padding(1)
-                            }
-                            .padding(.horizontal, 20)
-                        }
-                        
-                        Spacer()
-                    }
-                    
-                    if showPopUpView {
-                        Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                        EditProfilePopUpView(
-                            isPresented: $showPopUpView,
+                ScrollView {
+                    VStack {
+                        ProfileUserInfoView(
                             showPopUpView: $showPopUpView,
-                            isHiddenTabBar: $isHiddenTabBar,
-                            showImagePicker: $showImagePicker,
+                            navigateToEditUsername: $navigateToEditUsername,
                             selectedUIImage: $selectedUIImage,
-                            sourceType: $sourceType,
                             imageUrl: $imageUrl,
-                            presignedUrlViewModel: presignedUrlViewModel
+                            viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
                         )
+                            
+                        Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+                            
+                        VStack {
+                            Text("내 게시글")
+                                .font(.B1MediumFont())
+                                .platformTextColor(color: Color("Gray07"))
+                                .offset(x: -140, y: 0)
+                                
+                            Spacer().frame(height: 6 * DynamicSizeFactor.factor())
+                                
+                            Image("icon_illust_empty")
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
+                                
+                            Text("아직 작성된 글이 없어요")
+                                .font(.H4MediumFont())
+                                .platformTextColor(color: Color("Gray07"))
+                                .padding(1)
+                        }
+                        .padding(.horizontal, 20)
                     }
+                        
+                    Spacer()
                 }
+                    
+                if showPopUpView {
+                    Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                    EditProfilePopUpView(
+                        isPresented: $showPopUpView,
+                        showPopUpView: $showPopUpView,
+                        isHiddenTabBar: $isHiddenTabBar,
+                        showImagePicker: $showImagePicker,
+                        selectedUIImage: $selectedUIImage,
+                        sourceType: $sourceType,
+                        imageUrl: $imageUrl,
+                        presignedUrlViewModel: presignedUrlViewModel
+                    )
+                }
+            }
                 
-                .edgesIgnoringSafeArea(.bottom)
-                .sheet(isPresented: $showImagePicker, onDismiss: {
-                    // 사진 클릭한 경우
-                    showPopUpView = false
-                    presignedUrlViewModel.image = selectedUIImage
-                    presignedUrlViewModel.generatePresignedUrlApi { success in
-                        if success {
-                            presignedUrlViewModel.storePresignedUrlApi { success in
-                                if success {
-                                    profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
-                                }
+            .edgesIgnoringSafeArea(.bottom)
+            .sheet(isPresented: $showImagePicker, onDismiss: {
+                // 사진 클릭한 경우
+                showPopUpView = false
+                presignedUrlViewModel.image = selectedUIImage
+                presignedUrlViewModel.generatePresignedUrlApi { success in
+                    if success {
+                        presignedUrlViewModel.storePresignedUrlApi { success in
+                            if success {
+                                profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
                             }
                         }
                     }
-                }) {
-                    ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
-                        .edgesIgnoringSafeArea(.bottom)
                 }
-                .id(showPopUpView)
-                .background(Color("Gray01"))
-                .setTabBarVisibility(isHidden: showPopUpView)
-                .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
+            }) {
+                ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
+                    .edgesIgnoringSafeArea(.bottom)
+            }
+            .id(showPopUpView)
+            .background(Color("Gray01"))
+            .setTabBarVisibility(isHidden: showPopUpView)
+            .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
                 
-                //            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        HStack {
-                            Button(action: {
-                                isSelectedToolBar = true
-                            }, label: {
-                                Image("icon_hamburger_button")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                                    .padding(5)
-                            })
-                            .frame(width: 44, height: 44)
-                            .buttonStyle(BasicButtonStyleUtil())
-                        }
+            //            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack {
+                        Button(action: {
+                            isSelectedToolBar = true
+                        }, label: {
+                            Image("icon_hamburger_button")
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                                .padding(5)
+                        })
+                        .frame(width: 44, height: 44)
+                        .buttonStyle(BasicButtonStyleUtil())
                     }
                 }
+            }
                 
-                NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
-                    EmptyView()
-                }.hidden()
+            NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
+                EmptyView()
+            }.hidden()
                 
-                NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
-                    EmptyView()
-                }.hidden()
-            
+            NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
+                EmptyView()
+            }.hidden()
         }
         .onAppear {
             Log.debug("isHiddenTabBar:\(isHiddenTabBar)")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -114,19 +114,19 @@ struct AddSpendingHistoryView: View {
         }
         Log.debug("수정하기")
 
-        viewModel.editSpendingHistoryApi(spendingId: spendingId) { success in
-            if success {
+        viewModel.editSpendingHistoryApi(spendingId: spendingId) { response in
+
+            switch response {
+            case let .success(data):
                 self.presentationMode.wrappedValue.dismiss()
                 self.spendingHistoryViewModel.spendingDetailViewUpdated = spendingDetailViewUpdated
                 self.isEditSuccess = true
-                Log.debug("지출 내역 수정 성공")
-            } else {
-                Log.debug("지출 내역 수정 실패")
+
+                spendingCategoryViewModel.updateSpending(dto: data!)
+
+            case let .failure(error):
+                Log.debug("error")
             }
         }
     }
 }
-
-// #Preview {
-//    AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: .constant(Date()), spendingId: 0, isPresented: .constant(true), entryPoint: .main)
-// }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingInputFormView.swift
@@ -139,18 +139,9 @@ struct AddSpendingInputFormView: View {
                 viewModel.consumerText = ""
                 isDeleteButtonVisible = false
             })
-//            .onAppear {
-//                isDeleteButtonVisible = false
-//            }
             .onTapGesture {
                 isDeleteButtonVisible = true
             }
-//            .onChange(of: viewModel.consumerText) { newValue in
-//                if newValue.isEmpty {
-//                    isDeleteButtonVisible = false
-//                }
-//            }
-
             Spacer().frame(height: 28 * DynamicSizeFactor.factor())
             
             // 메모

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -13,7 +13,6 @@ struct CategoryDetailsView: View {
     @State private var showDeleteToastPopup = false
     @State private var showMoveToastPopup = false // 카테고리 이동
     @State var isDeleted = false
-    @State var isEditSuccess = false
     @State private var isNavigateToEditCategoryView = false
     @State private var isNavigateToMoveCategoryView = false
     
@@ -51,7 +50,7 @@ struct CategoryDetailsView: View {
                         
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                         
-                    CategorySpendingListView(viewModel: viewModel, showDeleteToastPopup: $showDeleteToastPopup, isDeleted: $isDeleted, isEditSuccess: $isEditSuccess)
+                    CategorySpendingListView(viewModel: viewModel, showDeleteToastPopup: $showDeleteToastPopup, isDeleted: $isDeleted)
                         
                     Spacer()
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -13,6 +13,7 @@ struct CategoryDetailsView: View {
     @State private var showDeleteToastPopup = false
     @State private var showMoveToastPopup = false // 카테고리 이동
     @State var isDeleted = false
+    @State var isEditSuccess = false
     @State private var isNavigateToEditCategoryView = false
     @State private var isNavigateToMoveCategoryView = false
     
@@ -50,7 +51,7 @@ struct CategoryDetailsView: View {
                         
                     Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                         
-                    CategorySpendingListView(viewModel: viewModel, showDeleteToastPopup: $showDeleteToastPopup, isDeleted: $isDeleted)
+                    CategorySpendingListView(viewModel: viewModel, showDeleteToastPopup: $showDeleteToastPopup, isDeleted: $isDeleted, isEditSuccess: $isEditSuccess)
                         
                     Spacer()
                 }
@@ -75,7 +76,6 @@ struct CategoryDetailsView: View {
                     }
                 }, alignment: .bottom
             )
-            
             .overlay(
                 VStack(alignment: .leading) {
                     if isClickMenu {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -7,6 +7,7 @@ struct CategorySpendingListView: View {
     @State private var showDetailSpendingView = false
     @Binding var showDeleteToastPopup: Bool
     @Binding var isDeleted: Bool
+    @Binding var isEditSuccess: Bool
 
     @State private var isLoadingViewShown: Bool = false
     @State private var animateLoadingView: Bool = false
@@ -66,7 +67,7 @@ struct CategorySpendingListView: View {
             }
         }
 
-        NavigationLink(destination: DetailSpendingView(clickDate: $clickDate, spendingId: $spendingId, isDeleted: $isDeleted, showToastPopup: $showDeleteToastPopup, isEditSuccess: .constant(false), spendingCategoryViewModel: viewModel), isActive: $showDetailSpendingView) {}
+        NavigationLink(destination: DetailSpendingView(clickDate: $clickDate, spendingId: $spendingId, isDeleted: $isDeleted, showToastPopup: $showDeleteToastPopup, isEditSuccess: $isEditSuccess, spendingCategoryViewModel: viewModel), isActive: $showDetailSpendingView) {}
             .hidden()
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategorySpendingListView.swift
@@ -7,8 +7,6 @@ struct CategorySpendingListView: View {
     @State private var showDetailSpendingView = false
     @Binding var showDeleteToastPopup: Bool
     @Binding var isDeleted: Bool
-    @Binding var isEditSuccess: Bool
-
     @State private var isLoadingViewShown: Bool = false
     @State private var animateLoadingView: Bool = false
     @State private var isReloadViewShown = false
@@ -67,7 +65,7 @@ struct CategorySpendingListView: View {
             }
         }
 
-        NavigationLink(destination: DetailSpendingView(clickDate: $clickDate, spendingId: $spendingId, isDeleted: $isDeleted, showToastPopup: $showDeleteToastPopup, isEditSuccess: $isEditSuccess, spendingCategoryViewModel: viewModel), isActive: $showDetailSpendingView) {}
+        NavigationLink(destination: DetailSpendingView(clickDate: $clickDate, spendingId: $spendingId, isDeleted: $isDeleted, showToastPopup: $showDeleteToastPopup, isEditSuccess: .constant(false), spendingCategoryViewModel: viewModel), isActive: $showDetailSpendingView) {}
             .hidden()
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/AddSpendingHistoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/AddSpendingHistoryViewModel.swift
@@ -76,7 +76,7 @@ class AddSpendingHistoryViewModel: ObservableObject {
         }
     }
 
-    func editSpendingHistoryApi(spendingId: Int, completion: @escaping (Bool) -> Void) {
+    func editSpendingHistoryApi(spendingId: Int, completion: @escaping (Result<AddSpendingHistoryResponseDto?, Error>) -> Void) {
         let amount = Int(amountSpentText.replacingOccurrences(of: ",", with: "")) ?? 0
         let spendAt = Date.getBasicformattedDate(from: clickDate ?? selectedDate)
         var categoryId = -1
@@ -108,18 +108,19 @@ class AddSpendingHistoryViewModel: ObservableObject {
                         if let jsonString = String(data: responseData, encoding: .utf8) {
                             Log.debug("지출 내역 수정 완료 \(jsonString)")
                         }
-                        completion(true)
+                        completion(.success(response))
+
                     } catch {
                         Log.fault("Error decoding JSON: \(error)")
-                        completion(false)
                     }
                 }
             case let .failure(error):
                 if let StatusSpecificError = error as? StatusSpecificError {
                     Log.info("StatusSpecificError occurred: \(StatusSpecificError)")
                 } else {
-                    Log.error("Network request faile: \(error)")
+                    Log.error("Network request failed: \(error)")
                 }
+                completion(.failure(error))
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
@@ -288,4 +288,14 @@ class SpendingCategoryViewModel: ObservableObject {
     func getSpendingDetail(by id: Int) -> IndividualSpending? {
         return dailyDetailSpendings.first { $0.id == id }
     }
+    
+    func updateSpending(dto: AddSpendingHistoryResponseDto) {
+        let id = selectSpending?.id
+        
+        if let firstIndex = dailyDetailSpendings.firstIndex(where: { $0.id == id }) {
+            dailyDetailSpendings[firstIndex].update(spending: dto.data.spending)
+        }
+        selectSpending?.update(spending: dto.data.spending)
+        Log.debug("spendingCategoryViewModel에서 지출 내역 삭제")
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 카테고리 리스트에서 진입하여 소비내역 수정한 경우 수정사항 반영

<br/>

## 작업 사항
### **1️⃣ 카테고리 리스트에서 진입하여 소비내역 수정한 경우 수정사항 반영**

뷰모델에서 updateSpending함수를 따로 만들어서 수정하기 api성공시 받은 응답으로 id값을 검색하고 수정에 성공했으면 해당 id에 대한 amount, category, memo, accountName, spendAt을 AddSpendingHistoryResponseDto내부에서 업데이트 시키도록 구현하였다.

그래서 뷰에서 따로 변경해주지 않아도 값이 바뀌었기 때문에 부모 뷰까지 전파되어 뷰가 다시 리렌더링 되기 때문에 수정된 값으로 잘 바뀐다.
```
    func updateSpending(dto: AddSpendingHistoryResponseDto) {
        let id = selectSpending?.id
        
        if let firstIndex = dailyDetailSpendings.firstIndex(where: { $0.id == id }) {
            dailyDetailSpendings[firstIndex].update(spending: dto.data.spending)
        }
        selectSpending?.update(spending: dto.data.spending)
        Log.debug("spendingCategoryViewModel에서 지출 내역 삭제")
    }
```

**동작과정**
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-22 at 09 44 30](https://github.com/user-attachments/assets/89e458ff-2b81-4327-a788-40ad14b06492)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
어제 같이 구현한 거 이제 PR올려요! 수고하셨숩니다..... 😂

<br/>

## 발견한 이슈
x