### PR TITLE
📮 api 경로 환경별 build 세팅

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -224,6 +224,8 @@
 		4AD70E252BE0153F0058A52A /* ProfileUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E242BE0153F0058A52A /* ProfileUserInfoView.swift */; };
 		4AD70E272BE015500058A52A /* ProfileOAuthButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E262BE015500058A52A /* ProfileOAuthButtonView.swift */; };
 		4AD70E292BE015970058A52A /* ProfileSettingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E282BE015970058A52A /* ProfileSettingListView.swift */; };
+		4AD8248D2C77D83400AEF371 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4AD824892C77D83400AEF371 /* Debug.xcconfig */; };
+		4AD8248E2C77D83400AEF371 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4AD8248A2C77D83400AEF371 /* Release.xcconfig */; };
 		4ADBFAED2BE2C36500C3ECE4 /* UserAccountAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADBFAEC2BE2C36500C3ECE4 /* UserAccountAlamofire.swift */; };
 		4ADBFAEF2BE2C43B00C3ECE4 /* UserAccountRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADBFAEE2BE2C43B00C3ECE4 /* UserAccountRouter.swift */; };
 		4ADBFAF12BE2C4E100C3ECE4 /* GetUserProfileResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADBFAF02BE2C4E100C3ECE4 /* GetUserProfileResponseDto.swift */; };
@@ -550,6 +552,8 @@
 		4AD70E242BE0153F0058A52A /* ProfileUserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUserInfoView.swift; sourceTree = "<group>"; };
 		4AD70E262BE015500058A52A /* ProfileOAuthButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileOAuthButtonView.swift; sourceTree = "<group>"; };
 		4AD70E282BE015970058A52A /* ProfileSettingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingListView.swift; sourceTree = "<group>"; };
+		4AD824892C77D83400AEF371 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4AD8248A2C77D83400AEF371 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		4ADBFAEC2BE2C36500C3ECE4 /* UserAccountAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccountAlamofire.swift; sourceTree = "<group>"; };
 		4ADBFAEE2BE2C43B00C3ECE4 /* UserAccountRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccountRouter.swift; sourceTree = "<group>"; };
 		4ADBFAF02BE2C4E100C3ECE4 /* GetUserProfileResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserProfileResponseDto.swift; sourceTree = "<group>"; };
@@ -1359,6 +1363,7 @@
 			isa = PBXGroup;
 			children = (
 				4AFF0C832C6A6B770040B192 /* GoogleService-Info.plist */,
+				4AD8248B2C77D83400AEF371 /* Xcconfig */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
 				4A1179B32BA958ED00A9CF4C /* Info.plist */,
@@ -1373,7 +1378,6 @@
 				4A762AFA2B99A1A5001C1188 /* Model */,
 				4A762AF02B99A16D001C1188 /* Assets.xcassets */,
 				4A762AF22B99A16D001C1188 /* Preview Content */,
-				B599E4B92C555A01006051E9 /* Secrets.xcconfig */,
 			);
 			path = "pennyway-client-iOS";
 			sourceTree = "<group>";
@@ -1727,6 +1731,16 @@
 			path = ProfileMainView;
 			sourceTree = "<group>";
 		};
+		4AD8248B2C77D83400AEF371 /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				B599E4B92C555A01006051E9 /* Secrets.xcconfig */,
+				4AD824892C77D83400AEF371 /* Debug.xcconfig */,
+				4AD8248A2C77D83400AEF371 /* Release.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		4ADBFAE72BE2C32800C3ECE4 /* UserDomain */ = {
 			isa = PBXGroup;
 			children = (
@@ -2060,6 +2074,7 @@
 			files = (
 				4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */,
 				4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */,
+				4AD8248D2C77D83400AEF371 /* Debug.xcconfig in Resources */,
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
@@ -2070,6 +2085,7 @@
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
+				4AD8248E2C77D83400AEF371 /* Release.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2575,7 +2591,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B599E4B92C555A01006051E9 /* Secrets.xcconfig */;
+			baseConfigurationReference = 4AD824892C77D83400AEF371 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2616,7 +2632,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B599E4B92C555A01006051E9 /* Secrets.xcconfig */;
+			baseConfigurationReference = 4AD8248A2C77D83400AEF371 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-Release.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-Release.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A762AE82B99A16B001C1188"
+               BuildableName = "pennyway-client-iOS.app"
+               BlueprintName = "pennyway-client-iOS"
+               ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A762AE82B99A16B001C1188"
+            BuildableName = "pennyway-client-iOS.app"
+            BlueprintName = "pennyway-client-iOS"
+            ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A762AE82B99A16B001C1188"
+            BuildableName = "pennyway-client-iOS.app"
+            BlueprintName = "pennyway-client-iOS"
+            ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-debug.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-debug.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A762AE82B99A16B001C1188"
+               BuildableName = "pennyway-client-iOS.app"
+               BlueprintName = "pennyway-client-iOS"
+               ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A762AE82B99A16B001C1188"
+            BuildableName = "pennyway-client-iOS.app"
+            BlueprintName = "pennyway-client-iOS"
+            ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A762AE82B99A16B001C1188"
+            BuildableName = "pennyway-client-iOS.app"
+            BlueprintName = "pennyway-client-iOS"
+            ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/pennyway-client-iOS/pennyway-client-iOS/Constants/BaseUrl.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Constants/BaseUrl.swift
@@ -1,6 +1,13 @@
 
 import Foundation
 
+// MARK: - API
+
 enum API {
-    static let BASE_URL: String = "https://api.dev.pennyway.co.kr/"
+    static let BASE_URL: String = {
+        guard let baseURL = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String else {
+            fatalError("BaseURL not found in Info.plist")
+        }
+        return baseURL.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\"", with: "")
+    }()
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Info.plist
+++ b/pennyway-client-iOS/pennyway-client-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BaseURL</key>
+	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -18,6 +20,14 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>$(GOOGLE_URL_SCHEMES)</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(BASE_URL)</string>
 			</array>
 		</dict>
 	</array>

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -33,9 +33,6 @@ class AppViewModel: ObservableObject {
     }
 
     func checkLoginStateApi() {
-        Log.debug("api: \(API.BASE_URL)")
-        Log.debug("api 경로: \(Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String ?? "")")
-
         UserAuthAlamofire.shared.checkLoginState { [weak self] result in
             switch result {
             case let .success(data):

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -33,6 +33,9 @@ class AppViewModel: ObservableObject {
     }
 
     func checkLoginStateApi() {
+        Log.debug("api: \(API.BASE_URL)")
+        Log.debug("api 경로: \(Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String ?? "")")
+
         UserAuthAlamofire.shared.checkLoginState { [weak self] result in
             switch result {
             case let .success(data):


### PR DESCRIPTION
## 작업 이유

- api 경로 환경별 build 세팅

<br/>

## 작업 사항

### 1️⃣ api 경로 환경별 build 세팅

- 빌드 경로와 배포 경로를 나누기 위해 세팅했다.

[블로그 참고](https://ios-development.tistory.com/428)

기존에 사용했던 API.BASE_URL을 아래와 같이 수정해서 info파일에 저장한 BaseURL을 가져오도록 했다.
이 과정에서 BaseURL에 공백과 큰따옴표가 같이 반환되는 문제가 있어 `replacingOccurrences`를 사용하여 제거했다.

```swift
enum API {
    static let BASE_URL: String = {
        guard let baseURL = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String else {
            fatalError("BaseURL not found in Info.plist")
        }
        return baseURL.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\"", with: "")
    }()
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

설명은 만나서 자세하게 해드릴게요!!

<br/>

## 발견한 이슈
없음