### PR TITLE
📍🎨 텍스트 필드 빈 화면 터치 오류 해결  + 목표 금액 없는 경우 뷰 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -121,6 +121,9 @@
 		4A5789992BDC2A1100AFEB26 /* UnprocessableContentError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */; };
 		4A57899B2BDC2A2500AFEB26 /* InternalServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */; };
 		4A5DA8C12C3C498D00685F77 /* FcmTokenDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */; };
+		4A5E6A6E2C78CFAF00389C98 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */; };
+		4A5E6A6F2C78CFAF00389C98 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */; };
+		4A5E6A702C78CFAF00389C98 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A5E6A6C2C78CFAE00389C98 /* Secrets.xcconfig */; };
 		4A60F64C2C595E4700805F2C /* CustomCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */; };
 		4A60F64E2C595F6A00805F2C /* CompleteDeleteUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */; };
 		4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */; };
@@ -449,6 +452,9 @@
 		4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnprocessableContentError.swift; sourceTree = "<group>"; };
 		4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalServerError.swift; sourceTree = "<group>"; };
 		4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FcmTokenDto.swift; sourceTree = "<group>"; };
+		4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		4A5E6A6C2C78CFAE00389C98 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCompleteView.swift; sourceTree = "<group>"; };
 		4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDeleteUserView.swift; sourceTree = "<group>"; };
 		4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalTargetAmountViewModel.swift; sourceTree = "<group>"; };
@@ -1278,6 +1284,16 @@
 			path = Request;
 			sourceTree = "<group>";
 		};
+		4A5E6A6D2C78CFAE00389C98 /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */,
+				4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */,
+				4A5E6A6C2C78CFAE00389C98 /* Secrets.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		4A6C79D02C4630A9009463E4 /* EditProfileView */ = {
 			isa = PBXGroup;
 			children = (
@@ -1364,6 +1380,7 @@
 			isa = PBXGroup;
 			children = (
 				4AFF0C832C6A6B770040B192 /* GoogleService-Info.plist */,
+				4A5E6A6D2C78CFAE00389C98 /* Xcconfig */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
 				4A1179B32BA958ED00A9CF4C /* Info.plist */,
@@ -2073,9 +2090,12 @@
 				4AFF0C842C6A6B770040B192 /* GoogleService-Info.plist in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
+				4A5E6A6E2C78CFAF00389C98 /* Debug.xcconfig in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
+				4A5E6A702C78CFAF00389C98 /* Secrets.xcconfig in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
+				4A5E6A6F2C78CFAF00389C98 /* Release.xcconfig in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2585,6 +2605,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2605,6 +2626,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -2625,6 +2647,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2645,6 +2668,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/pennyway-client-iOS/pennyway-client-iOS/Info.plist
+++ b/pennyway-client-iOS/pennyway-client-iOS/Info.plist
@@ -26,9 +26,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>$(BASE_URL)</string>
-			</array>
+			<array/>
 		</dict>
 	</array>
 	<key>GIDClientID</key>

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -85,6 +85,8 @@ struct CustomInputView: View {
 // MARK: - CustomTextFieldModifier
 
 // CustomTextFieldModifier: UIViewRepresentable을 사용하여 SwiftUI에서 UITextField 사용
+// 텍스트 입력, 입력 완료, 키보드 타입 등을 제어
+
 struct CustomTextFieldModifier: UIViewRepresentable {
     class Coordinator: NSObject, UITextFieldDelegate {
         var parent: CustomTextFieldModifier
@@ -93,12 +95,14 @@ struct CustomTextFieldModifier: UIViewRepresentable {
             self.parent = parent
         }
 
+        /// 텍스트 필드 편집 종료 시 호출되는 메서드(빈 화면 터치시 작동)
         func textFieldDidEndEditing(_: UITextField) {
             if !parent.text.isEmpty {
                 parent.onCommit?()
             }
         }
 
+        /// 텍스트 필드의 선택이 변경될 때 호출되는 메서드 (입력 시 호출)
         func textFieldDidChangeSelection(_ textField: UITextField) {
             parent.text = textField.text ?? ""
         }
@@ -112,9 +116,9 @@ struct CustomTextFieldModifier: UIViewRepresentable {
         }
     }
 
-    @Binding var text: String
-    var isSecureText: Bool
-    var onCommit: (() -> Void)?
+    @Binding var text: String // 텍스트 필드의 텍스트 바인딩
+    var isSecureText: Bool // 비밀번호 입력 필드인지 여부
+    var onCommit: (() -> Void)? // 입력 완료 시 실행할 함수 (옵션)
     var keyboardType: UIKeyboardType // 키보드 타입을 받아서 사용
 
     func makeCoordinator() -> Coordinator {
@@ -123,10 +127,10 @@ struct CustomTextFieldModifier: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UITextField {
         let textField = UITextField()
-        textField.isSecureTextEntry = isSecureText
+        textField.isSecureTextEntry = isSecureText // 비밀번호 입력 여부 설정
         textField.delegate = context.coordinator
-        textField.autocapitalizationType = .none
-        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none // 자동 대문자 비활성화
+        textField.autocorrectionType = .no // 자동 수정 비활성화
         textField.borderStyle = .none
         textField.keyboardType = keyboardType // 전달받은 키보드 타입 설정
         return textField

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -55,8 +55,6 @@ struct CustomInputView: View {
                         },
                         keyboardType: keyboardType // CustomInputView의 keyboardType 전달
                     )
-//                    .autocapitalization(.none)
-//                    .disableAutocorrection(true)
                     .padding(.leading, 12 * DynamicSizeFactor.factor())
                     .padding(.trailing, 35 * DynamicSizeFactor.factor())
                     .frame(height: 46 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/CustomView/CustomInputView.swift
@@ -1,19 +1,23 @@
 import SwiftUI
+import UIKit
+
+// MARK: - CustomInputView
 
 struct CustomInputView: View {
-    @Binding var inputText: String
-    @State var titleText: String?
-    @State var placeholder: String?
-    var onCommit: (() -> Void)?
-    var isSecureText: Bool
-    var isCustom: Bool?
-    var showDeleteButton: Bool = false
-    var deleteAction: (() -> Void)?
+    @Binding var inputText: String // 텍스트 필드에 입력된 내용을 바인딩
+    @State var titleText: String? // 타이틀 텍스트 (옵션)
+    @State var placeholder: String? // 플레이스홀더 텍스트 (옵션)
+    var onCommit: (() -> Void)? // 입력 완료 시 실행할 함수 (옵션)
+    var isSecureText: Bool // 텍스트 필드가 비밀번호 필드인지 여부
+    var isCustom: Bool? // 커스텀 텍스트 여부 (옵션)
+    var showDeleteButton: Bool = false // 삭제 버튼 표시 여부 (기본값: false)
+    var deleteAction: (() -> Void)? // 삭제 버튼 클릭 시 실행할 함수 (옵션)
+    var keyboardType: UIKeyboardType = .default // 키보드 타입 (기본값: .default)
 
     let baseAttribute: BaseAttribute = BaseAttribute(font: .B1MediumFont(), color: Color("Gray07"))
     let stringAttribute: StringAttribute = StringAttribute(text: "*", font: .B1MediumFont(), color: Color("Mint03"))
 
-    @State private var isDeleteButtonVisible: Bool = false
+    @State private var isDeleteButtonVisible: Bool = false // 삭제 버튼의 가시성 관리
 
     var body: some View {
         VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
@@ -42,34 +46,23 @@ struct CustomInputView: View {
                             .padding(.leading, 13 * DynamicSizeFactor.factor())
                             .font(.H4MediumFont())
                     }
-                    if isSecureText {
-                        SecureField("", text: $inputText, onCommit: {
+                    CustomTextFieldModifier(
+                        text: $inputText,
+                        isSecureText: isSecureText,
+                        onCommit: {
                             onCommit?()
                             isDeleteButtonVisible.toggle()
-                        })
-                        .autocapitalization(.none)
-                        .disableAutocorrection(true)
-                        .padding(.leading, 12 * DynamicSizeFactor.factor())
-                        .padding(.vertical, 16 * DynamicSizeFactor.factor())
-                        .font(.H4MediumFont())
-                        .onChange(of: inputText) { newValue in
-                            isDeleteButtonVisible = !newValue.isEmpty
-                        }
-
-                    } else {
-                        TextField("", text: $inputText, onCommit: {
-                            onCommit?()
-                            isDeleteButtonVisible.toggle()
-                        })
-                        .autocapitalization(.none)
-                        .disableAutocorrection(true)
-                        .padding(.leading, 12 * DynamicSizeFactor.factor())
-                        .padding(.trailing, 35 * DynamicSizeFactor.factor())
-                        .padding(.vertical, 16 * DynamicSizeFactor.factor())
-                        .font(.H4MediumFont())
-                        .onChange(of: inputText) { newValue in
-                            isDeleteButtonVisible = !newValue.isEmpty
-                        }
+                        },
+                        keyboardType: keyboardType // CustomInputView의 keyboardType 전달
+                    )
+//                    .autocapitalization(.none)
+//                    .disableAutocorrection(true)
+                    .padding(.leading, 12 * DynamicSizeFactor.factor())
+                    .padding(.trailing, 35 * DynamicSizeFactor.factor())
+                    .frame(height: 46 * DynamicSizeFactor.factor())
+                    .font(.H4MediumFont())
+                    .onChange(of: inputText) { newValue in
+                        isDeleteButtonVisible = !newValue.isEmpty
                     }
 
                     if showDeleteButton {
@@ -86,5 +79,60 @@ struct CustomInputView: View {
             }
             .padding(.horizontal, 20)
         }
+    }
+}
+
+// MARK: - CustomTextFieldModifier
+
+// CustomTextFieldModifier: UIViewRepresentable을 사용하여 SwiftUI에서 UITextField 사용
+struct CustomTextFieldModifier: UIViewRepresentable {
+    class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: CustomTextFieldModifier
+
+        init(parent: CustomTextFieldModifier) {
+            self.parent = parent
+        }
+
+        func textFieldDidEndEditing(_: UITextField) {
+            if !parent.text.isEmpty {
+                parent.onCommit?()
+            }
+        }
+
+        func textFieldDidChangeSelection(_ textField: UITextField) {
+            parent.text = textField.text ?? ""
+        }
+
+        /// Return 버튼을 눌렀을 때 호출되는 메서드
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            parent.onCommit?()
+            textField.resignFirstResponder() // 포커스를 해제하여 키보드를 닫음
+
+            return true
+        }
+    }
+
+    @Binding var text: String
+    var isSecureText: Bool
+    var onCommit: (() -> Void)?
+    var keyboardType: UIKeyboardType // 키보드 타입을 받아서 사용
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UITextField {
+        let textField = UITextField()
+        textField.isSecureTextEntry = isSecureText
+        textField.delegate = context.coordinator
+        textField.autocapitalizationType = .none
+        textField.autocorrectionType = .no
+        textField.borderStyle = .none
+        textField.keyboardType = keyboardType // 전달받은 키보드 타입 설정
+        return textField
+    }
+
+    func updateUIView(_ uiView: UITextField, context _: Context) {
+        uiView.text = text
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/EditProfileView/EditPhoneNumberView.swift
@@ -101,7 +101,6 @@ struct EditPhoneNumberView: View {
             HStack(spacing: 11 * DynamicSizeFactor.factor()) {
                 PhoneNumberInputField(phoneNumber: $viewModel.phoneNumber, onPhoneNumberChange: handlePhoneNumberChange, onCommit: {
                     isDeleteButtonVisible = false
-
                 }, showDeleteButton: true, deleteAction: {
                     viewModel.phoneNumber = ""
                     viewModel.showErrorExistingUser = false

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -156,8 +156,6 @@ struct ProfileMainView: View {
 
     func setOffset(offset: CGFloat) -> some View {
         DispatchQueue.main.async {
-            Log.debug("offset 값:\(offset)")
-
             if updateCount < 2 {
                 updateCount += 1
             } else if initialOffset == 0 {
@@ -165,8 +163,6 @@ struct ProfileMainView: View {
             }
 
             adjustedOffset = offset - initialOffset
-
-            Log.debug("initialOffset 값:\(offset)")
         }
         return EmptyView()
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -134,6 +134,8 @@ struct ProfileSettingSectionView: View {
                             .platformTextColor(color: Color("Gray07"))
                             .padding(.vertical, 7)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
                 })
                 .padding(.horizontal, 17)
                 .buttonStyle(BasicButtonStyleUtil())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
@@ -23,15 +23,14 @@ struct AmountInputView: View {
             }, isSecureText: false, isCustom: false, showDeleteButton: isDeleteButtonVisible, deleteAction: {
                 viewModel.amountSpentText = ""
                 isDeleteButtonVisible = false
-            })
-            .keyboardType(.numberPad)
-            .onChange(of: viewModel.amountSpentText) { _ in
-                viewModel.amountSpentText = NumberFormatterUtil.formatStringToDecimalString(viewModel.amountSpentText)
-                viewModel.validateForm()
-            }
-            .onTapGesture {
-                isDeleteButtonVisible = true
-            }
+            }, keyboardType: .numberPad)
+                .onChange(of: viewModel.amountSpentText) { _ in
+                    viewModel.amountSpentText = NumberFormatterUtil.formatStringToDecimalString(viewModel.amountSpentText)
+                    viewModel.validateForm()
+                }
+                .onTapGesture {
+                    isDeleteButtonVisible = true
+                }
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SpendingCategoryListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/SpendingCategory/SpendingCategoryListView.swift
@@ -38,7 +38,7 @@ struct SpendingCategoryListView: View {
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.vertical, 6 * DynamicSizeFactor.factor())
-                        .contentShape(Rectangle()) // This makes the entire HStack touchable
+                        .contentShape(Rectangle()) 
                         .onTapGesture {
                             if category.name == "추가하기" {
                                 viewModel.selectedCategoryIcon = CategoryIconName(baseName: CategoryBaseName.etc, state: .on) // icon 초기화

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
@@ -10,72 +10,9 @@ struct PastSpendingListView: View {
     var body: some View {
         ZStack {
             if viewModel.targetAmounts.isEmpty {
-                VStack {
-                    Spacer()
-                    
-                    VStack {
-                        Image("icon_illust_nohistory")
-                            .frame(width: 50 * DynamicSizeFactor.factor(), height: 66 * DynamicSizeFactor.factor())
-                            .padding()
-                        
-                        Text("아직 기록이 없어요")
-                            .platformTextColor(color: Color("Gray04"))
-                            .font(.H4MediumFont())
-                    }
-                    
-                    Spacer()
-                }
-                .edgesIgnoringSafeArea(.top)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                
+                emptyStateView()
             } else {
-                ScrollView {
-                    Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-                    
-                    ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
-                        VStack(alignment: .leading) {
-                            Text("\(String(content.year))년 \(content.month)월")
-                                .font(.B2MediumFont())
-                                .platformTextColor(color: Color("Gray05"))
-                            
-                            Spacer().frame(height: 8)
-                            HStack {
-                                HStack(spacing: 6 * DynamicSizeFactor.factor()) {
-                                    Text("\(content.totalSpending)원")
-                                        .font(.ButtonH4SemiboldFont())
-                                        .platformTextColor(color: Color("Gray07"))
-                                    
-                                    if content.targetAmountDetail.amount != -1 {
-                                        DiffAmountDynamicWidthView(
-                                            text: DiffAmountColorUtil.determineText(for: content.diffAmount),
-                                            backgroundColor: DiffAmountColorUtil.determineBackgroundColor(for: content.diffAmount),
-                                            textColor: DiffAmountColorUtil.determineTextColor(for: content.diffAmount)
-                                        )
-                                    }
-                                }
-                                
-                                Spacer()
-                                
-                                Image("icon_arrow_front_small_gray03")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                            }
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                let components = DateComponents(year: content.year, month: content.month)
-                                if let date = Calendar.current.date(from: components) {
-                                    currentMonth = date
-                                }
-                                navigateToMySpendingList = true
-                            }
-                        }
-                    }
-                    .frame(height: 60 * DynamicSizeFactor.factor())
-                    .padding(.horizontal, 20)
-                    
-                    Spacer().frame(height: 14 * DynamicSizeFactor.factor())
-                }
+                contentListView()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -101,5 +38,77 @@ struct PastSpendingListView: View {
             EmptyView()
         }
         .hidden()
+    }
+    
+    @ViewBuilder
+    private func emptyStateView() -> some View {
+        VStack {
+            Spacer()
+            
+            VStack {
+                Image("icon_illust_nohistory")
+                    .frame(width: 50 * DynamicSizeFactor.factor(), height: 66 * DynamicSizeFactor.factor())
+                    .padding()
+                
+                Text("아직 기록이 없어요")
+                    .platformTextColor(color: Color("Gray04"))
+                    .font(.H4MediumFont())
+            }
+            
+            Spacer()
+        }
+        .edgesIgnoringSafeArea(.top)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    @ViewBuilder
+    private func contentListView() -> some View {
+        ScrollView {
+            Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+            
+            ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
+                VStack(alignment: .leading) {
+                    Text("\(String(content.year))년 \(content.month)월")
+                        .font(.B2MediumFont())
+                        .platformTextColor(color: Color("Gray05"))
+                    
+                    Spacer().frame(height: 8)
+                    HStack {
+                        HStack(spacing: 6 * DynamicSizeFactor.factor()) {
+                            Text("\(content.totalSpending)원")
+                                .font(.ButtonH4SemiboldFont())
+                                .platformTextColor(color: Color("Gray07"))
+                            
+                            if content.targetAmountDetail.amount != -1 {
+                                DiffAmountDynamicWidthView(
+                                    text: DiffAmountColorUtil.determineText(for: content.diffAmount),
+                                    backgroundColor: DiffAmountColorUtil.determineBackgroundColor(for: content.diffAmount),
+                                    textColor: DiffAmountColorUtil.determineTextColor(for: content.diffAmount)
+                                )
+                            }
+                        }
+                        
+                        Spacer()
+                        
+                        Image("icon_arrow_front_small_gray03")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        let components = DateComponents(year: content.year, month: content.month)
+                        if let date = Calendar.current.date(from: components) {
+                            currentMonth = date
+                        }
+                        navigateToMySpendingList = true
+                    }
+                }
+            }
+            .frame(height: 60 * DynamicSizeFactor.factor())
+            .padding(.horizontal, 20)
+            
+            Spacer().frame(height: 14 * DynamicSizeFactor.factor())
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/PastSpendingListView.swift
@@ -9,52 +9,73 @@ struct PastSpendingListView: View {
     
     var body: some View {
         ZStack {
-            ScrollView {
-                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-                
-                ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
-                    VStack(alignment: .leading) {
-                        Text("\(String(content.year))년 \(content.month)월")
-                            .font(.B2MediumFont())
-                            .platformTextColor(color: Color("Gray05"))
+            if viewModel.targetAmounts.isEmpty {
+                VStack {
+                    Spacer()
+                    
+                    VStack {
+                        Image("icon_illust_nohistory")
+                            .frame(width: 50 * DynamicSizeFactor.factor(), height: 66 * DynamicSizeFactor.factor())
+                            .padding()
                         
-                        Spacer().frame(height: 8)
-                        HStack {
-                            HStack(spacing: 6 * DynamicSizeFactor.factor()) {
-                                Text("\(content.totalSpending)원")
-                                    .font(.ButtonH4SemiboldFont())
-                                    .platformTextColor(color: Color("Gray07"))
-                                
-                                if content.targetAmountDetail.amount != -1 {
-                                    DiffAmountDynamicWidthView(
-                                        text: DiffAmountColorUtil.determineText(for: content.diffAmount),
-                                        backgroundColor: DiffAmountColorUtil.determineBackgroundColor(for: content.diffAmount),
-                                        textColor: DiffAmountColorUtil.determineTextColor(for: content.diffAmount)
-                                    )
+                        Text("아직 기록이 없어요")
+                            .platformTextColor(color: Color("Gray04"))
+                            .font(.H4MediumFont())
+                    }
+                    
+                    Spacer()
+                }
+                .edgesIgnoringSafeArea(.top)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                
+            } else {
+                ScrollView {
+                    Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                    
+                    ForEach(Array(viewModel.targetAmounts.enumerated()), id: \.offset) { _, content in
+                        VStack(alignment: .leading) {
+                            Text("\(String(content.year))년 \(content.month)월")
+                                .font(.B2MediumFont())
+                                .platformTextColor(color: Color("Gray05"))
+                            
+                            Spacer().frame(height: 8)
+                            HStack {
+                                HStack(spacing: 6 * DynamicSizeFactor.factor()) {
+                                    Text("\(content.totalSpending)원")
+                                        .font(.ButtonH4SemiboldFont())
+                                        .platformTextColor(color: Color("Gray07"))
+                                    
+                                    if content.targetAmountDetail.amount != -1 {
+                                        DiffAmountDynamicWidthView(
+                                            text: DiffAmountColorUtil.determineText(for: content.diffAmount),
+                                            backgroundColor: DiffAmountColorUtil.determineBackgroundColor(for: content.diffAmount),
+                                            textColor: DiffAmountColorUtil.determineTextColor(for: content.diffAmount)
+                                        )
+                                    }
                                 }
+                                
+                                Spacer()
+                                
+                                Image("icon_arrow_front_small_gray03")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                             }
-                            
-                            Spacer()
-                            
-                            Image("icon_arrow_front_small_gray03")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            let components = DateComponents(year: content.year, month: content.month)
-                            if let date = Calendar.current.date(from: components) {
-                                currentMonth = date
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                let components = DateComponents(year: content.year, month: content.month)
+                                if let date = Calendar.current.date(from: components) {
+                                    currentMonth = date
+                                }
+                                navigateToMySpendingList = true
                             }
-                            navigateToMySpendingList = true
                         }
                     }
+                    .frame(height: 60 * DynamicSizeFactor.factor())
+                    .padding(.horizontal, 20)
+                    
+                    Spacer().frame(height: 14 * DynamicSizeFactor.factor())
                 }
-                .frame(height: 60 * DynamicSizeFactor.factor())
-                .padding(.horizontal, 20)
-                
-                Spacer().frame(height: 14 * DynamicSizeFactor.factor())
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -159,8 +159,6 @@ struct TotalTargetAmountView: View {
 
     func setOffset(offset: CGFloat) -> some View {
         DispatchQueue.main.async {
-            Log.debug("offset 값:\(offset)")
-
             if updateCount < 2 {
                 updateCount += 1
             } else if initialOffset == 0 {
@@ -168,8 +166,6 @@ struct TotalTargetAmountView: View {
             }
 
             adjustedOffset = offset - initialOffset
-
-            Log.debug("initialOffset 값:\(offset)")
         }
         return EmptyView()
     }


### PR DESCRIPTION
## 작업 이유

- 빈 화면 터치시 텍스트 필드 포커스 해제 및 로직 실행 구현
- 목표 금액 없는 경우 뷰 구현
- 설정 리스트 버튼 영역 수정

<br/>

## 작업 사항

### 1️⃣ 빈 화면 터치시 텍스트 필드 포커스 해제 및 로직 실행 구현

iOS 15 이상에서는 FocusState를 사용해 쉽게 처리할 수 있지만, iOS 14 이상이어 UIKit 기능을 사용했다.

CustomInputView에서 CustomTextFieldModifier를 사용하여 기존의 TextField 대신 UITextField를 활용하도록 수정했다. 
빈 화면을 터치하거나 Return 버튼을 눌렀을 때, onCommit() 로직이 실행되도록 구현했다.

따라서, CustomInputView를 사용하는 뷰에서 추가적인 처리 없이, CustomTextFieldModifier를 사용해 이 문제를 해결할 수 있었다.

```swift
CustomTextFieldModifier(
    text: $inputText,
    isSecureText: isSecureText,
    onCommit: {
        onCommit?()
        isDeleteButtonVisible.toggle()
    },
    keyboardType: keyboardType // CustomInputView의 keyboardType 전달
)
```

- 동작 확인

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-24 at 03 17 56](https://github.com/user-attachments/assets/2cea3801-cf8e-489a-8ed7-7eef2acc8862)


### 2️⃣ 목표 금액 없는 경우 뷰 구현

목표 금액이 없는 경우인 뷰를 구현하지 못해서 아래와 같이 구현했다. 
PastSpendingListView에서 분기처리를 하고 있고 viewModel.targetAmounts가 비어있다면 목표 금액이 없는 경우로 판단하였다.

```swift
ZStack {
    if viewModel.targetAmounts.isEmpty {
        emptyStateView()
    } else {
        contentListView()
    }
}
```

<img src = "https://github.com/user-attachments/assets/591e532c-6255-4541-9219-7263ffce884f" width = "300"/>

### 3️⃣ 설정 리스트 버튼 영역 수정

버튼 영역이 텍스트가 있는 부분만 터치되던 문제를 해결하기 위해, .contentShape(Rectangle())를 사용하여 버튼의 전체 영역이 터치되도록 수정했다. 

<img src = "https://github.com/user-attachments/assets/fc53f6b8-2e89-4b85-8fcb-4e1b076711a1" width = "300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

텍스트 필드 빈 화면 터치 오류 해결했습니다~~
그리고 목표 금액 없는 경우 뷰 구현과 버튼 영역도 같이 수정했어요!!
이상있으면 말씀해주세요~~


<br/>

## 발견한 이슈
없음