### PR TITLE
📍🎨 팝업창 바깥 영역 터치시 닫히도록 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindIdView/FindIdFormView.swift
@@ -48,7 +48,6 @@ struct FindIdFormView: View {
             }
 
             if showDiffNumberPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showDiffNumberPopUp,
                                 titleLabel: "인증 요청 번호와\n현재 입력된 번호가 달라요",
                                 subTitleLabel: "기존 번호(\(phoneVerificationViewModel.requestedPhoneNumber))로 인증할까요?",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -47,7 +47,6 @@ struct FindPwView: View {
             }
 
             if showDiffNumberPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showDiffNumberPopUp,
                                 titleLabel: "인증 요청 번호와\n현재 입력된 번호가 달라요",
                                 subTitleLabel: "기존 번호(\(phoneVerificationViewModel.requestedPhoneNumber))로 인증할까요?",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/SignUpView/PhoneVerificationView/PhoneVerificationView.swift
@@ -52,7 +52,6 @@ struct PhoneVerificationView: View {
             }
             
             if showDiffNumberPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showDiffNumberPopUp,
                                 titleLabel: "인증 요청 번호와\n현재 입력된 번호가 달라요",
                                 subTitleLabel: "기존 번호(\(phoneVerificationViewModel.requestedPhoneNumber))로 인증할까요?",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomPopUpView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomPopUpView.swift
@@ -21,15 +21,26 @@ struct CustomPopUpView: View {
     var heightSize: CGFloat? = nil
 
     var body: some View {
-        PopupContent(titleLabel: titleLabel,
-                     subTitleLabel: subTitleLabel,
-                     firstBtnAction: firstBtnAction,
-                     firstBtnLabel: firstBtnLabel,
-                     secondBtnAction: secondBtnAction,
-                     secondBtnLabel: secondBtnLabel,
-                     secondBtnColor: secondBtnColor,
-                     heightSize: heightSize,
-                     showingPopUp: $showingPopUp)
+        ZStack {
+            // 팝업 바깥 영역을 터치하면 닫히도록 설정
+            Color.black.opacity(0.3)
+                .edgesIgnoringSafeArea(.all)
+                .onTapGesture {
+                    showingPopUp = false
+                }
+
+            PopupContent(
+                titleLabel: titleLabel,
+                subTitleLabel: subTitleLabel,
+                firstBtnAction: firstBtnAction,
+                firstBtnLabel: firstBtnLabel,
+                secondBtnAction: secondBtnAction,
+                secondBtnLabel: secondBtnLabel,
+                secondBtnColor: secondBtnColor,
+                heightSize: heightSize,
+                showingPopUp: $showingPopUp
+            )
+        }
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -70,7 +70,6 @@ struct EditPhoneNumberView: View {
             }
 
             if showDiffNumberPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showDiffNumberPopUp,
                                 titleLabel: "인증 요청 번호와\n현재 입력된 번호가 달라요",
                                 subTitleLabel: "기존 번호(\(viewModel.requestedPhoneNumber))로 인증할까요?",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
@@ -44,8 +44,7 @@ struct ProfileMenuBarListView: View {
             }
 
             if showUnLinkPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                CustomPopUpView(showingPopUp: $showLogoutPopUp,
+                CustomPopUpView(showingPopUp: $showUnLinkPopUp,
                                 titleLabel: "계정 연동을 해제할까요?",
                                 subTitleLabel: "해제하더라도 다시 연동할 수 있어요",
                                 firstBtnAction: { self.showUnLinkPopUp = false },
@@ -57,7 +56,6 @@ struct ProfileMenuBarListView: View {
             }
 
             if showLogoutPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showLogoutPopUp,
                                 titleLabel: "로그아웃",
                                 subTitleLabel: "로그아웃하시겠어요?",
@@ -70,8 +68,7 @@ struct ProfileMenuBarListView: View {
             }
 
             if showDeleteUserPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                CustomPopUpView(showingPopUp: $showLogoutPopUp,
+                CustomPopUpView(showingPopUp: $showDeleteUserPopUp,
                                 titleLabel: "탈퇴하시겠어요?",
                                 subTitleLabel: "탈퇴 후에는 이용한 서비스\n내역이 모두 사라져요 😢",
                                 firstBtnAction: handleDeleteUserAccount,

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/DetailSpendingView/DetailSpendingView.swift
@@ -47,7 +47,6 @@ struct DetailSpendingView: View {
             }
 
             if showingPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showingPopUp,
                                 titleLabel: "내역을 삭제할까요?",
                                 subTitleLabel: "선택한 소비 내역이 사라져요",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/CategoryDetailsView.swift
@@ -140,7 +140,6 @@ struct CategoryDetailsView: View {
             }
             
             if showDeletePopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(
                     showingPopUp: $showDeletePopUp,
                     titleLabel: "카테고리를 삭제할까요?",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/MoveCategoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingCategoryManagementView/MoveCategoryView.swift
@@ -99,7 +99,6 @@ struct MoveCategoryView: View {
             }
             
             if showingPopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showingPopUp,
                                 titleLabel: "'\(spendingCategoryViewModel.selectedMoveCategory?.name ?? "")'으로 옮길까요?",
                                 subTitleLabel: "소비 내역 \(spendingCategoryViewModel.spedingHistoryTotalCount)개의 카테고리가 변경돼요",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/EditSpendingDetailView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingDetailBottomSheetView/EditSpendingDetailView.swift
@@ -107,7 +107,6 @@ struct EditSpendingDetailView: View {
             }
 
             if showingClosePopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showingClosePopUp,
                                 titleLabel: "편집을 끝낼까요?",
                                 subTitleLabel: "변경된 내용은 자동 저장돼요",
@@ -123,7 +122,6 @@ struct EditSpendingDetailView: View {
             }
 
             if showingDeletePopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showingDeletePopUp,
                                 titleLabel: "\(selectedIds.count)개의 내역을 삭제할까요?",
                                 subTitleLabel: "선택한 소비 내역이 사라져요",

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -98,7 +98,6 @@ struct TotalTargetAmountView: View {
             }
 
             if showingDeletePopUp {
-                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
                 CustomPopUpView(showingPopUp: $showingDeletePopUp,
                                 titleLabel: "목표금액을 초기화할까요?",
                                 subTitleLabel: "이번 달 목표금액이 사라져요",


### PR DESCRIPTION
## 작업 이유

- 팝업창 바깥 영역 터치시 닫히도록 구현

<br/>

## 작업 사항


### 1️⃣ 팝업창 바깥 영역 터치시 닫히도록 구현

CustomPopUpView에 바깥 영역을 터치하면 팝업이 닫히도록 하는 기능을 추가했다. 
이를 위해, ZStack 내에서 `Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)`를 사용해 반투명 배경을 설정하고, 해당 영역을 터치하면 showingPopUp이 false로 변경되어 팝업이 닫히도록 구현했다.

이 변경 사항으로 인해 CustomPopUpView를 사용하는 모든 뷰에서 자동으로 이 기능이 적용되며, 별도로 배경색을 설정할 필요 없이, 팝업 외부를 터치해 팝업을 닫을 수 있다.

```swift
@Binding var showingPopUp: Bool

ZStack {
        // 팝업 바깥 영역을 터치하면 닫히도록 설정
        Color.black.opacity(0.3)
            .edgesIgnoringSafeArea(.all)
            .onTapGesture {
                showingPopUp = false
            }
```


![Simulator Screen Recording - iPhone 15 Pro - 2024-08-23 at 02 31 55](https://github.com/user-attachments/assets/4a24ba1c-10df-4279-8b20-07591e76cfca)

버튼이 아닌 빈 화면을 터치하면 팝업창이 닫힌다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

팝업창 바깥 영역 터치시 닫히도록 구현 완료했습니다~

<br/>

## 발견한 이슈
없음