### PR TITLE
📍🎨 로그인 뷰 패딩 값 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/InputFormView.swift
@@ -8,14 +8,10 @@ struct InputFormView: View {
 
     var body: some View {
         VStack {
-            Spacer()
-
             HStack(alignment: .top) {
                 Text("친구들과 함께\n간편한 자산관리")
                     .font(.H1SemiboldFont())
                     .multilineTextAlignment(.leading)
-                    .padding(.top, 40 * DynamicSizeFactor.factor())
-
                 Spacer()
             }
             .padding(.leading, 20)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/LoginView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/LoginView.swift
@@ -13,7 +13,7 @@ struct LoginView: View {
 
                     AdditionalOptionView()
                 }
-                .padding(.bottom, 60 * DynamicSizeFactor.factor())
+                .padding(.bottom, 70 * DynamicSizeFactor.factor())
 
                 VStack {
                     Spacer()

--- a/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/LoginView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/AuthView/LoginView/LoginView.swift
@@ -7,16 +7,14 @@ struct LoginView: View {
         NavigationAvailable {
             ZStack {
                 VStack {
-                    ScrollView {
-                        InputFormView(loginViewModel: loginViewModel) // Id, Pw 입력 폼
+                    InputFormView(loginViewModel: loginViewModel) // Id, Pw 입력 폼
 
-                        LoginOAuthButtonView()
+                    LoginOAuthButtonView()
 
-                        Spacer().frame(height: 3 * DynamicSizeFactor.factor())
-
-                        AdditionalOptionView()
-                    }
+                    AdditionalOptionView()
                 }
+                .padding(.bottom, 60 * DynamicSizeFactor.factor())
+
                 VStack {
                     Spacer()
                     Button(action: {


### PR DESCRIPTION
## 작업 이유

- 로그인 뷰 패딩 값 수정


<br/>

## 작업 사항

### 1️⃣ 로그인 뷰 패딩 값 수정

- 로그인 뷰의 패딩을 상단에서부터 패딩 값을 주니 15 pro와 같이 큰 기기에서 너무 상단에 붙어보이는 문제가 있었다.

그래서 로그인 뷰를 정중앙에 둔 후 하단 패딩값으로 위치를 잡도록 수정했다.

<img src = "https://github.com/user-attachments/assets/4a299221-ba92-42fc-a6d9-244f21c5570a" width = "350"/>
<img src = "https://github.com/user-attachments/assets/caefbb33-0fd7-4b4f-ae5e-861f4f9d0741" width = "350"/>


### 2️⃣ 로그인 뷰 스크롤 뷰 제거

- 로그인 뷰 스크롤을 막기 위해서 scroll view를 제거하였다.



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

로그인 뷰 높이 수정 헸습니다~

<br/>

## 발견한 이슈
없음