### PR TITLE
📍 나의 소비내역에서 추가하기로 지출등록 했을 경우 버그픽스

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingCompleteView.swift
@@ -74,9 +74,13 @@ struct AddSpendingCompleteView: View {
                     
                     Log.debug("루트뷰로이동")
                 } else {
-                    isPresented = false
-                    Log.debug("isPresented: \(isPresented)")
-                    Log.debug("entryPoint: \(entryPoint)")
+                    if entryPoint == .NoSpendingHistoryView {
+                        NavigationUtil.popToView(at: 1)
+                    } else {
+                        isPresented = false
+                        Log.debug("isPresented: \(isPresented)")
+                        Log.debug("entryPoint: \(entryPoint)")
+                    }
                 }
                 
             }, label: "확인", isFormValid: .constant(true))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView.swift
@@ -94,15 +94,19 @@ struct AddSpendingHistoryView: View {
             return
         }
 
-        if let date = clickDate {
-            viewModel.clickDate = date
-            if isAddSpendingMode() {
-                addSpendingHistory()
-            } else {
-                editSpendingHistory(spendingDetailViewUpdated: false)
+        // 진입점을 먼저 찾은 후에 clickDate가 존재한다면 그 날짜에 해당하는 지출추가하기뷰를 보여줌
+        if isAddSpendingMode() {
+            if let date = clickDate {
+                viewModel.clickDate = date
             }
+            addSpendingHistory()
         } else {
-            editSpendingHistory(spendingDetailViewUpdated: true)
+            if let date = clickDate {
+                viewModel.clickDate = date
+                editSpendingHistory(spendingDetailViewUpdated: false)
+            } else {
+                editSpendingHistory(spendingDetailViewUpdated: true)
+            }
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/MySpendingListView.swift
@@ -52,6 +52,7 @@ struct MySpendingListView: View {
                                                     // 상세 화면으로 이동하기 전에 상태 보존
                                                     lastSelectedDate = spendingHistoryViewModel.selectedDate
                                                     lastSelectedMonth = spendingHistoryViewModel.currentDate
+
                                                 }, label: {
                                                     CustomSpendingRow(categoryIcon: iconName, category: item.category.name, amount: item.amount, memo: item.memo)
                                                         .contentShape(Rectangle())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
@@ -36,7 +36,16 @@ struct NoSpendingHistoryView: View {
                     .background(Color("Mint03"))
                     .cornerRadius(30)
 
-                    NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, spendingId: .constant(0), clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, isEditSuccess: .constant(false), isAddSpendingData: .constant(false), entryPoint: .detailSheet), isActive: $navigateToAddSpendingHistory) {
+                    NavigationLink(destination: AddSpendingHistoryView(
+                        spendingCategoryViewModel: SpendingCategoryViewModel(),
+                        spendingHistoryViewModel: spendingHistoryViewModel,
+                        spendingId: .constant(0), 
+                        clickDate: $clickDate,
+                        isPresented: $navigateToAddSpendingHistory,
+                        isEditSuccess: .constant(false),
+                        isAddSpendingData: .constant(false),
+                        entryPoint: .NoSpendingHistoryView), isActive: $navigateToAddSpendingHistory)
+                    {
                         EmptyView()
                     }.hidden()
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/MySpendingListView/NoSpendingHistoryView.swift
@@ -5,7 +5,7 @@ struct NoSpendingHistoryView: View {
     @State var navigateToAddSpendingHistory = false
     @ObservedObject var spendingHistoryViewModel: SpendingHistoryViewModel
 
-    @Binding var clickDate: Date?
+    @Binding var clickDate: Date? // 현재 선택된 날을 넘겨주기 위한 변수
 
     var body: some View {
         VStack(spacing: 0) {
@@ -53,8 +53,4 @@ struct NoSpendingHistoryView: View {
             .buttonStyle(BasicButtonStyleUtil())
         }
     }
-}
-
-#Preview {
-    NoSpendingHistoryView(spendingHistoryViewModel: SpendingHistoryViewModel(), clickDate: .constant(Date()))
 }


### PR DESCRIPTION
## 작업 이유
- 나의 소비내역에서 추가하기로 지출등록 했을 경우 버그픽스

<br/>

## 작업 사항
### **1️⃣ 나의 소비내역에서 추가하로 지출등록했을 경우 수정하기 api 호출되는 문제**

나의 소비내역에서 추가하기로 지출등록을 할 경우 추가하기 api를 호출해야 하는데 수정하기 api를 호출해서 지출등록이 안되는 이슈가 있었다.
AddSpendingHistoryView에서 api를 호출하는 조건문을 확인하니 clickDate가 존재한다면 -> 진입점을 확인하고 그 진입점에 해당하는 api를 호출해야 하는데, 나의 소비내역에서 추가하기가 나오는 경우는 그 달의 지출내역이 하나도 없는 뷰이기 때문에 당연히 clickDate가 존재하지 않다고 판단하여 else문인 수정하기 api로 이어진 것이다.

그래서 조건문을 아래와 같이 수정하였다.
1. 먼저 진입점을 판단함
2. clickDate값이 존재한다면 뷰모델 clickDate에 전달
3. 그 외의 경우 수정하기api호출

```
        // 진입점을 먼저 찾은 후에 clickDate가 존재한다면 그 날짜에 해당하는 지출추가하기뷰를 보여줌
        if isAddSpendingMode() {
            if let date = clickDate {
                viewModel.clickDate = date
            }
            addSpendingHistory()
        } else {
            if let date = clickDate {
                viewModel.clickDate = date
                editSpendingHistory(spendingDetailViewUpdated: false)
            } else {
                editSpendingHistory(spendingDetailViewUpdated: true)
            }
        }
```

**동작과정**

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-25 at 11 04 10](https://github.com/user-attachments/assets/0b1695c8-ae44-4cff-88d0-0e582eb69697)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
어제 발견하신거 처리해서 올렸습니다~

해당하는 달을 선택했을때 그 달에 맞는 지출내역 추가하기는 아직 구현하지 못했어요! 사용자가 .. 선택해야 하긴 하지만 지출등록은 잘 됩니다~

<br/>

## 발견한 이슈
만약 7월로 이동했을땐 7월 1일을 보여줘야 하는지, 7월 마지막 일을 보여줘야 하는지 ???? 이 부분은 추후에 수정하겠습니다~