### PR TITLE
🛠️ NavigationView 에러 + 상단 스크롤 막기 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -121,9 +121,6 @@
 		4A5789992BDC2A1100AFEB26 /* UnprocessableContentError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */; };
 		4A57899B2BDC2A2500AFEB26 /* InternalServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */; };
 		4A5DA8C12C3C498D00685F77 /* FcmTokenDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */; };
-		4A5E6A6E2C78CFAF00389C98 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */; };
-		4A5E6A6F2C78CFAF00389C98 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */; };
-		4A5E6A702C78CFAF00389C98 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A5E6A6C2C78CFAE00389C98 /* Secrets.xcconfig */; };
 		4A60F64C2C595E4700805F2C /* CustomCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */; };
 		4A60F64E2C595F6A00805F2C /* CompleteDeleteUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */; };
 		4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */; };
@@ -222,6 +219,9 @@
 		4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */; };
 		4AD0D84A2BFDF80D00A0808F /* AddSpendingHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8492BFDF80D00A0808F /* AddSpendingHistoryViewModel.swift */; };
 		4AD5733C2C5B973C00A4E192 /* PastSpendingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5733B2C5B973C00A4E192 /* PastSpendingListView.swift */; };
+		4AD69F872C7A13B000A62AAB /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4AD69F832C7A13B000A62AAB /* Debug.xcconfig */; };
+		4AD69F882C7A13B000A62AAB /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4AD69F842C7A13B000A62AAB /* Release.xcconfig */; };
+		4AD69F892C7A13B000A62AAB /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4AD69F852C7A13B000A62AAB /* Secrets.xcconfig */; };
 		4AD70E1B2BE0109D0058A52A /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E1A2BE0109D0058A52A /* WelcomeView.swift */; };
 		4AD70E222BE013C10058A52A /* ProfileMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E212BE013C10058A52A /* ProfileMainView.swift */; };
 		4AD70E252BE0153F0058A52A /* ProfileUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD70E242BE0153F0058A52A /* ProfileUserInfoView.swift */; };
@@ -292,9 +292,6 @@
 		D85927FA2BE9116700653391 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85927F52BE9116700653391 /* LoginViewModel.swift */; };
 		D85927FB2BE9116700653391 /* SignUpNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85927F62BE9116700653391 /* SignUpNavigationViewModel.swift */; };
 		D85927FC2BE9116700653391 /* TermsAndConditionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85927F72BE9116700653391 /* TermsAndConditionsViewModel.swift */; };
-		D85ABDE62C78DA1500FD152A /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D85ABDE22C78DA1500FD152A /* Debug.xcconfig */; };
-		D85ABDE72C78DA1500FD152A /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D85ABDE32C78DA1500FD152A /* Release.xcconfig */; };
-		D85ABDE82C78DA1500FD152A /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D85ABDE42C78DA1500FD152A /* Secrets.xcconfig */; };
 		D86773042C76C90700C68728 /* PrivatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86773032C76C90700C68728 /* PrivatePolicy.swift */; };
 		D86773062C76CA0100C68728 /* KeyboardHandlerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86773052C76CA0100C68728 /* KeyboardHandlerManager.swift */; };
 		D874F52B2C32888E00936886 /* DetailSpendingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D874F52A2C32888E00936886 /* DetailSpendingView.swift */; };
@@ -456,9 +453,6 @@
 		4A5789982BDC2A1100AFEB26 /* UnprocessableContentError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnprocessableContentError.swift; sourceTree = "<group>"; };
 		4A57899A2BDC2A2500AFEB26 /* InternalServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalServerError.swift; sourceTree = "<group>"; };
 		4A5DA8C02C3C498D00685F77 /* FcmTokenDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FcmTokenDto.swift; sourceTree = "<group>"; };
-		4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		4A5E6A6C2C78CFAE00389C98 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		4A60F64B2C595E4700805F2C /* CustomCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCompleteView.swift; sourceTree = "<group>"; };
 		4A60F64D2C595F6A00805F2C /* CompleteDeleteUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDeleteUserView.swift; sourceTree = "<group>"; };
 		4A641A142C0F98380041B053 /* TotalTargetAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalTargetAmountViewModel.swift; sourceTree = "<group>"; };
@@ -558,6 +552,9 @@
 		4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifierExtension.swift; sourceTree = "<group>"; };
 		4AD0D8492BFDF80D00A0808F /* AddSpendingHistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSpendingHistoryViewModel.swift; sourceTree = "<group>"; };
 		4AD5733B2C5B973C00A4E192 /* PastSpendingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastSpendingListView.swift; sourceTree = "<group>"; };
+		4AD69F832C7A13B000A62AAB /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4AD69F842C7A13B000A62AAB /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		4AD69F852C7A13B000A62AAB /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		4AD70E1A2BE0109D0058A52A /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		4AD70E212BE013C10058A52A /* ProfileMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileMainView.swift; sourceTree = "<group>"; };
 		4AD70E242BE0153F0058A52A /* ProfileUserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUserInfoView.swift; sourceTree = "<group>"; };
@@ -625,9 +622,6 @@
 		D85927F52BE9116700653391 /* LoginViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		D85927F62BE9116700653391 /* SignUpNavigationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUpNavigationViewModel.swift; sourceTree = "<group>"; };
 		D85927F72BE9116700653391 /* TermsAndConditionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsViewModel.swift; sourceTree = "<group>"; };
-		D85ABDE22C78DA1500FD152A /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		D85ABDE32C78DA1500FD152A /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		D85ABDE42C78DA1500FD152A /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		D86773032C76C90700C68728 /* PrivatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivatePolicy.swift; sourceTree = "<group>"; };
 		D86773052C76CA0100C68728 /* KeyboardHandlerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHandlerManager.swift; sourceTree = "<group>"; };
 		D874F52A2C32888E00936886 /* DetailSpendingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSpendingView.swift; sourceTree = "<group>"; };
@@ -1293,16 +1287,6 @@
 			path = Request;
 			sourceTree = "<group>";
 		};
-		4A5E6A6D2C78CFAE00389C98 /* Xcconfig */ = {
-			isa = PBXGroup;
-			children = (
-				4A5E6A6A2C78CFAE00389C98 /* Debug.xcconfig */,
-				4A5E6A6B2C78CFAE00389C98 /* Release.xcconfig */,
-				4A5E6A6C2C78CFAE00389C98 /* Secrets.xcconfig */,
-			);
-			path = Xcconfig;
-			sourceTree = "<group>";
-		};
 		4A6C79D02C4630A9009463E4 /* EditProfileView */ = {
 			isa = PBXGroup;
 			children = (
@@ -1389,7 +1373,7 @@
 			isa = PBXGroup;
 			children = (
 				4AFF0C832C6A6B770040B192 /* GoogleService-Info.plist */,
-				D85ABDE52C78DA1500FD152A /* Xcconfig */,
+				4AD69F862C7A13B000A62AAB /* Xcconfig */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
 				4A1179B32BA958ED00A9CF4C /* Info.plist */,
@@ -1695,6 +1679,16 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		4AD69F862C7A13B000A62AAB /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				4AD69F832C7A13B000A62AAB /* Debug.xcconfig */,
+				4AD69F842C7A13B000A62AAB /* Release.xcconfig */,
+				4AD69F852C7A13B000A62AAB /* Secrets.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		4AD70E192BE010430058A52A /* AuthView */ = {
 			isa = PBXGroup;
 			children = (
@@ -1966,17 +1960,6 @@
 			path = Alamofire;
 			sourceTree = "<group>";
 		};
-		D85ABDE52C78DA1500FD152A /* Xcconfig */ = {
-			isa = PBXGroup;
-			children = (
-				D85ABDE22C78DA1500FD152A /* Debug.xcconfig */,
-				D85ABDE32C78DA1500FD152A /* Release.xcconfig */,
-				D85ABDE42C78DA1500FD152A /* Secrets.xcconfig */,
-			);
-			name = Xcconfig;
-			path = ../../../../Downloads/Xcconfig;
-			sourceTree = "<group>";
-		};
 		D874F5292C32881400936886 /* DetailSpendingView */ = {
 			isa = PBXGroup;
 			children = (
@@ -2102,12 +2085,12 @@
 				4AFF0C842C6A6B770040B192 /* GoogleService-Info.plist in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
-				D85ABDE62C78DA1500FD152A /* Debug.xcconfig in Resources */,
+				4AD69F872C7A13B000A62AAB /* Debug.xcconfig in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
-				D85ABDE82C78DA1500FD152A /* Secrets.xcconfig in Resources */,
+				4AD69F892C7A13B000A62AAB /* Secrets.xcconfig in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
-				D85ABDE72C78DA1500FD152A /* Release.xcconfig in Resources */,
+				4AD69F882C7A13B000A62AAB /* Release.xcconfig in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2618,7 +2601,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D85ABDE22C78DA1500FD152A /* Debug.xcconfig */;
+			baseConfigurationReference = 4AD69F832C7A13B000A62AAB /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2660,7 +2643,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D85ABDE32C78DA1500FD152A /* Release.xcconfig */;
+			baseConfigurationReference = 4AD69F842C7A13B000A62AAB /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		4A6C79E42C46DE8B009463E4 /* VerificationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C79E32C46DE8B009463E4 /* VerificationButton.swift */; };
 		4A6C79E62C46DEA7009463E4 /* ErrorText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C79E52C46DEA7009463E4 /* ErrorText.swift */; };
 		4A6C79E82C46DFBE009463E4 /* CodeInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C79E72C46DFBE009463E4 /* CodeInputField.swift */; };
+		4A6CC1E02C80E3F600D638B2 /* ScreenUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6CC1DF2C80E3F600D638B2 /* ScreenUtil.swift */; };
 		4A6E62D62BA5F7FC00111246 /* PhoneVerificationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D52BA5F7FC00111246 /* PhoneVerificationContentView.swift */; };
 		4A6E62D82BA6082100111246 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E62D72BA6082100111246 /* SignUpView.swift */; };
 		4A7514D72C51713F00573671 /* PhoneViewModelHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7514D62C51713F00573671 /* PhoneViewModelHandlers.swift */; };
@@ -471,6 +472,7 @@
 		4A6C79E32C46DE8B009463E4 /* VerificationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationButton.swift; sourceTree = "<group>"; };
 		4A6C79E52C46DEA7009463E4 /* ErrorText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorText.swift; sourceTree = "<group>"; };
 		4A6C79E72C46DFBE009463E4 /* CodeInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeInputField.swift; sourceTree = "<group>"; };
+		4A6CC1DF2C80E3F600D638B2 /* ScreenUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenUtil.swift; sourceTree = "<group>"; };
 		4A6E62D32BA18F9B00111246 /* pennyway-client-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "pennyway-client-iOS.entitlements"; sourceTree = "<group>"; };
 		4A6E62D52BA5F7FC00111246 /* PhoneVerificationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerificationContentView.swift; sourceTree = "<group>"; };
 		4A6E62D72BA6082100111246 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -1557,6 +1559,7 @@
 				4A8BDEE22C6246B900D21424 /* DiffAmountColorUtil.swift */,
 				4A8BDEE42C629C3600D21424 /* SpendingHistoryUtil.swift */,
 				D889F9FB2C652CB50055D045 /* BasicButtonStyleUtil.swift */,
+				4A6CC1DF2C80E3F600D638B2 /* ScreenUtil.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2386,6 +2389,7 @@
 				D847A78F2BEBB42200899AA3 /* RequestResetPwDto.swift in Sources */,
 				4A0FFBF52BCDA16B00EFEC56 /* CheckDuplicateRequestDto.swift in Sources */,
 				4AC320472C11D5AC00DDB4B6 /* NoSpendingHistoryView.swift in Sources */,
+				4A6CC1E02C80E3F600D638B2 /* ScreenUtil.swift in Sources */,
 				B50160612C75EA8C00328AFD /* QuestionAnalyticsEvents.swift in Sources */,
 				4A69C14A2BE2CF6700A27B82 /* UserDefaultsHelper.swift in Sources */,
 				B599E4CD2C59067C006051E9 /* FirebaseAnalyticsService.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Constants/BaseUrl.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Constants/BaseUrl.swift
@@ -9,6 +9,6 @@ enum API {
         guard let baseURL = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String else {
             fatalError("BaseURL not found in Info.plist")
         }
-        return baseURL.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\"", with: "")
+        return baseURL.replacingOccurrences(of: " ", with: "")
     }()
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationAvailable.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationAvailable.swift
@@ -6,6 +6,6 @@ func NavigationAvailable<Content: View>(@ViewBuilder content: () -> Content) -> 
         return AnyView(NavigationStack { content() })
     } else {
         return AnyView(NavigationView { content() }
-            .navigationViewStyle(.stack))//navigation index 파악위해 stack 사용
+            .navigationViewStyle(.stack)) // navigation index 파악위해 stack 사용
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationAvailable.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationAvailable.swift
@@ -5,6 +5,7 @@ func NavigationAvailable<Content: View>(@ViewBuilder content: () -> Content) -> 
     if #available(iOS 16.0, *) {
         return AnyView(NavigationStack { content() })
     } else {
-        return AnyView(NavigationView { content() })
+        return AnyView(NavigationView { content() }
+            .navigationViewStyle(.stack))//navigation index 파악위해 stack 사용
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
@@ -53,8 +53,6 @@ enum NavigationUtil {
 
         let viewControllersCount = navigationController.viewControllers.count
 
-        Log.debug(viewControllersCount)
-
         guard index < viewControllersCount else {
             Log.error("Index out of bounds")
             return

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
@@ -11,25 +11,9 @@ enum NavigationUtil {
             .first?.windows
             .filter { $0.isKeyWindow }.first
 
-        // 루트 뷰 컨트롤러의 이름 출력
-        if let rootViewController = keyWindow?.rootViewController {
-            Log.debug("Root ViewController name: \(String(describing: type(of: rootViewController)))")
-        }
+        findNavigationController(viewController: keyWindow?.rootViewController)?
 
-        // TabBarController가 루트 컨트롤러인 경우
-        if let tabBarController = keyWindow?.rootViewController as? UITabBarController {
-            // 원하는 탭으로 설정 (여기서는 첫 번째 탭으로 설정)
-            tabBarController.selectedIndex = 0
-
-            // 선택된 탭 내의 NavigationController를 찾아 루트로 이동
-            if let navController = tabBarController.selectedViewController as? UINavigationController {
-                navController.popToRootViewController(animated: true)
-            }
-        } else {
-            // 루트 뷰 컨트롤러에서 NavigationController를 찾아 루트로 이동
-            findNavigationController(viewController: keyWindow?.rootViewController)?
-                .popToRootViewController(animated: true)
-        }
+            .popToRootViewController(animated: true)
     }
 
     static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
@@ -38,17 +22,53 @@ enum NavigationUtil {
         }
 
         if let navigationController = viewController as? UINavigationController {
+            Log.debug(navigationController)
             return navigationController
         }
 
         for childViewController in viewController.children {
-            if let navigationController = findNavigationController(viewController: childViewController) {
-                return navigationController
-            }
+            Log.debug(childViewController)
+            return findNavigationController(viewController: childViewController)
         }
 
         return nil
     }
+
+//    static func popToRootView() {
+//        let keyWindow = UIApplication.shared.connectedScenes
+//
+//            .filter { $0.activationState == .foregroundActive }
+//            .compactMap { $0 as? UIWindowScene }
+//            .first?.windows
+//            .filter { $0.isKeyWindow }.first
+//
+//        // 루트 뷰 컨트롤러의 이름 출력
+//        if let rootViewController = keyWindow?.rootViewController {
+//            Log.debug("Root ViewController name: \(String(describing: type(of: rootViewController)))")
+//        }
+//
+//        // 루트 뷰 컨트롤러에서 NavigationController를 찾아 루트로 이동
+//        findNavigationController(viewController: keyWindow?.rootViewController)?
+//            .popToRootViewController(animated: true)
+//    }
+//
+//    static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
+//        guard let viewController = viewController else {
+//            return nil
+//        }
+//
+//        if let navigationController = viewController as? UINavigationController {
+//            return navigationController
+//        }
+//
+//        for childViewController in viewController.children {
+//            if let navigationController = findNavigationController(viewController: childViewController) {
+//                return navigationController
+//            }
+//        }
+//
+//        return nil
+//    }
 
     static func popToView(at index: Int) {
         let keyWindow = UIApplication.shared.connectedScenes
@@ -63,6 +83,8 @@ enum NavigationUtil {
         }
 
         let viewControllersCount = navigationController.viewControllers.count
+
+        Log.debug(viewControllersCount)
 
         guard index < viewControllersCount else {
             Log.error("Index out of bounds")

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+// MARK: - NavigationUtil
+
 enum NavigationUtil {
     static func popToRootView() {
         let keyWindow = UIApplication.shared.connectedScenes
@@ -9,9 +11,25 @@ enum NavigationUtil {
             .first?.windows
             .filter { $0.isKeyWindow }.first
 
-        findNavigationController(viewController: keyWindow?.rootViewController)?
+        // 루트 뷰 컨트롤러의 이름 출력
+        if let rootViewController = keyWindow?.rootViewController {
+            Log.debug("Root ViewController name: \(String(describing: type(of: rootViewController)))")
+        }
 
-            .popToRootViewController(animated: true)
+        // TabBarController가 루트 컨트롤러인 경우
+        if let tabBarController = keyWindow?.rootViewController as? UITabBarController {
+            // 원하는 탭으로 설정 (여기서는 첫 번째 탭으로 설정)
+            tabBarController.selectedIndex = 0
+
+            // 선택된 탭 내의 NavigationController를 찾아 루트로 이동
+            if let navController = tabBarController.selectedViewController as? UINavigationController {
+                navController.popToRootViewController(animated: true)
+            }
+        } else {
+            // 루트 뷰 컨트롤러에서 NavigationController를 찾아 루트로 이동
+            findNavigationController(viewController: keyWindow?.rootViewController)?
+                .popToRootViewController(animated: true)
+        }
     }
 
     static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
@@ -20,13 +38,13 @@ enum NavigationUtil {
         }
 
         if let navigationController = viewController as? UINavigationController {
-            Log.debug(navigationController)
             return navigationController
         }
 
         for childViewController in viewController.children {
-            Log.debug(childViewController)
-            return findNavigationController(viewController: childViewController)
+            if let navigationController = findNavigationController(viewController: childViewController) {
+                return navigationController
+            }
         }
 
         return nil

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/NavigationUtil.swift
@@ -11,8 +11,13 @@ enum NavigationUtil {
             .first?.windows
             .filter { $0.isKeyWindow }.first
 
-        findNavigationController(viewController: keyWindow?.rootViewController)?
+        // 루트 뷰 컨트롤러의 이름 출력
+        if let rootViewController = keyWindow?.rootViewController {
+            Log.debug("Root ViewController name: \(String(describing: type(of: rootViewController)))")
+        }
 
+        // 루트 뷰 컨트롤러에서 NavigationController를 찾아 루트로 이동
+        findNavigationController(viewController: keyWindow?.rootViewController)?
             .popToRootViewController(animated: true)
     }
 
@@ -22,53 +27,17 @@ enum NavigationUtil {
         }
 
         if let navigationController = viewController as? UINavigationController {
-            Log.debug(navigationController)
             return navigationController
         }
 
         for childViewController in viewController.children {
-            Log.debug(childViewController)
-            return findNavigationController(viewController: childViewController)
+            if let navigationController = findNavigationController(viewController: childViewController) {
+                return navigationController
+            }
         }
 
         return nil
     }
-
-//    static func popToRootView() {
-//        let keyWindow = UIApplication.shared.connectedScenes
-//
-//            .filter { $0.activationState == .foregroundActive }
-//            .compactMap { $0 as? UIWindowScene }
-//            .first?.windows
-//            .filter { $0.isKeyWindow }.first
-//
-//        // 루트 뷰 컨트롤러의 이름 출력
-//        if let rootViewController = keyWindow?.rootViewController {
-//            Log.debug("Root ViewController name: \(String(describing: type(of: rootViewController)))")
-//        }
-//
-//        // 루트 뷰 컨트롤러에서 NavigationController를 찾아 루트로 이동
-//        findNavigationController(viewController: keyWindow?.rootViewController)?
-//            .popToRootViewController(animated: true)
-//    }
-//
-//    static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
-//        guard let viewController = viewController else {
-//            return nil
-//        }
-//
-//        if let navigationController = viewController as? UINavigationController {
-//            return navigationController
-//        }
-//
-//        for childViewController in viewController.children {
-//            if let navigationController = findNavigationController(viewController: childViewController) {
-//                return navigationController
-//            }
-//        }
-//
-//        return nil
-//    }
 
     static func popToView(at index: Int) {
         let keyWindow = UIApplication.shared.connectedScenes
@@ -83,7 +52,7 @@ enum NavigationUtil {
         }
 
         let viewControllersCount = navigationController.viewControllers.count
-
+        
         Log.debug(viewControllersCount)
 
         guard index < viewControllersCount else {

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/View/ScreenUtil.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/View/ScreenUtil.swift
@@ -1,0 +1,19 @@
+
+import SwiftUI
+
+enum ScreenUtil {
+    static func calculateAvailableHeight() -> CGFloat {
+        let screenHeight = UIScreen.main.bounds.height
+        
+        // 네비게이션 바 높이
+        let navigationBarHeight = UINavigationController().navigationBar.frame.height
+        
+        // 탭바 높이
+        let tabBarHeight = UITabBarController().tabBar.frame.height
+        
+        // (네비게이션 바 - 탭바) 높이 제거한 뷰의 높이
+        let availableHeight = screenHeight - navigationBarHeight - tabBarHeight
+        
+        return availableHeight
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
@@ -5,6 +5,8 @@ struct CompleteChangePwView: View {
     @EnvironmentObject var authViewModel: AppViewModel
     let entryPoint: PasswordChangeTypeNavigation
 
+    @State var navigateToRootView = false
+
     var body: some View {
         VStack {
             ScrollView {
@@ -17,11 +19,14 @@ struct CompleteChangePwView: View {
                 if entryPoint == .findPw {
                     NavigationUtil.popToRootView()
                 } else {
-                    NavigationUtil.popToView(at: 1)
+                    navigateToRootView = true
                 }
 
             }, label: "메인으로 돌아가기", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
+
+            NavigationLink(destination: ProfileMainView(), isActive: $navigateToRootView) {}
+                .hidden()
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(true)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
@@ -3,9 +3,6 @@ import SwiftUI
 
 struct CompleteChangePwView: View {
     @EnvironmentObject var authViewModel: AppViewModel
-
-    @Binding var firstNaviLinkActive: Bool
-    @State private var navigateView = false
     let entryPoint: PasswordChangeTypeNavigation
 
     var body: some View {
@@ -17,18 +14,10 @@ struct CompleteChangePwView: View {
                 )
             }
             CustomBottomButton(action: {
-                firstNaviLinkActive = false
                 NavigationUtil.popToRootView()
 
-                if entryPoint == .modifyPw {
-                    navigateView = true
-                }
             }, label: "메인으로 돌아가기", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
-
-            NavigationLink(destination: ProfileMainView(), isActive: $navigateView) {
-                EmptyView()
-            }.hidden()
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(true)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/CompleteChangePwView.swift
@@ -14,7 +14,11 @@ struct CompleteChangePwView: View {
                 )
             }
             CustomBottomButton(action: {
-                NavigationUtil.popToRootView()
+                if entryPoint == .findPw {
+                    NavigationUtil.popToRootView()
+                } else {
+                    NavigationUtil.popToView(at: 1)
+                }
 
             }, label: "메인으로 돌아가기", isFormValid: .constant(true))
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/FindPwView.swift
@@ -25,7 +25,7 @@ struct FindPwView: View {
                 }, label: "확인", isFormValid: $phoneVerificationViewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
 
-                NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel(), firstNaviLinkActive: .constant(true), entryPoint: .findPw), isActive: $isNavigateToFindPwView) {
+                NavigationLink(destination: ResetPwView(formViewModel: SignUpFormViewModel(), entryPoint: .findPw), isActive: $isNavigateToFindPwView) {
                     EmptyView()
                 }.hidden()
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwFormView.swift
@@ -12,7 +12,6 @@ struct ResetPwFormView: View {
     var body: some View {
         VStack(alignment: .leading) {
             CustomInputView(inputText: $formViewModel.password, titleText: "비밀번호", onCommit: {
-                Log.debug("pw: \(formViewModel.password)")
                 formViewModel.validatePassword()
                 isPwDeleteButtonVisible = false
             }, isSecureText: true, showDeleteButton: true,
@@ -41,7 +40,6 @@ struct ResetPwFormView: View {
             }
             
             CustomInputView(inputText: $formViewModel.confirmPw, titleText: "비밀번호 확인", onCommit: {
-                Log.debug("confirmPw: \(formViewModel.confirmPw)")
                 RegistrationManager.shared.password = formViewModel.confirmPw
                 formViewModel.validateConfirmPw()
                 isConfirmPwDeleteButtonVisible = false

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/FindPwView/ResetPwView.swift
@@ -7,7 +7,6 @@ struct ResetPwView: View {
     @State private var navigateView = false
     @StateObject var resetPwViewModel = ResetPwViewModel()
     @StateObject var accountViewModel = UserAccountViewModel()
-    @Binding var firstNaviLinkActive: Bool
     let entryPoint: PasswordChangeTypeNavigation
     
     var body: some View {
@@ -39,7 +38,7 @@ struct ResetPwView: View {
                 }, label: "변경하기", isFormValid: $formViewModel.isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
                 
-                NavigationLink(destination: CompleteChangePwView(firstNaviLinkActive: $firstNaviLinkActive, entryPoint: entryPoint), isActive: $navigateView) {
+                NavigationLink(destination: CompleteChangePwView(entryPoint: entryPoint), isActive: $navigateView) {
                     EmptyView()
                 }.hidden()
             }
@@ -51,11 +50,10 @@ struct ResetPwView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 HStack {
                     Button(action: {
-                        NavigationUtil.popToRootView()
-                        firstNaviLinkActive = false
-                        
                         if entryPoint == .modifyPw {
                             self.presentationMode.wrappedValue.dismiss()
+                        } else {
+                            NavigationUtil.popToRootView()
                         }
                     }, label: {
                         Image("icon_arrow_back")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+// MARK: - MainTabView
+
 struct MainTabView: View {
     @State private var selection = 0
     @EnvironmentObject var authViewModel: AppViewModel

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
@@ -8,44 +8,42 @@ struct MainTabView: View {
     @EnvironmentObject var networkStatus: NetworkStatusViewModel
 
     var body: some View {
-        ZStack {
-            TabView(selection: $selection) {
-                SpendingManagementMainView()
-                    .tabItem {
-                        selection == 0 ? Image("icon_tabbar_expenditure_on") : Image("icon_tabbar_expenditure_off")
-                        Text("지출관리")
-                    }
-                    .tag(0)
-                    .buttonStyle(BasicButtonStyleUtil())
+        TabView(selection: $selection) {
+            SpendingManagementMainView()
+                .tabItem {
+                    selection == 0 ? Image("icon_tabbar_expenditure_on") : Image("icon_tabbar_expenditure_off")
+                    Text("지출관리")
+                }
+                .tag(0)
+                .buttonStyle(BasicButtonStyleUtil())
 
-                PreparedView()
-                    .tabItem {
-                        selection == 1 ? Image("icon_tapbar_feed_on") : Image("icon_tapbar_feed_off")
-                        Text("피드")
-                    }
-                    .tag(1)
-                    .buttonStyle(BasicButtonStyleUtil())
+            PreparedView()
+                .tabItem {
+                    selection == 1 ? Image("icon_tapbar_feed_on") : Image("icon_tapbar_feed_off")
+                    Text("피드")
+                }
+                .tag(1)
+                .buttonStyle(BasicButtonStyleUtil())
 
-                PreparedView()
-                    .tabItem {
-                        selection == 2 ? Image("icon_tapbar_chatting_on") : Image("icon_tapbar_chatting_off")
-                        Text("채팅")
-                    }
-                    .tag(2)
-                    .buttonStyle(BasicButtonStyleUtil())
+            PreparedView()
+                .tabItem {
+                    selection == 2 ? Image("icon_tapbar_chatting_on") : Image("icon_tapbar_chatting_off")
+                    Text("채팅")
+                }
+                .tag(2)
+                .buttonStyle(BasicButtonStyleUtil())
 
-                ProfileMainView()
-                    .tabItem {
-                        selection == 3 ? Image("icon_tabbar_profile_on") : Image("icon_tabbar_profile_off")
-                        Text("프로필")
-                    }
-                    .tag(3)
-                    .buttonStyle(BasicButtonStyleUtil())
-            }
-            .accentColor(Color("Mint03"))
-            .onAppear {
-                UITabBar.appearance().barTintColor = .white
-            }
+            ProfileMainView()
+                .tabItem {
+                    selection == 3 ? Image("icon_tabbar_profile_on") : Image("icon_tabbar_profile_off")
+                    Text("프로필")
+                }
+                .tag(3)
+                .buttonStyle(BasicButtonStyleUtil())
+        }
+        .accentColor(Color("Mint03"))
+        .onAppear {
+            UITabBar.appearance().barTintColor = .white
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -24,145 +24,135 @@ struct ProfileMainView: View {
     @State private var updateCount = 0 // 업데이트 횟수를 추적하는 변수
 
     var body: some View {
-        NavigationView {
+        NavigationAvailable {
             ZStack {
-                ScrollView {
-                    GeometryReader { geometry in
-                        let offset = geometry.frame(in: .global).minY
-                        setOffset(offset: offset)
-                        ProfileUserInfoView(
-                            showPopUpView: $showPopUpView,
-                            navigateToEditUsername: $navigateToEditUsername,
-                            selectedUIImage: $selectedUIImage,
-                            imageUrl: $imageUrl,
-                            viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
-                        )
-                        .background(Color("White01"))
-                        .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
-                    }
-                    .frame(height: profileViewHeight)
+                content
 
-                    VStack {
-                        Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-
-                        Text("내 게시글")
-                            .font(.B1MediumFont())
-                            .platformTextColor(color: Color("Gray07"))
-                            .offset(x: -140, y: 0)
-
-                        Spacer().frame(height: 6 * DynamicSizeFactor.factor())
-
-                        Image("icon_illust_empty")
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
-
-                        Text("아직 작성된 글이 없어요")
-                            .font(.H4MediumFont())
-                            .platformTextColor(color: Color("Gray07"))
-                            .padding(1)
-                    }
-                    .padding(.horizontal, 20)
-                    .background(Color("Gray01"))
+                if showPopUpView {
+                    Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+                    EditProfilePopUpView(
+                        isPresented: $showPopUpView,
+                        showPopUpView: $showPopUpView,
+                        isHiddenTabBar: $isHiddenTabBar,
+                        showImagePicker: $showImagePicker,
+                        selectedUIImage: $selectedUIImage,
+                        sourceType: $sourceType,
+                        imageUrl: $imageUrl,
+                        presignedUrlViewModel: presignedUrlViewModel
+                    )
                 }
             }
-//            if showPopUpView {
-//                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-//                EditProfilePopUpView(
-//                    isPresented: $showPopUpView,
-//                    showPopUpView: $showPopUpView,
-//                    isHiddenTabBar: $isHiddenTabBar,
-//                    showImagePicker: $showImagePicker,
-//                    selectedUIImage: $selectedUIImage,
-//                    sourceType: $sourceType,
-//                    imageUrl: $imageUrl,
-//                    presignedUrlViewModel: presignedUrlViewModel
-//                )
-//            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                HStack {
-                    Button(action: {
-                        isSelectedToolBar = true
-                    }, label: {
-                        Image("icon_hamburger_button")
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                            .padding(5)
-                    })
-                    .frame(width: 44, height: 44)
-                    .buttonStyle(BasicButtonStyleUtil())
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color("Gray01"))
+            .setTabBarVisibility(isHidden: showPopUpView)
+            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
+            .navigationBarBackButtonHidden()
+            .edgesIgnoringSafeArea(.bottom)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack {
+                        Button(action: {
+                            isSelectedToolBar = true
+                        }, label: {
+                            Image("icon_hamburger_button")
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                                .padding(5)
+                        })
+                        .frame(width: 44, height: 44)
+                        .buttonStyle(BasicButtonStyleUtil())
+                    }
                 }
             }
-        }
+            .sheet(isPresented: $showImagePicker, onDismiss: {
+                // 사진 클릭한 경우
+                showPopUpView = false
+                presignedUrlViewModel.image = selectedUIImage
+                presignedUrlViewModel.generatePresignedUrlApi { success in
+                    if success {
+                        presignedUrlViewModel.storePresignedUrlApi { success in
+                            if success {
+                                profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
+                            }
+                        }
+                    }
+                }
+            }) {
+                ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
+                    .edgesIgnoringSafeArea(.bottom)
+            }
 
-//        .edgesIgnoringSafeArea(.bottom)
-//        .sheet(isPresented: $showImagePicker, onDismiss: {
-//            // 사진 클릭한 경우
-//            showPopUpView = false
-//            presignedUrlViewModel.image = selectedUIImage
-//            presignedUrlViewModel.generatePresignedUrlApi { success in
-//                if success {
-//                    presignedUrlViewModel.storePresignedUrlApi { success in
-//                        if success {
-//                            profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
-//                        }
-//                    }
-//                }
-//            }
-//        }) {
-//            ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
-//                .edgesIgnoringSafeArea(.bottom)
-//        }
-//        .id(showPopUpView)
-//        .background(Color("Gray01"))
-//        .setTabBarVisibility(isHidden: showPopUpView)
-//        .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
-//        .navigationBarBackButtonHidden()
-//        .frame(maxWidth: .infinity, maxHeight: .infinity)
-//        .toolbar {
-//            ToolbarItem(placement: .navigationBarTrailing) {
-//                HStack {
-//                    Button(action: {
-//                        isSelectedToolBar = true
-//                    }, label: {
-//                        Image("icon_hamburger_button")
-//                            .resizable()
-//                            .aspectRatio(contentMode: .fill)
-//                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-//                            .padding(5)
-//                    })
-//                    .frame(width: 44, height: 44)
-//                    .buttonStyle(BasicButtonStyleUtil())
-//                }
-//            }
-//        }
-//
-//        NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
-//            EmptyView()
-//        }.hidden()
-//
-//        NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
-//            EmptyView()
-//        }.hidden()
-//            //        }
-//
-//            .onAppear {
-//                Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
-//                Log.debug("showPopUpView:\(showPopUpView)")
-//                loadUserDataImage() // 사용자 프로필 사진 불러오기
-//            }
-//            .onChange(of: showPopUpView) { newValue in
-//                isHiddenTabBar = newValue
-//            }
-//            .analyzeEvent(ProfileEvents.profileTapView)
-//            .onChange(of: ProfileNavigationState(navigateToEditUsername: navigateToEditUsername, isSelectedToolBar: isSelectedToolBar, showPopUpView: showPopUpView)) { state in
-//                if state.isReturn() {
-//                    AnalyticsManager.shared.trackEvent(ProfileEvents.profileTapView, additionalParams: nil)
-//                }
-//            }
+            .background(
+                NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
+                    EmptyView()
+                }.hidden()
+            )
+            .background(
+                NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
+                    EmptyView()
+                }.hidden()
+            )
+        }
+        .id(showPopUpView)
+        .onAppear {
+            Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
+            Log.debug("showPopUpView:\(showPopUpView)")
+            loadUserDataImage() // 사용자 프로필 사진 불러오기
+        }
+        .onChange(of: showPopUpView) { newValue in
+            isHiddenTabBar = newValue
+        }
+        .onChange(of: ProfileNavigationState(navigateToEditUsername: navigateToEditUsername, isSelectedToolBar: isSelectedToolBar, showPopUpView: showPopUpView)) { state in
+            if state.isReturn() {
+                AnalyticsManager.shared.trackEvent(ProfileEvents.profileTapView, additionalParams: nil)
+            }
+        }
+        .analyzeEvent(ProfileEvents.profileTapView)
+    }
+
+    // MARK: - Subviews
+
+    private var content: some View {
+        ScrollView {
+            GeometryReader { geometry in
+                let offset = geometry.frame(in: .global).minY
+                setOffset(offset: offset)
+                ProfileUserInfoView(
+                    showPopUpView: $showPopUpView,
+                    navigateToEditUsername: $navigateToEditUsername,
+                    selectedUIImage: $selectedUIImage,
+                    imageUrl: $imageUrl,
+                    viewModel: profileImageViewModel, deleteViewModel: deleteProfileImageViewModel
+                )
+                .background(Color("White01"))
+                .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
+            }
+            .frame(height: profileViewHeight)
+
+            VStack {
+                Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+
+                Text("내 게시글")
+                    .font(.B1MediumFont())
+                    .platformTextColor(color: Color("Gray07"))
+                    .offset(x: -140, y: 0)
+
+                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
+
+                Image("icon_illust_empty")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
+
+                Text("아직 작성된 글이 없어요")
+                    .font(.H4MediumFont())
+                    .platformTextColor(color: Color("Gray07"))
+                    .padding(1)
+            }
+            .padding(.horizontal, 20)
+            .background(Color("Gray01"))
+        }
     }
 
     private func loadUserDataImage() {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -24,7 +24,7 @@ struct ProfileMainView: View {
     @State private var updateCount = 0 // 업데이트 횟수를 추적하는 변수
 
     var body: some View {
-        NavigationAvailable {
+        NavigationView {
             ZStack {
                 ScrollView {
                     GeometryReader { geometry in
@@ -65,86 +65,104 @@ struct ProfileMainView: View {
                     .padding(.horizontal, 20)
                     .background(Color("Gray01"))
                 }
-
-                if showPopUpView {
-                    Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
-                    EditProfilePopUpView(
-                        isPresented: $showPopUpView,
-                        showPopUpView: $showPopUpView,
-                        isHiddenTabBar: $isHiddenTabBar,
-                        showImagePicker: $showImagePicker,
-                        selectedUIImage: $selectedUIImage,
-                        sourceType: $sourceType,
-                        imageUrl: $imageUrl,
-                        presignedUrlViewModel: presignedUrlViewModel
-                    )
+            }
+//            if showPopUpView {
+//                Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+//                EditProfilePopUpView(
+//                    isPresented: $showPopUpView,
+//                    showPopUpView: $showPopUpView,
+//                    isHiddenTabBar: $isHiddenTabBar,
+//                    showImagePicker: $showImagePicker,
+//                    selectedUIImage: $selectedUIImage,
+//                    sourceType: $sourceType,
+//                    imageUrl: $imageUrl,
+//                    presignedUrlViewModel: presignedUrlViewModel
+//                )
+//            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                HStack {
+                    Button(action: {
+                        isSelectedToolBar = true
+                    }, label: {
+                        Image("icon_hamburger_button")
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                            .padding(5)
+                    })
+                    .frame(width: 44, height: 44)
+                    .buttonStyle(BasicButtonStyleUtil())
                 }
             }
-            .edgesIgnoringSafeArea(.bottom)
-            .sheet(isPresented: $showImagePicker, onDismiss: {
-                // 사진 클릭한 경우
-                showPopUpView = false
-                presignedUrlViewModel.image = selectedUIImage
-                presignedUrlViewModel.generatePresignedUrlApi { success in
-                    if success {
-                        presignedUrlViewModel.storePresignedUrlApi { success in
-                            if success {
-                                profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
-                            }
-                        }
-                    }
-                }
-            }) {
-                ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
-                    .edgesIgnoringSafeArea(.bottom)
-            }
-            .id(showPopUpView)
-            .background(Color("Gray01"))
-            .setTabBarVisibility(isHidden: showPopUpView)
-            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
-            .navigationBarBackButtonHidden()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    HStack {
-                        Button(action: {
-                            isSelectedToolBar = true
-                        }, label: {
-                            Image("icon_hamburger_button")
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                                .padding(5)
-                        })
-                        .frame(width: 44, height: 44)
-                        .buttonStyle(BasicButtonStyleUtil())
-                    }
-                }
-            }
-
-            NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
-                EmptyView()
-            }.hidden()
-
-            NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
-                EmptyView()
-            }.hidden()
         }
 
-        .onAppear {
-            Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
-            Log.debug("showPopUpView:\(showPopUpView)")
-            loadUserDataImage() // 사용자 프로필 사진 불러오기
-        }
-        .onChange(of: showPopUpView) { newValue in
-            isHiddenTabBar = newValue
-        }
-        .analyzeEvent(ProfileEvents.profileTapView)
-        .onChange(of: ProfileNavigationState(navigateToEditUsername: navigateToEditUsername, isSelectedToolBar: isSelectedToolBar, showPopUpView: showPopUpView)) { state in
-            if state.isReturn() {
-                AnalyticsManager.shared.trackEvent(ProfileEvents.profileTapView, additionalParams: nil)
-            }
-        }
+//        .edgesIgnoringSafeArea(.bottom)
+//        .sheet(isPresented: $showImagePicker, onDismiss: {
+//            // 사진 클릭한 경우
+//            showPopUpView = false
+//            presignedUrlViewModel.image = selectedUIImage
+//            presignedUrlViewModel.generatePresignedUrlApi { success in
+//                if success {
+//                    presignedUrlViewModel.storePresignedUrlApi { success in
+//                        if success {
+//                            profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
+//                        }
+//                    }
+//                }
+//            }
+//        }) {
+//            ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
+//                .edgesIgnoringSafeArea(.bottom)
+//        }
+//        .id(showPopUpView)
+//        .background(Color("Gray01"))
+//        .setTabBarVisibility(isHidden: showPopUpView)
+//        .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
+//        .navigationBarBackButtonHidden()
+//        .frame(maxWidth: .infinity, maxHeight: .infinity)
+//        .toolbar {
+//            ToolbarItem(placement: .navigationBarTrailing) {
+//                HStack {
+//                    Button(action: {
+//                        isSelectedToolBar = true
+//                    }, label: {
+//                        Image("icon_hamburger_button")
+//                            .resizable()
+//                            .aspectRatio(contentMode: .fill)
+//                            .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+//                            .padding(5)
+//                    })
+//                    .frame(width: 44, height: 44)
+//                    .buttonStyle(BasicButtonStyleUtil())
+//                }
+//            }
+//        }
+//
+//        NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
+//            EmptyView()
+//        }.hidden()
+//
+//        NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
+//            EmptyView()
+//        }.hidden()
+//            //        }
+//
+//            .onAppear {
+//                Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
+//                Log.debug("showPopUpView:\(showPopUpView)")
+//                loadUserDataImage() // 사용자 프로필 사진 불러오기
+//            }
+//            .onChange(of: showPopUpView) { newValue in
+//                isHiddenTabBar = newValue
+//            }
+//            .analyzeEvent(ProfileEvents.profileTapView)
+//            .onChange(of: ProfileNavigationState(navigateToEditUsername: navigateToEditUsername, isSelectedToolBar: isSelectedToolBar, showPopUpView: showPopUpView)) { state in
+//                if state.isReturn() {
+//                    AnalyticsManager.shared.trackEvent(ProfileEvents.profileTapView, additionalParams: nil)
+//                }
+//            }
     }
 
     private func loadUserDataImage() {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -18,6 +18,7 @@ struct ProfileMainView: View {
 
     @State var imageUrl = ""
 
+    let screenHeight = UIScreen.main.bounds.height
     let profileViewHeight = 267 * DynamicSizeFactor.factor()
     @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
     @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
@@ -31,6 +32,7 @@ struct ProfileMainView: View {
                     .setTabBarVisibility(isHidden: showPopUpView)
                     .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
                     .background(Color("Gray01"))
+                    .navigationBarBackButtonHidden(true)
                     .toolbar {
                         ToolbarItem(placement: .topBarTrailing) {
                             HStack {
@@ -126,31 +128,32 @@ struct ProfileMainView: View {
                 )
                 .background(Color("White01"))
                 .offset(y: adjustedOffset > 0 ? -adjustedOffset : 0)
+
+                VStack(alignment: .center) {
+                    Spacer().frame(height: 33 * DynamicSizeFactor.factor())
+
+                    Text("내 게시글")
+                        .font(.B1MediumFont())
+                        .platformTextColor(color: Color("Gray07"))
+                        .offset(x: -140, y: 0)
+
+                    Spacer().frame(height: 6 * DynamicSizeFactor.factor())
+
+                    Image("icon_illust_empty")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
+
+                    Text("아직 작성된 글이 없어요")
+                        .font(.H4MediumFont())
+                        .platformTextColor(color: Color("Gray07"))
+                        .padding(1)
+                }
+                .frame(maxWidth: .infinity)
+                .background(Color("Gray01"))
+                .offset(y: adjustedOffset > 0 ? (profileViewHeight - adjustedOffset) : profileViewHeight)
             }
-            .frame(height: profileViewHeight)
-
-            VStack {
-                Spacer().frame(height: 33 * DynamicSizeFactor.factor())
-
-                Text("내 게시글")
-                    .font(.B1MediumFont())
-                    .platformTextColor(color: Color("Gray07"))
-                    .offset(x: -140, y: 0)
-
-                Spacer().frame(height: 6 * DynamicSizeFactor.factor())
-
-                Image("icon_illust_empty")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 100 * DynamicSizeFactor.factor(), height: 100 * DynamicSizeFactor.factor())
-
-                Text("아직 작성된 글이 없어요")
-                    .font(.H4MediumFont())
-                    .platformTextColor(color: Color("Gray07"))
-                    .padding(1)
-            }
-            .padding(.horizontal, 20)
-            .background(Color("Gray01"))
+            .frame(height: screenHeight)
         }
     }
 
@@ -190,3 +193,4 @@ struct ProfileNavigationState: Equatable {
 #Preview {
     ProfileMainView()
 }
+

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -18,7 +18,6 @@ struct ProfileMainView: View {
 
     @State var imageUrl = ""
 
-    let screenHeight = UIScreen.main.bounds.height
     let profileViewHeight = 267 * DynamicSizeFactor.factor()
     @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
     @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
@@ -153,7 +152,7 @@ struct ProfileMainView: View {
                 .background(Color("Gray01"))
                 .offset(y: adjustedOffset > 0 ? (profileViewHeight - adjustedOffset) : profileViewHeight)
             }
-            .frame(height: screenHeight)
+            .frame(height: ScreenUtil.calculateAvailableHeight())
         }
     }
 
@@ -193,4 +192,3 @@ struct ProfileNavigationState: Equatable {
 #Preview {
     ProfileMainView()
 }
-

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -27,6 +27,56 @@ struct ProfileMainView: View {
         NavigationAvailable {
             ZStack {
                 content
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .setTabBarVisibility(isHidden: showPopUpView)
+                    .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
+                    .background(Color("Gray01"))
+//                .edgesIgnoringSafeArea(.bottom) 루트 뷰 이동 가능
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            HStack {
+                                Button(action: {
+                                    isSelectedToolBar = true
+                                }, label: {
+                                    Image("icon_hamburger_button")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                                        .padding(5)
+                                })
+                                .frame(width: 44, height: 44)
+                                .buttonStyle(BasicButtonStyleUtil())
+                            }
+                        }
+                    }
+                    .sheet(isPresented: $showImagePicker, onDismiss: {
+                        // 사진 클릭한 경우
+                        showPopUpView = false
+                        presignedUrlViewModel.image = selectedUIImage
+                        presignedUrlViewModel.generatePresignedUrlApi { success in
+                            if success {
+                                presignedUrlViewModel.storePresignedUrlApi { success in
+                                    if success {
+                                        profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
+                                    }
+                                }
+                            }
+                        }
+                    }) {
+                        ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
+                            .edgesIgnoringSafeArea(.bottom)
+                    }
+
+                    .background(
+                        NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
+                            EmptyView()
+                        }.hidden()
+                    )
+                    .background(
+                        NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
+                            EmptyView()
+                        }.hidden()
+                    )
 
                 if showPopUpView {
                     Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
@@ -40,59 +90,9 @@ struct ProfileMainView: View {
                         imageUrl: $imageUrl,
                         presignedUrlViewModel: presignedUrlViewModel
                     )
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color("Gray01"))
-            .setTabBarVisibility(isHidden: showPopUpView)
-            .navigationBarTitle(getUserData()?.username ?? "", displayMode: .inline)
-            .navigationBarBackButtonHidden()
-            .edgesIgnoringSafeArea(.bottom)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    HStack {
-                        Button(action: {
-                            isSelectedToolBar = true
-                        }, label: {
-                            Image("icon_hamburger_button")
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                                .padding(5)
-                        })
-                        .frame(width: 44, height: 44)
-                        .buttonStyle(BasicButtonStyleUtil())
-                    }
-                }
-            }
-            .sheet(isPresented: $showImagePicker, onDismiss: {
-                // 사진 클릭한 경우
-                showPopUpView = false
-                presignedUrlViewModel.image = selectedUIImage
-                presignedUrlViewModel.generatePresignedUrlApi { success in
-                    if success {
-                        presignedUrlViewModel.storePresignedUrlApi { success in
-                            if success {
-                                profileImageViewModel.uploadProfileImageApi(presignedUrlViewModel.payload)
-                            }
-                        }
-                    }
-                }
-            }) {
-                ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
                     .edgesIgnoringSafeArea(.bottom)
+                }
             }
-
-            .background(
-                NavigationLink(destination: EditUsernameView(), isActive: $navigateToEditUsername) {
-                    EmptyView()
-                }.hidden()
-            )
-            .background(
-                NavigationLink(destination: ProfileMenuBarListView(), isActive: $isSelectedToolBar) {
-                    EmptyView()
-                }.hidden()
-            )
         }
         .id(showPopUpView)
         .onAppear {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -31,9 +31,8 @@ struct ProfileMainView: View {
                     .setTabBarVisibility(isHidden: showPopUpView)
                     .navigationBarColor(UIColor(named: "White01"), title: getUserData()?.username ?? "")
                     .background(Color("Gray01"))
-//                .edgesIgnoringSafeArea(.bottom) 루트 뷰 이동 가능
                     .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
+                        ToolbarItem(placement: .topBarTrailing) {
                             HStack {
                                 Button(action: {
                                     isSelectedToolBar = true

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMainView.swift
@@ -93,8 +93,8 @@ struct ProfileMainView: View {
                     .edgesIgnoringSafeArea(.bottom)
                 }
             }
+            .id(showPopUpView)
         }
-        .id(showPopUpView)
         .onAppear {
             Log.debug("isHiddenTabBar:\(isHiddenTabBar)")
             Log.debug("showPopUpView:\(showPopUpView)")

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileMenuBarListView.swift
@@ -30,7 +30,7 @@ struct ProfileMenuBarListView: View {
                 }
                 .background(Color("Gray01"))
             }
-            .setTabBarVisibility(isHidden: false)
+            .setTabBarVisibility(isHidden: true)
             .navigationBarColor(UIColor(named: "White01"), title: "")
             .navigationBarBackButtonHidden(true)
             .toolbar {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileModifyPwView.swift
@@ -7,7 +7,6 @@ struct ProfileModifyPwView: View {
     @State private var navigateView = false
     @State private var isFormValid = false
     @State private var isPwDeleteButtonVisible: Bool = false
-    @Binding var firstNaviLinkActive: Bool
     private let maxLength = 16
 
     let entryPoint: PasswordChangeTypeNavigation
@@ -62,7 +61,7 @@ struct ProfileModifyPwView: View {
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
             }
 
-            NavigationLink(destination: ResetPwView(firstNaviLinkActive: $firstNaviLinkActive, entryPoint: .modifyPw), isActive: $navigateView) {
+            NavigationLink(destination: ResetPwView(entryPoint: .modifyPw), isActive: $navigateView) {
                 EmptyView()
             }.hidden()
         }
@@ -99,5 +98,5 @@ struct ProfileModifyPwView: View {
 }
 
 #Preview {
-    ProfileModifyPwView(firstNaviLinkActive: .constant(true), entryPoint: .modifyPw)
+    ProfileModifyPwView(entryPoint: .modifyPw)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -20,8 +20,7 @@ struct ProfileSettingListView: View {
                         }),
                         ProfileSettingListItem(title: "스크랩", icon: "icon_scrap", action: {}),
                         ProfileSettingListItem(title: "비밀번호 변경", icon: "icon_change password", action: {
-//                            activeNavigation = .modifyPw
-                            NavigationUtil.popToRootView()
+                            activeNavigation = .modifyPw
                         })
                     ])
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/ProfileView/ProfileMainView/ProfileSettingListView.swift
@@ -6,8 +6,6 @@ import SwiftUI
 struct ProfileSettingListView: View {
     @Binding var showLogoutPopUp: Bool
     @Binding var showDeleteUserPopUp: Bool
-    @State var firstNaviLinkActive = true
-
     @State private var activeNavigation: ProfileActiveNavigation?
 
     var body: some View {
@@ -22,7 +20,8 @@ struct ProfileSettingListView: View {
                         }),
                         ProfileSettingListItem(title: "스크랩", icon: "icon_scrap", action: {}),
                         ProfileSettingListItem(title: "비밀번호 변경", icon: "icon_change password", action: {
-                            activeNavigation = .modifyPw
+//                            activeNavigation = .modifyPw
+                            NavigationUtil.popToRootView()
                         })
                     ])
 
@@ -65,8 +64,6 @@ struct ProfileSettingListView: View {
 
             navigationLinks
         }
-        .setTabBarVisibility(isHidden: true)
-        .navigationBarColor(UIColor(named: "White01"), title: "")
     }
 
     @ViewBuilder
@@ -90,7 +87,7 @@ struct ProfileSettingListView: View {
         case .editProfile:
             EditProfileListView()
         case .modifyPw:
-            ProfileModifyPwView(firstNaviLinkActive: $firstNaviLinkActive, entryPoint: .modifyPw)
+            ProfileModifyPwView(entryPoint: .modifyPw)
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -26,6 +26,12 @@ struct SpendingManagementMainView: View {
                 .setTabBarVisibility(isHidden: ishidden)
                 .navigationBarColor(UIColor(named: "Gray01"), title: "")
                 .background(Color("Gray01"))
+                .onAppear {
+                    spendingHistoryViewModel.checkSpendingHistoryApi { _ in }
+                    targetAmountViewModel.getTargetAmountForDateApi { _ in }
+                    notificationViewModel.checkUnReadNotificationsApi { _ in }
+                    Log.debug("hasUnread : \(notificationViewModel.hasUnread)")
+                }
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Image("icon_logo_text")
@@ -108,12 +114,6 @@ struct SpendingManagementMainView: View {
         .dragBottomSheet(isPresented: $showSpendingDetailView, minHeight: bottomSheetMinHeight, maxHeight: 524 * DynamicSizeFactor.factor()) {
             SpendingDetailSheetView(clickDate: $clickDate, viewModel: AddSpendingHistoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel)
                 .zIndex(2)
-        }
-        .onAppear {
-            spendingHistoryViewModel.checkSpendingHistoryApi { _ in }
-            targetAmountViewModel.getTargetAmountForDateApi { _ in }
-            notificationViewModel.checkUnReadNotificationsApi { _ in }
-            Log.debug("hasUnread : \(notificationViewModel.hasUnread)")
         }
         .onChange(of: showSpendingDetailView) { isPresented in
             ishidden = isPresented

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -21,107 +21,81 @@ struct SpendingManagementMainView: View {
 
     var body: some View {
         NavigationAvailable {
-            ScrollView {
-                VStack {
-                    Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-                    
-                    if !targetAmountViewModel.isHiddenSuggestionView {
-                        RecentTargetAmountSuggestionView(viewModel: targetAmountViewModel, showToastPopup: $showToastPopup, isHidden: $targetAmountViewModel.isHiddenSuggestionView)
-                        
-                        Spacer().frame(height: 13 * DynamicSizeFactor.factor())
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .setTabBarVisibility(isHidden: ishidden)
+                .navigationBarColor(UIColor(named: "Gray01"), title: "")
+                .background(Color("Gray01"))
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Image("icon_logo_text")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 99 * DynamicSizeFactor.factor(), height: 18 * DynamicSizeFactor.factor())
                     }
-                    
-                    SpendingCheckBoxView(viewModel: targetAmountViewModel)
-                        .padding(.horizontal, 20)
-                    
-                    Spacer().frame(height: 13 * DynamicSizeFactor.factor())
-                    
-                    SpendingCalenderView(spendingHistoryViewModel: spendingHistoryViewModel, showSpendingDetailView: $showSpendingDetailView, date: $spendingHistoryViewModel.currentDate, clickDate: $clickDate)
-                        .padding(.horizontal, 20)
-                    
-                    Spacer().frame(height: 13 * DynamicSizeFactor.factor())
-                    
-                    CustomRectangleButton(action: {
-                        navigateToMySpendingList = true
-                        Log.debug(navigateToMySpendingList)
-                    }, label: "나의 소비 내역")
-                    
-                    Spacer().frame(height: 23 * DynamicSizeFactor.factor())
-                }
-                .analyzeEvent(SpendingEvents.spendingTabView)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .setTabBarVisibility(isHidden: ishidden)
-            .navigationBarColor(UIColor(named: "Gray01"), title: "")
-            .background(Color("Gray01"))
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Image("icon_logo_text")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 99 * DynamicSizeFactor.factor(), height: 18 * DynamicSizeFactor.factor())
-                }
             
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 0) {
-                        Button(action: {
-                            clickDate = Date() // +아이콘을 통해 들어간 경우 현재날짜 고정
-                            entryPoint = .main
-                            navigateToAddSpendingHistory = true
-                        }, label: {
-                            Image("icon_navigation_add_black")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 28 * DynamicSizeFactor.factor(), height: 28 * DynamicSizeFactor.factor())
-                                .padding(5 * DynamicSizeFactor.factor())
-                        })
-                        .padding(.trailing, 5 * DynamicSizeFactor.factor())
-                        .frame(width: 44, height: 44)
-                        .buttonStyle(BasicButtonStyleUtil())
+                    ToolbarItem(placement: .topBarTrailing) {
+                        HStack(spacing: 0) {
+                            Button(action: {
+                                clickDate = Date() // +아이콘을 통해 들어간 경우 현재날짜 고정
+                                entryPoint = .main
+                                navigateToAddSpendingHistory = true
+                            }, label: {
+                                Image("icon_navigation_add_black")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 28 * DynamicSizeFactor.factor(), height: 28 * DynamicSizeFactor.factor())
+                                    .padding(5 * DynamicSizeFactor.factor())
+                            })
+                            .padding(.trailing, 5 * DynamicSizeFactor.factor())
+                            .frame(width: 44, height: 44)
+                            .buttonStyle(BasicButtonStyleUtil())
             
-                        Button(action: {
-                            navigateToMainAlarmView = true
-                        }, label: {
-                            Image(notificationViewModel.hasUnread ? "icon_navigationbar_bell_dot" : "icon_navigationbar_bell")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
-                                .padding(5 * DynamicSizeFactor.factor())
-                        })
-                        .padding(.trailing, 5 * DynamicSizeFactor.factor())
-                        .frame(width: 44, height: 44)
-                        .buttonStyle(BasicButtonStyleUtil())
+                            Button(action: {
+                                navigateToMainAlarmView = true
+                            }, label: {
+                                Image(notificationViewModel.hasUnread ? "icon_navigationbar_bell_dot" : "icon_navigationbar_bell")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
+                                    .padding(5 * DynamicSizeFactor.factor())
+                            })
+                            .padding(.trailing, 5 * DynamicSizeFactor.factor())
+                            .frame(width: 44, height: 44)
+                            .buttonStyle(BasicButtonStyleUtil())
+                        }
+                        .offset(x: 10)
                     }
-                    .offset(x: 10)
                 }
-            }
-            .overlay(
-                Group {
-                    if showToastPopup {
-                        CustomToastView(message: "\(Date.month(from: Date()))월의 새로운 목표금액을 설정했어요")
-                            .transition(.move(edge: .bottom))
-                            .animation(.easeInOut(duration: 0.2)) // 애니메이션 시간
-                            .padding(.bottom, 10 * DynamicSizeFactor.factor())
+                .overlay(
+                    Group {
+                        if showToastPopup {
+                            CustomToastView(message: "\(Date.month(from: Date()))월의 새로운 목표금액을 설정했어요")
+                                .transition(.move(edge: .bottom))
+                                .animation(.easeInOut(duration: 0.2)) // 애니메이션 시간
+                                .padding(.bottom, 10 * DynamicSizeFactor.factor())
+                        }
+                    }, alignment: .bottom
+                )
+                .background(
+                    NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: .constant(Date()), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
+                        EmptyView()
                     }
-                }, alignment: .bottom
-            )
-            .background(
-                NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: .constant(Date()), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
-                    EmptyView()
-                }
                     .hidden()
-            )
-            .background(
-                NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, spendingId: .constant(0), clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, isEditSuccess: .constant(false), isAddSpendingData: .constant(false), entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
-                    EmptyView()
-                }
-                .hidden()
-            )
+                )
+                .background(
+                    NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, spendingId: .constant(0), clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, isEditSuccess: .constant(false), isAddSpendingData: .constant(false), entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
+                        EmptyView()
+                    }
+                    .hidden()
+                )
             
-            NavigationLink(destination: ProfileAlarmView(), isActive: $navigateToMainAlarmView) {
-                EmptyView()
-            }
-            .hidden()
+                .background(
+                    NavigationLink(destination: ProfileAlarmView(), isActive: $navigateToMainAlarmView) {
+                        EmptyView()
+                    }
+                    .hidden()
+                )
             
             if #available(iOS 15.0, *) {
             } else {
@@ -130,7 +104,6 @@ struct SpendingManagementMainView: View {
                 }
                 .hidden()
             }
-            
         }
         .dragBottomSheet(isPresented: $showSpendingDetailView, minHeight: bottomSheetMinHeight, maxHeight: 524 * DynamicSizeFactor.factor()) {
             SpendingDetailSheetView(clickDate: $clickDate, viewModel: AddSpendingHistoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel)
@@ -153,6 +126,40 @@ struct SpendingManagementMainView: View {
             }
         }
         .id(ishidden)
+    }
+    
+    // MARK: - Subviews
+
+    private var content: some View {
+        ScrollView {
+            VStack {
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                
+                if !targetAmountViewModel.isHiddenSuggestionView {
+                    RecentTargetAmountSuggestionView(viewModel: targetAmountViewModel, showToastPopup: $showToastPopup, isHidden: $targetAmountViewModel.isHiddenSuggestionView)
+                    
+                    Spacer().frame(height: 13 * DynamicSizeFactor.factor())
+                }
+                
+                SpendingCheckBoxView(viewModel: targetAmountViewModel)
+                    .padding(.horizontal, 20)
+                
+                Spacer().frame(height: 13 * DynamicSizeFactor.factor())
+                
+                SpendingCalenderView(spendingHistoryViewModel: spendingHistoryViewModel, showSpendingDetailView: $showSpendingDetailView, date: $spendingHistoryViewModel.currentDate, clickDate: $clickDate)
+                    .padding(.horizontal, 20)
+                
+                Spacer().frame(height: 13 * DynamicSizeFactor.factor())
+                
+                CustomRectangleButton(action: {
+                    navigateToMySpendingList = true
+                    Log.debug(navigateToMySpendingList)
+                }, label: "나의 소비 내역")
+                
+                Spacer().frame(height: 23 * DynamicSizeFactor.factor())
+            }
+            .analyzeEvent(SpendingEvents.spendingTabView)
+        }
     }
 
     private var bottomSheetMinHeight: CGFloat {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingManagementMainView.swift
@@ -24,42 +24,36 @@ struct SpendingManagementMainView: View {
             ScrollView {
                 VStack {
                     Spacer().frame(height: 16 * DynamicSizeFactor.factor())
-
+                    
                     if !targetAmountViewModel.isHiddenSuggestionView {
                         RecentTargetAmountSuggestionView(viewModel: targetAmountViewModel, showToastPopup: $showToastPopup, isHidden: $targetAmountViewModel.isHiddenSuggestionView)
-
+                        
                         Spacer().frame(height: 13 * DynamicSizeFactor.factor())
                     }
-
+                    
                     SpendingCheckBoxView(viewModel: targetAmountViewModel)
                         .padding(.horizontal, 20)
-
+                    
                     Spacer().frame(height: 13 * DynamicSizeFactor.factor())
-
+                    
                     SpendingCalenderView(spendingHistoryViewModel: spendingHistoryViewModel, showSpendingDetailView: $showSpendingDetailView, date: $spendingHistoryViewModel.currentDate, clickDate: $clickDate)
                         .padding(.horizontal, 20)
-
+                    
                     Spacer().frame(height: 13 * DynamicSizeFactor.factor())
-
+                    
                     CustomRectangleButton(action: {
                         navigateToMySpendingList = true
                         Log.debug(navigateToMySpendingList)
                     }, label: "나의 소비 내역")
-
+                    
                     Spacer().frame(height: 23 * DynamicSizeFactor.factor())
                 }
                 .analyzeEvent(SpendingEvents.spendingTabView)
             }
-            .onAppear {
-                spendingHistoryViewModel.checkSpendingHistoryApi { _ in }
-                targetAmountViewModel.getTargetAmountForDateApi { _ in }
-                notificationViewModel.checkUnReadNotificationsApi { _ in }
-                Log.debug("hasUnread : \(notificationViewModel.hasUnread)")
-            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .setTabBarVisibility(isHidden: ishidden)
             .navigationBarColor(UIColor(named: "Gray01"), title: "")
             .background(Color("Gray01"))
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Image("icon_logo_text")
@@ -67,7 +61,7 @@ struct SpendingManagementMainView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 99 * DynamicSizeFactor.factor(), height: 18 * DynamicSizeFactor.factor())
                 }
-
+            
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack(spacing: 0) {
                         Button(action: {
@@ -84,7 +78,7 @@ struct SpendingManagementMainView: View {
                         .padding(.trailing, 5 * DynamicSizeFactor.factor())
                         .frame(width: 44, height: 44)
                         .buttonStyle(BasicButtonStyleUtil())
-
+            
                         Button(action: {
                             navigateToMainAlarmView = true
                         }, label: {
@@ -115,9 +109,20 @@ struct SpendingManagementMainView: View {
                 NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: .constant(Date()), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
                     EmptyView()
                 }
+                    .hidden()
+            )
+            .background(
+                NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, spendingId: .constant(0), clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, isEditSuccess: .constant(false), isAddSpendingData: .constant(false), entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
+                    EmptyView()
+                }
                 .hidden()
             )
-
+            
+            NavigationLink(destination: ProfileAlarmView(), isActive: $navigateToMainAlarmView) {
+                EmptyView()
+            }
+            .hidden()
+            
             if #available(iOS 15.0, *) {
             } else {
                 NavigationLink(destination: MySpendingListView(spendingHistoryViewModel: SpendingHistoryViewModel(), currentMonth: .constant(Date()), clickDate: $clickDate), isActive: $navigateToMySpendingList) {
@@ -125,20 +130,17 @@ struct SpendingManagementMainView: View {
                 }
                 .hidden()
             }
-
-            NavigationLink(destination: AddSpendingHistoryView(spendingCategoryViewModel: SpendingCategoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel, spendingId: .constant(0), clickDate: $clickDate, isPresented: $navigateToAddSpendingHistory, isEditSuccess: .constant(false), isAddSpendingData: .constant(false), entryPoint: .main), isActive: $navigateToAddSpendingHistory) {
-                EmptyView()
-            }
-            .hidden()
-
-            NavigationLink(destination: ProfileAlarmView(), isActive: $navigateToMainAlarmView) {
-                EmptyView()
-            }
-            .hidden()
+            
         }
         .dragBottomSheet(isPresented: $showSpendingDetailView, minHeight: bottomSheetMinHeight, maxHeight: 524 * DynamicSizeFactor.factor()) {
             SpendingDetailSheetView(clickDate: $clickDate, viewModel: AddSpendingHistoryViewModel(), spendingHistoryViewModel: spendingHistoryViewModel)
                 .zIndex(2)
+        }
+        .onAppear {
+            spendingHistoryViewModel.checkSpendingHistoryApi { _ in }
+            targetAmountViewModel.getTargetAmountForDateApi { _ in }
+            notificationViewModel.checkUnReadNotificationsApi { _ in }
+            Log.debug("hasUnread : \(notificationViewModel.hasUnread)")
         }
         .onChange(of: showSpendingDetailView) { isPresented in
             ishidden = isPresented

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -12,7 +12,6 @@ struct TotalTargetAmountView: View {
     @State private var showingDeletePopUp = false
     @State private var showToastPopup = false
 
-    @State var screenHeight = UIScreen.main.bounds.height
     let hearderViewHeight = 173 * DynamicSizeFactor.factor()
     @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
     @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
@@ -32,7 +31,7 @@ struct TotalTargetAmountView: View {
                     TotalTargetAmountContentView(viewModel: viewModel, isnavigateToPastSpendingView: $isnavigateToPastSpendingView)
                         .offset(y: adjustedOffset > 0 ? (hearderViewHeight - adjustedOffset) : hearderViewHeight)
                 }
-                .frame(height: screenHeight + hearderViewHeight)
+                .frame(height: ScreenUtil.calculateAvailableHeight() + calculateAdditionalHeight())
             }
             .overlay(
                 VStack(alignment: .leading) {
@@ -157,7 +156,7 @@ struct TotalTargetAmountView: View {
         }
     }
 
-    func setOffset(offset: CGFloat) -> some View {
+    private func setOffset(offset: CGFloat) -> some View {
         DispatchQueue.main.async {
             if updateCount < 2 {
                 updateCount += 1
@@ -168,6 +167,16 @@ struct TotalTargetAmountView: View {
             adjustedOffset = offset - initialOffset
         }
         return EmptyView()
+    }
+
+    /// viewModel.targetAmounts의 개수에 따라 추가 높이를 계산하는 함수
+    private func calculateAdditionalHeight() -> CGFloat {
+        let count = viewModel.targetAmounts.count
+        if count >= 3 {
+            return CGFloat(min(count - 2, 4)) * 60 * DynamicSizeFactor.factor()
+        } else {
+            return 0
+        }
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -173,8 +173,8 @@ struct TotalTargetAmountView: View {
     /// viewModel.targetAmounts의 개수에 따라 추가 높이를 계산하는 함수
     private func calculateAdditionalHeight() -> CGFloat {
         let count = viewModel.targetAmounts.count
-        if count >= 3 {
-            return CGFloat(min(count - 2, 4)) * 60 * DynamicSizeFactor.factor()
+        if count >= 2 {
+            return CGFloat(min(count - 1, 5)) * 60 * DynamicSizeFactor.factor()
         } else {
             return 0
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -12,7 +12,7 @@ struct TotalTargetAmountView: View {
     @State private var showingDeletePopUp = false
     @State private var showToastPopup = false
 
-    let screenHeight = UIScreen.main.bounds.height
+    @State var screenHeight = UIScreen.main.bounds.height
     let hearderViewHeight = 173 * DynamicSizeFactor.factor()
     @State private var initialOffset: CGFloat = 0 // 초기 오프셋 값 저장
     @State private var adjustedOffset: CGFloat = 0 // (현재 오프셋 값 - 초기 오프셋 값) 계산
@@ -32,7 +32,7 @@ struct TotalTargetAmountView: View {
                     TotalTargetAmountContentView(viewModel: viewModel, isnavigateToPastSpendingView: $isnavigateToPastSpendingView)
                         .offset(y: adjustedOffset > 0 ? (hearderViewHeight - adjustedOffset) : hearderViewHeight)
                 }
-                .frame(height: screenHeight)
+                .frame(height: screenHeight + hearderViewHeight)
             }
             .overlay(
                 VStack(alignment: .leading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - TotalTargetAmountView
 
 struct TotalTargetAmountView: View {
+    @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel = TotalTargetAmountViewModel()
     @State private var isClickMenu = false
     @State private var selectedMenu: String? = nil // 선택한 메뉴
@@ -72,7 +73,7 @@ struct TotalTargetAmountView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     HStack {
                         Button(action: {
-                            NavigationUtil.popToRootView()
+                            self.presentationMode.wrappedValue.dismiss()
                         }, label: {
                             Image("icon_arrow_back_white")
                                 .resizable()


### PR DESCRIPTION
## 작업 이유

- NavigationView 에러
- 상단 스크롤 막기 수정
- 메인 뷰, 프로필 뷰 리팩토링

<br/>

## 작업 사항

### 1️⃣ NavigationView 에러

ios 15는 NavigationView를 사용하여 NavigationUtil의 popToView()를 실행하면 오류가 발생했다.
확인해보니 NavigationView가 NavigationStack처럼 스택이 쌓이는 구조가 아니라서 popToView의 index를 찾을 수 없었다.
그래서 `.navigationViewStyle(.stack))`를 사용하여 스택처럼 쌓이도록 수정하니 popToView()가 오류 없이 잘 실행된다.

```swift
func NavigationAvailable<Content: View>(@ViewBuilder content: () -> Content) -> some View {
    if #available(iOS 16.0, *) {
        return AnyView(NavigationStack { content() })
    } else {
        return AnyView(NavigationView { content() }
            .navigationViewStyle(.stack)) // navigation index 파악위해 stack 사용
    }
}
```

<br/>

### 2️⃣ 상단 스크롤 막기 수정

목표 금액에서만 상단 뷰와 하위뷰를 하나로 묶어서 스크롤 되도록 처리했었는데 프로필 화면도 똑같이 적용했다. 

![Simulator Screen Recording - iPhone 8 Plus - 2024-08-30 at 02 39 55](https://github.com/user-attachments/assets/af3ec86e-6876-42f4-8b46-a6aac57a7399)

```swift
enum ScreenUtil {
    static func calculateAvailableHeight() -> CGFloat {
        let screenHeight = UIScreen.main.bounds.height
        ...
        // (네비게이션 바 - 탭바) 높이 제거한 뷰의 높이
        let availableHeight = screenHeight - navigationBarHeight - tabBarHeight
        
        return availableHeight
    }
}
```
ScreenUtil을 사용하여 (네비게이션 바 - 탭바) 높이 제거한 뷰의 높이를 파악해 스크롤가능한 높이를 설정했다.
이렇게 구현하니까 목표금액 뷰에서 스크롤이 모든 영역이 되지 않는 문제가 있었다.

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-30 at 01 45 46](https://github.com/user-attachments/assets/1eecbab0-75ab-422d-b8ab-ff099e4dd4a8)

그래서 아래와 같이 viewModel.targetAmounts의 개수가 즉 하단의 목표금액 개수와 같기 때문에 2개이상일때부터 하나의 셀 크기만큼 곱해주도록 했다. `.frame(height: ScreenUtil.calculateAvailableHeight() + calculateAdditionalHeight())`최종적으로 이렇게 높이를 지정해주었다.

```swift
/// viewModel.targetAmounts의 개수에 따라 추가 높이를 계산하는 함수
private func calculateAdditionalHeight() -> CGFloat {
    let count = viewModel.targetAmounts.count
    if count >= 2 {
        return CGFloat(min(count - 1, 5)) * 60 * DynamicSizeFactor.factor()
    } else {
        return 0
    }
}
```


### 3️⃣ 메인 뷰, 프로필 뷰 리팩토링

SpendingManagementMainView와 ProfileMainView의 코드를 리팩토링하였다.
NavigationAvailable 하위에 있던 ui 코드들을 `private var content: some View {`로 분리하여 아래와 같이 사용했다.

```swift
 NavigationAvailable {
            content
            ...
}

```

### 4️⃣ 비밀번호 변경 후 루트 뷰 돌아가기 로직 수정

- 비밀번호 변경 후 루트 뷰로 돌아가는 로직 NavigationLink를 사용하도록 했는데, CompleteChangePwView에서 NavigationLink로 구현하고 사용안하는 코드들은 다 삭제했다.

navigateView나 firstNaviLinkActive 변수들은 사용하지 않아서 삭제했다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
NavigationView에러 수정하였고, 상단 스크롤 막기 프로필 화면도 구현했습니다!
그리고 3️⃣ 메인 뷰, 프로필 뷰 리팩토링 했는데 이상있으면 말씀해주세요~!

<br/>

## 발견한 이슈

나의 소비내역 화면에서 iPhone 8 Plus로 실행해봤는데 처음에 요일이 상단에 있다가 스크롤하면 정상적으로 내려오더라고요,,, ㅎ
이 부분 확인해봐야할 것 같아요!

![Simulator Screen Recording - iPhone 8 Plus - 2024-08-30 at 02 29 19](https://github.com/user-attachments/assets/df425c16-1b0b-46a5-a7c1-f3f43dd57ab2)

