### PR TITLE
🎨💻 회원가입 네비게이션 카운트 아이콘 사이즈 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/ElementView/NavigationCountView.swift
@@ -9,21 +9,21 @@ struct NavigationCountView: View {
         HStack(spacing: 8 * DynamicSizeFactor.factor()) {
             LazyHGrid(rows: [GridItem(.flexible())]) {
                 Text("1")
-                    .padding(6)
+                    .frame(width: 18 * DynamicSizeFactor.factor(), height: 18 * DynamicSizeFactor.factor())
                     .background(selectedText ?? 0 >= 1 ? Color("Gray06") : Color("Gray03"))
                     .platformTextColor(color: selectedText ?? 0 >= 1 ? Color("White01") : Color("Gray04"))
                     .clipShape(Circle())
                     .font(.B2MediumFont())
 
                 Text("2")
-                    .padding(6)
+                    .frame(width: 18 * DynamicSizeFactor.factor(), height: 18 * DynamicSizeFactor.factor())
                     .background(selectedText ?? 0 >= 2 ? Color("Gray06") : Color("Gray03"))
                     .platformTextColor(color: selectedText ?? 0 >= 2 ? Color("White01") : Color("Gray04"))
                     .clipShape(Circle())
                     .font(.B2MediumFont())
 
                 Text("3")
-                    .padding(6)
+                    .frame(width: 18 * DynamicSizeFactor.factor(), height: 18 * DynamicSizeFactor.factor())
                     .background(selectedText ?? 0 >= 3 ? Color("Gray06") : Color("Gray03"))
                     .platformTextColor(color: selectedText ?? 0 >= 3 ? Color("White01") : Color("Gray04"))
                     .clipShape(Circle())
@@ -32,6 +32,6 @@ struct NavigationCountView: View {
             Spacer()
         }
         .padding(.horizontal, 20)
-        .frame(height: 18)
+        .frame(maxHeight: 18 * DynamicSizeFactor.factor())
     }
 }


### PR DESCRIPTION
## 작업 이유

- 네비게이션 카운트 아이콘 사이즈 수정

<br/>

## 작업 사항

### 1️⃣ 네비게이션 카운트 아이콘 사이즈 수정

이전에 아이콘 크기를 padding으로 지정하다 보니, 숫자 1이 2와 3보다 너비가 작아서 같은 padding 값을 적용해도 크기가 다르게 보이는 문제가 있었다.
frame으로 수정하여 숫자에 상관없이 모든 아이콘이 동일한 크기를 가지도록 변경했다.

![스크린샷 2024-09-06 오전 2 01 56](https://github.com/user-attachments/assets/f7d8dc3a-2e0a-4000-b377-9929ed4fd260)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

네비게이션 카운트 아이콘 사이즈 수정 완료했습니다~

<br/>

## 발견한 이슈
없음