### PR TITLE
🛠️ Stomp heart-beat 헤더 추가

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/DefaultChatStompRepository.swift
@@ -52,7 +52,7 @@ class DefaultChatStompRepository: NSObject, ChatStompRepository {
         let accessToken = KeychainHelper.loadAccessToken() ?? ""
         let deviceName = DeviceInfoManager.getDeviceModelName()
         let deviceId = DeviceInfoManager.getDeviceId()
-        let headers = ["Authorization": "Bearer \(accessToken)", "device-id": "\(deviceId)", "device-name": "\(deviceName)"]
+        let headers = ["Authorization": "Bearer \(accessToken)", "device-id": "\(deviceId)", "device-name": "\(deviceName)", "heart-beat": "0,25000"] // heart-beat 25초
         
         let request = NSURLRequest(url: URL(string: url)!)
         


### PR DESCRIPTION
## 작업 이유

- heart-beat 헤더 추가

<br/>

## 작업 사항

### 1️⃣ heart-beat 헤더 추가

WebSocket에 연결하고 난 뒤 몇초뒤면 자꾸 연결이 끊기는 문제가 있었다.
이걸 해결하기 위해 heart-beat를 넣어 연결이 끊어졌는지 여부를 확인하기 위해 주기적으로 패킷을 보내도록 한다.

heart-beat는 ms이기 때문에 25000로 설정해서 25초마다 서버가 클라이언트로 heart-beat를 보내도록 한다.
그럼 연결이 끊겼는지 판단해서 재연결을 시도하게 되므로 연결이 끊기는 문제는 해결된다.

```swift
let headers = ["heart-beat": "0,25000"] // heart-beat 25초
stompClient.openSocketWithURLRequest(request: request, delegate: self, connectionHeaders: headers)
```



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

연결 끊기는 문제 heart-beat헤더를 넣어서 해결했습니다!!
이상있거나 궁금한 점 물어봐주세요~


<br/>

## 발견한 이슈
없음