### PR TITLE
📍상단 스크롤 블로킹 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 
 struct MainTabView: View {
     @State private var selection = 0
-    @EnvironmentObject var authViewModel: AppViewModel
 
     var body: some View {
         ZStack {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -17,7 +17,6 @@ struct ProfileMainView: View {
     @StateObject var profileImageViewModel = ProfileImageViewModel()
 
     @State var imageUrl = ""
-    @State private var offsetY: CGFloat = CGFloat.zero
 
     let profileViewHeight = 267 * DynamicSizeFactor.factor()
     @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
@@ -166,7 +165,6 @@ struct ProfileMainView: View {
     
     func setOffset(offset: CGFloat) -> some View {
         DispatchQueue.main.async {
-            self.offsetY = offset
             Log.debug("offset 값:\(offset)")
             
             if updateCount < 2 {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+// MARK: - ProfileMainView
+
 struct ProfileMainView: View {
     @State private var isSelectedToolBar = false
     @State private var navigateToEditUsername = false
@@ -16,112 +18,118 @@ struct ProfileMainView: View {
 
     @State var imageUrl = ""
 
+    @State private var scrollOffset: CGFloat = 0
+    @State private var lastScrollOffset: CGFloat = 0
+
     var body: some View {
         NavigationAvailable {
             ZStack {
+                BouncelessScrollView {
+                    ProfileUserInfoView(
+                        showPopUpView: $showPopUpView,
+                        navigateToEditUsername: $navigateToEditUsername,
+                        selectedUIImage: $selectedUIImage,
+                        imageUrl: $imageUrl,
+                        viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
+                    )
 
-                    ScrollView {
-                        VStack {
-                            ProfileUserInfoView(
-                                showPopUpView: $showPopUpView,
-                                navigateToEditUsername: $navigateToEditUsername,
-                                selectedUIImage: $selectedUIImage,
-                                imageUrl: $imageUrl,
-                                viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
-                            )
-                            
-                            Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-                            
-                            VStack {
-                                Text("내 게시글")
-                                    .font(.B1MediumFont())
-                                    .platformTextColor(color: Color("Gray07"))
-                                    .offset(x: -140, y: 0)
-                                
-                                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
-                                
-                                Image("icon_illust_empty")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
-                                
-                                Text("아직 작성된 글이 없어요")
-                                    .font(.H4MediumFont())
-                                    .platformTextColor(color: Color("Gray07"))
-                                    .padding(1)
-                            }
-                            .padding(.horizontal, 20)
-                        }
-                        
-                        Spacer()
+                    VStack {
+                        Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+
+                        Text("내 게시글")
+                            .font(.B1MediumFont())
+                            .platformTextColor(color: Color("Gray07"))
+                            .offset(x: -140, y: 0)
+
+                        Spacer().frame(height: 6 * DynamicSizeFactor.factor())
+
+                        Image("icon_illust_empty")
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
+
+                        Text("아직 작성된 글이 없어요")
+                            .font(.H4MediumFont())
+                            .platformTextColor(color: Color("Gray07"))
+                            .padding(1)
+
+                        Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+
+                        Text("내 게시글")
+                            .font(.B1MediumFont())
+                            .platformTextColor(color: Color("Gray07"))
+                            .offset(x: -140, y: 0)
                     }
-                    
-                    if showPopUpView {
-                        Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                        EditProfilePopUpView(
-                            isPresented: $showPopUpView,
-                            showPopUpView: $showPopUpView,
-                            isHiddenTabBar: $isHiddenTabBar,
-                            showImagePicker: $showImagePicker,
-                            selectedUIImage: $selectedUIImage,
-                            sourceType: $sourceType,
-                            imageUrl: $imageUrl,
-                            presignedUrlViewModel: presignedUrlViewModel
-                        )
-                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 20)
+                    .background(Color("Gray01"))
                 }
-                
-                .edgesIgnoringSafeArea(.bottom)
-                .sheet(isPresented: $showImagePicker, onDismiss: {
-                    // 사진 클릭한 경우
-                    showPopUpView = false
-                    presignedUrlViewModel.image = selectedUIImage
-                    presignedUrlViewModel.generatePresignedUrlApi { success in
-                        if success {
-                            presignedUrlViewModel.storePresignedUrlApi { success in
-                                if success {
-                                    profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
-                                }
+
+                if showPopUpView {
+                    Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                    EditProfilePopUpView(
+                        isPresented: $showPopUpView,
+                        showPopUpView: $showPopUpView,
+                        isHiddenTabBar: $isHiddenTabBar,
+                        showImagePicker: $showImagePicker,
+                        selectedUIImage: $selectedUIImage,
+                        sourceType: $sourceType,
+                        imageUrl: $imageUrl,
+                        presignedUrlViewModel: presignedUrlViewModel
+                    )
+                }
+            }
+
+            .edgesIgnoringSafeArea(.bottom)
+            .sheet(isPresented: $showImagePicker, onDismiss: {
+                // 사진 클릭한 경우
+                showPopUpView = false
+                presignedUrlViewModel.image = selectedUIImage
+                presignedUrlViewModel.generatePresignedUrlApi { success in
+                    if success {
+                        presignedUrlViewModel.storePresignedUrlApi { success in
+                            if success {
+                                profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
                             }
                         }
                     }
-                }) {
-                    ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
-                        .edgesIgnoringSafeArea(.bottom)
                 }
-                .id(showPopUpView)
-                .background(Color("Gray01"))
-                .setTabBarVisibility(isHidden: showPopUpView)
-                .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
-                
-                //            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        HStack {
-                            Button(action: {
-                                isSelectedToolBar = true
-                            }, label: {
-                                Image("icon_hamburger_button")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                                    .padding(5)
-                            })
-                            .frame(width: 44, height: 44)
-                            .buttonStyle(BasicButtonStyleUtil())
-                        }
+            }) {
+                ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
+                    .edgesIgnoringSafeArea(.bottom)
+            }
+            .id(showPopUpView)
+            .background(Color("Gray01"))
+            .setTabBarVisibility(isHidden: showPopUpView)
+            .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
+
+            //            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack {
+                        Button(action: {
+                            isSelectedToolBar = true
+                        }, label: {
+                            Image("icon_hamburger_button")
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                                .padding(5)
+                        })
+                        .frame(width: 44, height: 44)
+                        .buttonStyle(BasicButtonStyleUtil())
                     }
                 }
-                
-                NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
-                    EmptyView()
-                }.hidden()
-                
-                NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
-                    EmptyView()
-                }.hidden()
-            
+            }
+
+            NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
+                EmptyView()
+            }.hidden()
+
+            NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
+                EmptyView()
+            }.hidden()
         }
         .onAppear {
             Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
@@ -143,4 +151,52 @@ struct ProfileMainView: View {
 
 #Preview {
     ProfileMainView()
+}
+
+// MARK: - ScrollOffsetKey
+
+struct ScrollOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+import SwiftUI
+
+// MARK: - BouncelessScrollView
+
+struct BouncelessScrollView<Content: View>: UIViewRepresentable {
+    var content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    func makeUIView(context _: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        let hostedView = UIHostingController(rootView: content)
+        hostedView.view.translatesAutoresizingMaskIntoConstraints = false
+
+        scrollView.addSubview(hostedView.view)
+
+        // Set up constraints for the content to fill the scroll view
+        NSLayoutConstraint.activate([
+            hostedView.view.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            hostedView.view.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            hostedView.view.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            hostedView.view.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            hostedView.view.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+        ])
+
+        // Disable the bounce effect only for this instance
+        scrollView.contentInsetAdjustmentBehavior = .automatic
+        scrollView.bounces = false
+
+        return scrollView
+    }
+
+    func updateUIView(_: UIScrollView, context _: Context) {
+        // Update the content of the scroll view if needed
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -19,7 +19,10 @@ struct ProfileMainView: View {
     @State var imageUrl = ""
     @State private var offsetY: CGFloat = CGFloat.zero
 
-    let profileViewHeight = 260 * DynamicSizeFactor.factor()
+    let profileViewHeight = 267 * DynamicSizeFactor.factor()
+    @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
+    @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
+    @State private var updateCount = 0 // 업데이트 횟수를 추적하는 변수
 
     var body: some View {
         NavigationAvailable {
@@ -28,6 +31,7 @@ struct ProfileMainView: View {
                     GeometryReader { geometry in
                         let offset = geometry.frame(in: .global).minY
                         setOffset(offset: offset)
+                        
                         ProfileUserInfoView(
                             showPopUpView: $showPopUpView,
                             navigateToEditUsername: $navigateToEditUsername,
@@ -36,10 +40,9 @@ struct ProfileMainView: View {
                             viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
                         )
                         .background(Color("White01"))
-                        .offset(y: offset > 0 ? -offset : 0)
+                        .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
                     }
                     .frame(height: profileViewHeight)
-                    .border(.black)
                     
                     VStack {
                         Spacer().frame(height: 33 * DynamicSizeFactor.factor())
@@ -164,7 +167,17 @@ struct ProfileMainView: View {
     func setOffset(offset: CGFloat) -> some View {
         DispatchQueue.main.async {
             self.offsetY = offset
-            Log.debug("??:\(offset)")
+            Log.debug("offset 값:\(offset)")
+            
+            if updateCount < 2 {
+                updateCount += 1
+            } else if initialOffset == 0 {
+                initialOffset = offset
+            }
+            
+            adjustedOffset = offset - initialOffset
+            
+            Log.debug("initialOffset 값:\(offset)")
         }
         return EmptyView()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -17,54 +17,54 @@ struct ProfileMainView: View {
     @StateObject var profileImageViewModel = ProfileImageViewModel()
 
     @State var imageUrl = ""
+    @State private var offsetY: CGFloat = CGFloat.zero
 
-    @State private var scrollOffset: CGFloat = 0
-    @State private var lastScrollOffset: CGFloat = 0
+    let profileViewHeight = 260 * DynamicSizeFactor.factor()
 
     var body: some View {
         NavigationAvailable {
             ZStack {
-                BouncelessScrollView {
-                    ProfileUserInfoView(
-                        showPopUpView: $showPopUpView,
-                        navigateToEditUsername: $navigateToEditUsername,
-                        selectedUIImage: $selectedUIImage,
-                        imageUrl: $imageUrl,
-                        viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
-                    )
-
+                ScrollView {
+                    GeometryReader { geometry in
+                        let offset = geometry.frame(in: .global).minY
+                        setOffset(offset: offset)
+                        ProfileUserInfoView(
+                            showPopUpView: $showPopUpView,
+                            navigateToEditUsername: $navigateToEditUsername,
+                            selectedUIImage: $selectedUIImage,
+                            imageUrl: $imageUrl,
+                            viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
+                        )
+                        .background(Color("White01"))
+                        .offset(y: offset > 0 ? -offset : 0)
+                    }
+                    .frame(height: profileViewHeight)
+                    .border(.black)
+                    
                     VStack {
                         Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-
+                        
                         Text("내 게시글")
                             .font(.B1MediumFont())
                             .platformTextColor(color: Color("Gray07"))
                             .offset(x: -140, y: 0)
-
+                        
                         Spacer().frame(height: 6 * DynamicSizeFactor.factor())
-
+                        
                         Image("icon_illust_empty")
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
-
+                        
                         Text("아직 작성된 글이 없어요")
                             .font(.H4MediumFont())
                             .platformTextColor(color: Color("Gray07"))
                             .padding(1)
-
-                        Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-
-                        Text("내 게시글")
-                            .font(.B1MediumFont())
-                            .platformTextColor(color: Color("Gray07"))
-                            .offset(x: -140, y: 0)
                     }
-                    .frame(maxWidth: .infinity)
                     .padding(.horizontal, 20)
                     .background(Color("Gray01"))
                 }
-
+                
                 if showPopUpView {
                     Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                     EditProfilePopUpView(
@@ -79,7 +79,6 @@ struct ProfileMainView: View {
                     )
                 }
             }
-
             .edgesIgnoringSafeArea(.bottom)
             .sheet(isPresented: $showImagePicker, onDismiss: {
                 // 사진 클릭한 경우
@@ -99,10 +98,9 @@ struct ProfileMainView: View {
                     .edgesIgnoringSafeArea(.bottom)
             }
             .id(showPopUpView)
-            .background(Color("Gray01"))
             .setTabBarVisibility(isHidden: showPopUpView)
             .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
-
+            .background(Color("Gray01"))
             //            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .toolbar {
@@ -122,15 +120,16 @@ struct ProfileMainView: View {
                     }
                 }
             }
-
+            
             NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
                 EmptyView()
             }.hidden()
-
+            
             NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
                 EmptyView()
             }.hidden()
         }
+        
         .onAppear {
             Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
             Log.debug("showPopUpView:\(showPopUpView)")
@@ -140,63 +139,23 @@ struct ProfileMainView: View {
             isHiddenTabBar = newValue
         }
     }
-
+    
     private func loadUserDataImage() {
         if let userData = getUserData() {
             imageUrl = userData.profileImageUrl
             profileImageViewModel.loadImageUrl(from: imageUrl)
         }
     }
+    
+    func setOffset(offset: CGFloat) -> some View {
+        DispatchQueue.main.async {
+            self.offsetY = offset
+            Log.debug("??:\(offset)")
+        }
+        return EmptyView()
+    }
 }
 
 #Preview {
     ProfileMainView()
-}
-
-// MARK: - ScrollOffsetKey
-
-struct ScrollOffsetKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
-import SwiftUI
-
-// MARK: - BouncelessScrollView
-
-struct BouncelessScrollView<Content: View>: UIViewRepresentable {
-    var content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    func makeUIView(context _: Context) -> UIScrollView {
-        let scrollView = UIScrollView()
-        let hostedView = UIHostingController(rootView: content)
-        hostedView.view.translatesAutoresizingMaskIntoConstraints = false
-
-        scrollView.addSubview(hostedView.view)
-
-        // Set up constraints for the content to fill the scroll view
-        NSLayoutConstraint.activate([
-            hostedView.view.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            hostedView.view.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
-            hostedView.view.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            hostedView.view.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-            hostedView.view.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
-        ])
-
-        // Disable the bounce effect only for this instance
-        scrollView.contentInsetAdjustmentBehavior = .automatic
-        scrollView.bounces = false
-
-        return scrollView
-    }
-
-    func updateUIView(_: UIScrollView, context _: Context) {
-        // Update the content of the scroll view if needed
-    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileUserInfoView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileUserInfoView.swift
@@ -24,7 +24,7 @@ struct ProfileUserInfoView: View {
     var body: some View {
         ZStack {
             VStack {
-//                Spacer().frame(height: 27 * DynamicSizeFactor.factor())
+                Spacer().frame(height: 22 * DynamicSizeFactor.factor())
                 
                 Button(action: {
                     showPopUpView = true
@@ -132,9 +132,9 @@ struct ProfileUserInfoView: View {
                     .padding(.horizontal, 34)
                 }
                 
-//                Spacer().frame(height: 28 * DynamicSizeFactor.factor())
+                Spacer().frame(height: 28 * DynamicSizeFactor.factor())
             }
-            .frame(maxWidth: .infinity, maxHeight: 304 * DynamicSizeFactor.factor())
+            .frame(maxWidth: .infinity, maxHeight: 267 * DynamicSizeFactor.factor())
             .background(Color("White01"))
             .onAppear {
                 loadUserData()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileUserInfoView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileUserInfoView.swift
@@ -24,7 +24,7 @@ struct ProfileUserInfoView: View {
     var body: some View {
         ZStack {
             VStack {
-                Spacer().frame(height: 27 * DynamicSizeFactor.factor())
+//                Spacer().frame(height: 27 * DynamicSizeFactor.factor())
                 
                 Button(action: {
                     showPopUpView = true
@@ -132,7 +132,7 @@ struct ProfileUserInfoView: View {
                     .padding(.horizontal, 34)
                 }
                 
-                Spacer().frame(height: 28 * DynamicSizeFactor.factor())
+//                Spacer().frame(height: 28 * DynamicSizeFactor.factor())
             }
             .frame(maxWidth: .infinity, maxHeight: 304 * DynamicSizeFactor.factor())
             .background(Color("White01"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -4,6 +4,8 @@ struct TotalTargetAmountContentView: View {
     @ObservedObject var viewModel: TotalTargetAmountViewModel
     @Binding var isnavigateToPastSpendingView: Bool
     
+    @State private var scrollOffset: CGFloat = 0
+    
     var body: some View {
         VStack {
             HStack {
@@ -99,6 +101,7 @@ struct TotalTargetAmountContentView: View {
             .cornerRadius(8)
         }
         .padding(.horizontal, 20)
+        .background(Color("Gray01"))
         
         Spacer()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -8,35 +8,6 @@ struct TotalTargetAmountContentView: View {
     
     var body: some View {
         VStack {
-            HStack {
-                HStack(spacing: 4) {
-                    Image("icon_remaining_amount")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                    
-                    Text("남은 금액")
-                        .font(.B1MediumFont())
-                        .platformTextColor(color: Color("Gray04"))
-                }
-                .padding(.leading, 14)
-                .padding(.bottom, 12)
-                
-                Spacer()
-                
-                Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.diffAmount <= 0 ? "" : "-")\(abs(viewModel.currentData.diffAmount))원" : "-원")
-                    .font(.B1SemiboldeFont())
-                    .platformTextColor(color: determineDiffAmountColor(for: viewModel.currentData.diffAmount))
-                    .padding(.trailing, 16)
-                    .padding(.bottom, 12)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 38 * DynamicSizeFactor.factor())
-            .background(
-                RoundedCornerUtil(radius: 8, corners: [.bottomLeft, .bottomRight])
-                    .fill(Color("White01"))
-            )
-            
             Spacer().frame(height: 13 * DynamicSizeFactor.factor())
             
             VStack {
@@ -104,15 +75,5 @@ struct TotalTargetAmountContentView: View {
         .background(Color("Gray01"))
         
         Spacer()
-    }
-    
-    // Color 설정
-    
-    func determineDiffAmountColor(for diffAmount: Int64) -> Color {
-        if viewModel.currentData.targetAmountDetail.amount != -1 {
-            return diffAmount > 0 ? Color("Red03") : Color("Gray07")
-        } else {
-            return Color("Gray07")
-        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountHeaderView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountHeaderView.swift
@@ -8,56 +8,99 @@ struct TotalTargetAmountHeaderView: View {
         VStack(spacing: 0) {
             Spacer().frame(height: 16 * DynamicSizeFactor.factor())
                 
-            VStack(alignment: .leading, spacing: 8 * DynamicSizeFactor.factor()) {
-                Text("\(String(viewModel.currentData.year))년 \(viewModel.currentData.month)월 목표금액")
-                    .font(.ButtonH4SemiboldFont())
-                    .platformTextColor(color: Color("White01"))
-                        
-                HStack(spacing: 0) {
-                    Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.targetAmountDetail.amount)" : "-")
-                        .font(.H1BoldFont())
+            Group {
+                VStack(alignment: .leading, spacing: 8 * DynamicSizeFactor.factor()) {
+                    Text("\(String(viewModel.currentData.year))년 \(viewModel.currentData.month)월 목표금액")
+                        .font(.ButtonH4SemiboldFont())
                         .platformTextColor(color: Color("White01"))
-                    Text(" 원")
-                        .font(.H3SemiboldFont())
-                        .platformTextColor(color: Color("White01"))
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 20)
-            
-            Spacer().frame(height: 24 * DynamicSizeFactor.factor())
-                
-            HStack {
-                HStack(spacing: 4) {
-                    Image("icon_ current_spending")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                     
-                    Text("현재 소비 금액")
-                        .font(.B1MediumFont())
-                        .platformTextColor(color: Color("Gray04"))
+                    HStack(spacing: 0) {
+                        Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.targetAmountDetail.amount)" : "-")
+                            .font(.H1BoldFont())
+                            .platformTextColor(color: Color("White01"))
+                        Text(" 원")
+                            .font(.H3SemiboldFont())
+                            .platformTextColor(color: Color("White01"))
+                    }
                 }
-                .padding(.leading, 14)
-                .padding(.top, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
                 
-                Spacer()
-                            
-                Text("\(viewModel.currentData.totalSpending)원")
-                    .font(.B1SemiboldeFont())
-                    .platformTextColor(color: Color("Gray07"))
-                    .padding(.trailing, 16)
+                Spacer().frame(height: 24 * DynamicSizeFactor.factor())
+                
+                HStack {
+                    HStack(spacing: 4) {
+                        Image("icon_ current_spending")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                        
+                        Text("현재 소비 금액")
+                            .font(.B1MediumFont())
+                            .platformTextColor(color: Color("Gray04"))
+                    }
+                    .padding(.leading, 14)
                     .padding(.top, 12)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 38 * DynamicSizeFactor.factor())
-            .background(
-                RoundedCornerUtil(radius: 8, corners: [.topLeft, .topRight])
-                    .fill(Color("White01"))
-            )
-            .padding(.horizontal, 20)
+                    
+                    Spacer()
+                    
+                    Text("\(viewModel.currentData.totalSpending)원")
+                        .font(.B1SemiboldeFont())
+                        .platformTextColor(color: Color("Gray07"))
+                        .padding(.trailing, 16)
+                        .padding(.top, 12)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 38 * DynamicSizeFactor.factor())
+                .background(
+                    RoundedCornerUtil(radius: 8, corners: [.topLeft, .topRight])
+                        .fill(Color("White01"))
+                )
+                .padding(.horizontal, 20)
+            }.background(Color("Mint03"))
+            
+            HStack {
+                HStack {
+                    HStack(spacing: 4) {
+                        Image("icon_remaining_amount")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                        
+                        Text("남은 금액")
+                            .font(.B1MediumFont())
+                            .platformTextColor(color: Color("Gray04"))
+                    }
+                    .padding(.leading, 14)
+                    .padding(.bottom, 12)
+                    
+                    Spacer()
+                    
+                    Text(viewModel.currentData.targetAmountDetail.amount != -1 ? "\(viewModel.currentData.diffAmount <= 0 ? "" : "-")\(abs(viewModel.currentData.diffAmount))원" : "-원")
+                        .font(.B1SemiboldeFont())
+                        .platformTextColor(color: determineDiffAmountColor(for: viewModel.currentData.diffAmount))
+                        .padding(.trailing, 16)
+                        .padding(.bottom, 12)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 38 * DynamicSizeFactor.factor())
+                .background(
+                    RoundedCornerUtil(radius: 8, corners: [.bottomLeft, .bottomRight])
+                        .fill(Color("White01"))
+                )
+                .padding(.horizontal, 20)
+            }.background(Color("Gray01"))
         }
         .frame(maxWidth: .infinity)
-        .background(Color("Mint03"))
+    }
+    
+    // Color 설정
+    
+    func determineDiffAmountColor(for diffAmount: Int64) -> Color {
+        if viewModel.currentData.targetAmountDetail.amount != -1 {
+            return diffAmount > 0 ? Color("Red03") : Color("Gray07")
+        } else {
+            return Color("Gray07")
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -12,7 +12,8 @@ struct TotalTargetAmountView: View {
     @State private var showingDeletePopUp = false
     @State private var showToastPopup = false
 
-    let headerViewHeight = 173 * DynamicSizeFactor.factor()
+    let screenHeight = UIScreen.main.bounds.height
+    let hearderViewHeight = 173 * DynamicSizeFactor.factor()
     @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
     @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
     @State private var updateCount = 0 // 업데이트 횟수를 추적하는 변수
@@ -20,21 +21,18 @@ struct TotalTargetAmountView: View {
     var body: some View {
         ZStack {
             ScrollView {
-                VStack(spacing: 0) {
-                    GeometryReader { geometry in
-                        let offset = geometry.frame(in: .global).minY
-                        setOffset(offset: offset)
+                GeometryReader { geometry in
+                    let offset = geometry.frame(in: .global).minY
+                    setOffset(offset: offset)
 
-                        TotalTargetAmountHeaderView(viewModel: viewModel)
-                            .background(Color("Mint03"))
-                            .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
-                    }
-                    .frame(height: headerViewHeight)
+                    TotalTargetAmountHeaderView(viewModel: viewModel)
+                        .background(Color("Mint03"))
+                        .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
 
                     TotalTargetAmountContentView(viewModel: viewModel, isnavigateToPastSpendingView: $isnavigateToPastSpendingView)
-
-                    Spacer().frame(height: 29 * DynamicSizeFactor.factor())
+                        .offset(y: adjustedOffset > 0 ? (hearderViewHeight - adjustedOffset) : hearderViewHeight)
                 }
+                .frame(height: screenHeight)
             }
             .overlay(
                 VStack(alignment: .leading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -12,11 +12,24 @@ struct TotalTargetAmountView: View {
     @State private var showingDeletePopUp = false
     @State private var showToastPopup = false
 
+    let headerViewHeight = 173 * DynamicSizeFactor.factor()
+    @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
+    @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
+    @State private var updateCount = 0 // 업데이트 횟수를 추적하는 변수
+
     var body: some View {
         ZStack {
             ScrollView {
                 VStack(spacing: 0) {
-                    TotalTargetAmountHeaderView(viewModel: viewModel)
+                    GeometryReader { geometry in
+                        let offset = geometry.frame(in: .global).minY
+                        setOffset(offset: offset)
+
+                        TotalTargetAmountHeaderView(viewModel: viewModel)
+                            .background(Color("Mint03"))
+                            .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
+                    }
+                    .frame(height: headerViewHeight)
 
                     TotalTargetAmountContentView(viewModel: viewModel, isnavigateToPastSpendingView: $isnavigateToPastSpendingView)
 
@@ -145,6 +158,23 @@ struct TotalTargetAmountView: View {
                 Log.fault("목표 금액 초기화 실패")
             }
         }
+    }
+
+    func setOffset(offset: CGFloat) -> some View {
+        DispatchQueue.main.async {
+            Log.debug("offset 값:\(offset)")
+
+            if updateCount < 2 {
+                updateCount += 1
+            } else if initialOffset == 0 {
+                initialOffset = offset
+            }
+
+            adjustedOffset = offset - initialOffset
+
+            Log.debug("initialOffset 값:\(offset)")
+        }
+        return EmptyView()
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/SpendingViewModel/SpendingCategoryViewModel.swift
@@ -111,7 +111,7 @@ class SpendingCategoryViewModel: ObservableObject {
             return
         }
         
-        let getCategorySpendingHistoryRequestDto = GetCategorySpendingHistoryRequestDto(type: "\(selectedCategory?.isCustom ?? false ? "CUSTOM" : "DEFAULT")", size: "5", page: "\(currentPageNumber)")
+        let getCategorySpendingHistoryRequestDto = GetCategorySpendingHistoryRequestDto(type: "\(selectedCategory?.isCustom ?? false ? "CUSTOM" : "DEFAULT")", size: "30", page: "\(currentPageNumber)")
         
         let categoryId = selectedCategory!.id < 0 ? abs(selectedCategory!.id) : selectedCategory!.id
         
@@ -126,17 +126,15 @@ class SpendingCategoryViewModel: ObservableObject {
                             Log.debug("카테고리에 등록된 지출내역 조회\(jsonString)")
                         }
                         
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
-                            self.dailyDetailSpendings.removeAll { $0.category.id != self.selectedCategory!.id }
-                            self.mergeNewSpendings(newSpendings: response.data.spendings.content)
-                            self.hasNext = response.data.spendings.hasNext
+                        self.dailyDetailSpendings.removeAll { $0.category.id != self.selectedCategory!.id }
+                        self.mergeNewSpendings(newSpendings: response.data.spendings.content)
+                        self.hasNext = response.data.spendings.hasNext
                             
-                            if !(isReload ?? false) {
-                                self.currentPageNumber += 1
-                            }
-                            
-                            completion(true)
+                        if !(isReload ?? false) {
+                            self.currentPageNumber += 1
                         }
+                            
+                        completion(true)
                         
                     } catch {
                         Log.fault("Error decoding JSON: \(error)")


### PR DESCRIPTION
## 작업 이유

- 상단 스크롤 블로킹 해결


<br/>

## 작업 사항


### 1️⃣ 프로필 화면 상단 스크롤 블로킹 해결

GeometryReader를 사용해서 뷰의 위치를 감지하는데 `geometry.frame(in: .global).minY`으로 Y축 위치를 계산한다. 

왜인지는 모르겠는데 처음에 뷰 생성할 때 `geometry.frame(in: .global).minY`를 호출하면 첫번째 값은 0, 두번째 값은 149, 그리고 세번째 값이 97으로 올바르게 나온다,,,

![스크린샷 2024-08-22 오후 10 08 44](https://github.com/user-attachments/assets/e444d716-3224-4922-8880-1aac7291138a)

처음에 빌드 되면서 뷰의 위치를 감지하는데 발생한 것 같다. 

그래서 setOffset(offset:) 함수를 사용하여 초기 오프셋 값을 감지하고, 세번째 값을 찾아 위치를 조정하도록 했다.

updateCount 변수를 사용해, 최초 두 번의 오프셋 업데이트를 건너뛰고, 세 번째 값부터 유효한 초기 오프셋으로 저장한다. 

```swift
func setOffset(offset: CGFloat) -> some View {
        ...
        if updateCount < 2 {//처음 두 번의 위치 업데이트는 무시
            updateCount += 1
        } else if initialOffset == 0 {
            initialOffset = offset//세 번째 위치 값이 들어왔을 때 이를 initialOffset으로 저장
        }
        
        adjustedOffset = offset - initialOffset//계산된 오프셋에서 초기 오프셋을 뺀 값을 사용해 뷰의 위치를 보정
        ...
}
```

setOffset(offset:) 함수에서 계산한 adjustedOffset으로 스크롤 위치를 감지해 ProfileUserInfoView의 위치를 조정하였다.

```swift
ScrollView {
      GeometryReader { geometry in
          let offset = geometry.frame(in: .global).minY
          setOffset(offset: offset)
          
          ProfileUserInfoView(
             ...
          )
          .background(Color("White01"))
          .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
      }
      .frame(height: profileViewHeight)
     ...
}
```

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-22 at 18 25 39](https://github.com/user-attachments/assets/d5bd9882-891d-4f98-aa54-95d82be31d19)

> 아래 내 게시글 부분도 상단에 bounce가 없도록 수정해야 한다.


<br/>


### 2️⃣ 목표 금액 화면 상단 스크롤 블로킹 해결

1️⃣번과 마찬가지로 GeometryReader를 사용하여 오프셋을 감지하지만, 목표 금액 화면에서는 모든 뷰 요소가 함께 움직이도록 구성했다.

adjustedOffset > 0은 사용자가 화면을 상단으로 스크롤했을 때를 의미한다. 
GeometryReader 내부에 TotalTargetAmountHeaderView와 TotalTargetAmountContentView를 함께 배치하여, TotalTargetAmountHeaderView는 스크롤 시 상단에 고정되도록 설정했다.

TotalTargetAmountContentView는 TotalTargetAmountHeaderView의 높이에서 오프셋 값을 뺀 값을 적용하여, 상단 스크롤이 발생할 때 콘텐츠 뷰가 현재 위치에 고정되도록 처리했다.

결과적으로 스크롤 시 헤더는 고정되고, 콘텐츠는 헤더 아래에서 자연스럽게 이동한다.

```swift
 ScrollView {
    GeometryReader { geometry in
        let offset = geometry.frame(in: .global).minY
        setOffset(offset: offset)

        TotalTargetAmountHeaderView(viewModel: viewModel)
            .background(Color("Mint03"))
            .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)

        TotalTargetAmountContentView(viewModel: viewModel, isnavigateToPastSpendingView: $isnavigateToPastSpendingView)
            .offset(y: adjustedOffset > 0 ? (hearderViewHeight - adjustedOffset) : hearderViewHeight)
    }
    .frame(height: screenHeight)
}
```

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-23 at 01 37 32](https://github.com/user-attachments/assets/daef70af-5209-458c-b798-55789b846770)



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

상단 스크롤 블로킹 구현했습니다~
이상 있으면 말씀해주세요!

<br/>

## 발견한 이슈
없음