### PR TITLE
🎨 채팅방 생성 UI 수정 및 내채팅 검색기능 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		D889F9F62C6484950055D045 /* CheckUnReadNotificationResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D889F9F52C6484950055D045 /* CheckUnReadNotificationResponseDto.swift */; };
 		D889F9F82C64BCC00055D045 /* DeleteProfileImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D889F9F72C64BCC00055D045 /* DeleteProfileImageViewModel.swift */; };
 		D889F9FC2C652CB50055D045 /* BasicButtonStyleUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D889F9FB2C652CB50055D045 /* BasicButtonStyleUtil.swift */; };
+		D89263282CD3AD080057AAD6 /* GetChatRoomResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89263272CD3AD080057AAD6 /* GetChatRoomResponseDto.swift */; };
 		D898E8182CA5A8C9003739F1 /* LogoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D898E8172CA5A8C9003739F1 /* LogoutViewModel.swift */; };
 		D89FB7822BD97A2F0019DE3C /* FindUserNameResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */; };
 		D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */; };
@@ -799,6 +800,7 @@
 		D889F9F52C6484950055D045 /* CheckUnReadNotificationResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUnReadNotificationResponseDto.swift; sourceTree = "<group>"; };
 		D889F9F72C64BCC00055D045 /* DeleteProfileImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteProfileImageViewModel.swift; sourceTree = "<group>"; };
 		D889F9FB2C652CB50055D045 /* BasicButtonStyleUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicButtonStyleUtil.swift; sourceTree = "<group>"; };
+		D89263272CD3AD080057AAD6 /* GetChatRoomResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChatRoomResponseDto.swift; sourceTree = "<group>"; };
 		D898E8172CA5A8C9003739F1 /* LogoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutViewModel.swift; sourceTree = "<group>"; };
 		D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameResponseDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Response/FindUserNameResponseDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameRequestDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Request/FindUserNameRequestDto.swift"; sourceTree = SOURCE_ROOT; };
@@ -2691,6 +2693,7 @@
 			children = (
 				D80C68912CC80BEA00928921 /* GetChatServerResponseDto.swift */,
 				D8DCCF942CBD903400550A8B /* MakeChatRoomResponseDto.swift */,
+				D89263272CD3AD080057AAD6 /* GetChatRoomResponseDto.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -2877,6 +2880,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D89263282CD3AD080057AAD6 /* GetChatRoomResponseDto.swift in Sources */,
 				D8C9AC402BF661A2006D1FCD /* InquiryView.swift in Sources */,
 				4AA13C602C63E2B300D8DEE7 /* ObjectStorageRouter.swift in Sources */,
 				D80C68922CC80BEA00928921 /* GetChatServerResponseDto.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomResponseDto.swift
@@ -1,0 +1,32 @@
+//
+//  GetChatRoomResponseDto.swift
+//  pennyway-client-iOS
+//
+//  Created by 아우신얀 on 10/31/24.
+//
+
+// MARK: - GetChatRoomResponseDto
+
+struct GetChatRoomResponseDto: Codable {
+    let code: String
+    let data: ChatRoomData
+}
+
+// MARK: - ChatRoomData
+
+struct ChatRoomData: Codable {
+    let chatRooms: [ChatRoomDetail]
+}
+
+// MARK: - ChatRoomDetail
+
+struct ChatRoomDetail: Codable {
+    let id: Int64
+    let title: String
+    let description: String
+    let backgroundImageUrl: String
+    let isPrivate: Bool
+    let isAdmin: Bool
+    let participantCount: Int32
+    let createdAt: String?
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/MakeChatRoomResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/MakeChatRoomResponseDto.swift
@@ -5,18 +5,18 @@ import Foundation
 
 struct MakeChatRoomResponseDto: Codable {
     let code: String
-    let data: ChatRoomData
+    let data: MakeChatRoomData
 }
 
-// MARK: - ChatRoomData
+// MARK: - MakeChatRoomData
 
-struct ChatRoomData: Codable {
-    let chatRooms: [ChatRoomDetail]
+struct MakeChatRoomData: Codable {
+    let chatRoom: MakeChatRoomDetail
 }
 
-// MARK: - ChatRoomDetail
+// MARK: - MakeChatRoomDetail
 
-struct ChatRoomDetail: Codable {
+struct MakeChatRoomDetail: Codable {
     let id: Int64
     let title: String
     let description: String

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultGetChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultGetChatRoomRepository.swift
@@ -16,7 +16,7 @@ class DefaultGetChatRoomRepository: GetChatRoomRepository {
             case let .success(data):
                 if let responseData = data {
                     do {
-                        let response = try JSONDecoder().decode(MakeChatRoomResponseDto.self, from: responseData)
+                        let response = try JSONDecoder().decode(GetChatRoomResponseDto.self, from: responseData)
                         // 응답 DTO를 Model로 매핑
                         let chatRooms = response.data.chatRooms.map { chatRoomDetail in
                             let completeBackgroundImageUrl = self.createFullURL(with: self.cdnUrl, pathComponent: chatRoomDetail.backgroundImageUrl)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultMakeChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultMakeChatRoomRepository.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 class DefaultMakeChatRoomRepository: MakeChatRoomRepository {
-    func makeChatRoom(roomData: MakeChatRoomItemModel, completion: @escaping (Result<ChatRoomData, Error>) -> Void) {
+    func makeChatRoom(roomData: MakeChatRoomItemModel, completion: @escaping (Result<MakeChatRoomData, Error>) -> Void) {
         let parserData = parseChatroomUrl(from: roomData.backgroundImageUrl ?? "")
 
         Log.debug("DefaultMakeChatRoomRepository: title: \(roomData.title), description: \(roomData.description), password: \(roomData.password), backgroundImageUrl: \(parserData)")

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/MakeChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/MakeChatRoomRepository.swift
@@ -4,5 +4,5 @@ import Foundation
 /// 채팅방 생성 동작을 정의하는 프로토콜
 protocol MakeChatRoomRepository {
     /// 채팅방 생성하는 함수
-    func makeChatRoom(roomData: MakeChatRoomItemModel, completion: @escaping (Result<ChatRoomData, Error>) -> Void)
+    func makeChatRoom(roomData: MakeChatRoomItemModel, completion: @escaping (Result<MakeChatRoomData, Error>) -> Void)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -19,7 +19,6 @@ struct ChatRoomContent: View {
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
-//            .padding(.horizontal, 20)
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -11,7 +11,7 @@ struct ChatRoomContent: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 12) {
-                ForEach(dummyChatRooms, id: \.title) { chatRoom in
+                ForEach(dummyChatRooms, id: \.id) { chatRoom in
                     ChatRoomCell(chatRoom: chatRoom, isMyChat: isMyChat, onDelete: {
                         isPopUp = true
                         selectedChatRoom = chatRoom
@@ -19,7 +19,7 @@ struct ChatRoomContent: View {
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
-            .padding(.horizontal, 20)
+//            .padding(.horizontal, 20)
         }
     }
 }
@@ -135,6 +135,8 @@ struct ChatRoomCell: View {
                 }
             }
             .padding(.vertical, 8)
+            .padding(.horizontal, 20)
+
             .frame(maxWidth: .infinity, maxHeight: 60 * DynamicSizeFactor.factor())
             .background(Color.white)
             .offset(x: offset)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
@@ -51,6 +51,14 @@ struct ChatCellView: View {
                     }
                 }
                 
+                if isCheckMarkVisible {
+                    Image("icon_illust_completion")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
+                        .zIndex(1)
+                }
+                
                 if isPopUp, let chatRoom = selectedChatRoom {
                     CustomPopUpView(
                         showingPopUp: $isPopUp,
@@ -67,13 +75,6 @@ struct ChatCellView: View {
                         secondBtnColor: Color("Red03"))
                 }
                 
-                if isCheckMarkVisible {
-                    Image("icon_illust_completion")
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 68 * DynamicSizeFactor.factor(), height: 68 * DynamicSizeFactor.factor())
-                        .zIndex(1)
-                }
                 NavigationLink(destination: MakeChatRoomView(chatViewModelWrapper: viewModelWrapper), isActive: $isNavigateToMakeChatRoom) {}
                     .hidden()
             }
@@ -227,7 +228,6 @@ final class ChatViewModelWrapper: ObservableObject {
         
         chatData = getChatRoomViewModel.roomData.value
         
-        // Observable을 통해 userData 변화를 감지하고 업데이트
         getChatRoomViewModel.roomData.observe(on: self) { [weak self] newData in
             self?.chatData = newData
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
@@ -12,13 +12,13 @@ struct ChatCellView: View {
     @EnvironmentObject var viewStateManager: ViewStateManager
     @ObservedObject var viewModelWrapper: ChatViewModelWrapper
     private let maxLength = 19
-
+    
     var body: some View {
         NavigationAvailable {
             ZStack {
                 VStack {
                     Spacer().frame(height: 38 * DynamicSizeFactor.factor())
-
+                    
                     HStack(spacing: 30) {
                         Button(action: {
                             selectedTab = 1
@@ -31,9 +31,9 @@ struct ChatCellView: View {
                             RecommendChatContainer
                         })
                     }
-
+                    
                     Spacer().frame(height: 28 * DynamicSizeFactor.factor())
-
+                    
                     // 내 채팅에서 채팅방의 존재 유무에 따라 다른 뷰를 보여주도록 함
                     if selectedTab == 1 {
                         if viewModelWrapper.chatData.isEmpty {
@@ -47,10 +47,10 @@ struct ChatCellView: View {
                         searchChatContainer
                         Spacer()
                         // TODO: 추천 채팅일 경우엔 검색 api 호출 후 관련 리스트가 보이도록 해야 함
-//                        ChatRoomContent(isPopUp: $isPopUp, selectedChatRoom: $selectedChatRoom, dummyChatRooms: $viewModelWrapper.chatData, isMyChat: false)
+                        //                        ChatRoomContent(isPopUp: $isPopUp, selectedChatRoom: $selectedChatRoom, dummyChatRooms: $viewModelWrapper.chatData, isMyChat: false)
                     }
                 }
-
+                
                 if isPopUp, let chatRoom = selectedChatRoom {
                     CustomPopUpView(
                         showingPopUp: $isPopUp,
@@ -61,12 +61,12 @@ struct ChatCellView: View {
                         secondBtnAction: {
                             self.isPopUp = false // 팝업 닫기
                             showCheckMarkAnimation(chatRoom)
-
+                            
                         },
                         secondBtnLabel: "나가기",
                         secondBtnColor: Color("Red03"))
                 }
-
+                
                 if isCheckMarkVisible {
                     Image("icon_illust_completion")
                         .resizable()
@@ -98,8 +98,10 @@ struct ChatCellView: View {
             }
             .onAppear {
                 // 뷰에 진입하자마자 내채팅 조회 api 호출
+                
                 viewModelWrapper.getChatRoomViewModel.getChatRoom()
                 viewStateManager.setCurrentView(self, selectedTab: selectedTab)
+                
                 // 검색어 초기화하여 전체 목록 표시
                 viewModelWrapper.searchQuery = ""
                 chatRoomName = ""
@@ -109,28 +111,28 @@ struct ChatCellView: View {
             }
         }
     }
-
+    
     private func showCheckMarkAnimation(_ chatRoom: ChatRoomItemModel) {
         withAnimation {
             isCheckMarkVisible = true
         }
-
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             deleteChatRoom(chatRoom)
             isCheckMarkVisible = false
         }
     }
-
+    
     /// 채팅방 삭제 함수
     private func deleteChatRoom(_ chatRoom: ChatRoomItemModel) {
         viewModelWrapper.getChatRoomViewModel.roomData.value.removeAll { $0.id == chatRoom.id }
     }
-
+    
     private var searchChatContainer: some View {
         VStack {
             CustomInputView(inputText: $chatRoomName, placeholder: "원하는 주제를 찾아보세요", onCommit: {
                 viewModelWrapper.searchQuery = chatRoomName // 엔터 키 입력 시 검색어 업데이트
-
+                
             }, isSecureText: false, showSearchBtn: true)
                 .onChange(of: chatRoomName) { newValue in
                     if newValue.count > maxLength {
@@ -140,7 +142,7 @@ struct ChatCellView: View {
             Spacer().frame(height: 23 * DynamicSizeFactor.factor())
         }
     }
-
+    
     private var MyChatContainer: some View {
         VStack {
             if selectedTab == 1 {
@@ -172,7 +174,7 @@ struct ChatCellView: View {
         }
         .contentShape(Rectangle())
     }
-
+    
     private var RecommendChatContainer: some View {
         VStack {
             if selectedTab == 2 {
@@ -197,7 +199,7 @@ struct ChatCellView: View {
                     .padding(.top, 4)
             }
         }
-        .contentShape(Rectangle()) 
+        .contentShape(Rectangle())
     }
 }
 
@@ -206,10 +208,10 @@ struct ChatCellView: View {
 final class ChatViewModelWrapper: ObservableObject {
     @Published var chatData: [ChatRoomItemModel] = []
     @Published var searchQuery: String = "" // 검색어 추가
-
+    
     var makeChatViewModel: any MakeChatRoomViewModel
     var getChatRoomViewModel: any GetChatRoomViewModel
-
+    
     var filteredChatData: [ChatRoomItemModel] {
         if searchQuery.isEmpty {
             return chatData
@@ -218,13 +220,13 @@ final class ChatViewModelWrapper: ObservableObject {
             return chatData.filter { $0.title.range(of: searchQuery, options: .caseInsensitive) != nil }
         }
     }
-
+    
     init(makeChatViewModel: any MakeChatRoomViewModel, getChatRoomViewModel: any GetChatRoomViewModel) {
         self.makeChatViewModel = makeChatViewModel
         self.getChatRoomViewModel = getChatRoomViewModel
-
+        
         chatData = getChatRoomViewModel.roomData.value
-
+        
         // Observable을 통해 userData 변화를 감지하고 업데이트
         getChatRoomViewModel.roomData.observe(on: self) { [weak self] newData in
             self?.chatData = newData

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ChatCellView: View {
     @State private var selectedTab: Int = 1
     @State private var chatRoomName: String = "" // 수정 예정
-    @State private var isNavigateToMakeChatRoom = false
+    @State var isNavigateToMakeChatRoom = false
     @State private var isCheckMarkVisible = false // 체크 표시를 보여줄지 여부
     @State private var isPopUp = false // 채팅방 나가기 팝업 표시 여부
     @State private var selectedChatRoom: ChatRoomItemModel? = nil // 어떤 채팅방이 선택됐는지의 여부
@@ -47,7 +47,7 @@ struct ChatCellView: View {
                         searchChatContainer
                         Spacer()
                         // TODO: 추천 채팅일 경우엔 검색 api 호출 후 관련 리스트가 보이도록 해야 함
-                        //                        ChatRoomContent(isPopUp: $isPopUp, selectedChatRoom: $selectedChatRoom, dummyChatRooms: $viewModelWrapper.chatData, isMyChat: false)
+                        // ChatRoomContent(isPopUp: $isPopUp, selectedChatRoom: $selectedChatRoom, dummyChatRooms: $viewModelWrapper.chatData, isMyChat: false)
                     }
                 }
                 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
@@ -41,7 +41,7 @@ struct ChatCellView: View {
                             Spacer()
                         } else {
                             searchChatContainer
-                            ChatRoomContent(isPopUp: $isPopUp, selectedChatRoom: $selectedChatRoom, dummyChatRooms: $viewModelWrapper.chatData, isMyChat: true)
+                            ChatRoomContent(isPopUp: $isPopUp, selectedChatRoom: $selectedChatRoom, dummyChatRooms: .constant(viewModelWrapper.filteredChatData), isMyChat: true)
                         }
                     } else {
                         searchChatContainer
@@ -100,6 +100,9 @@ struct ChatCellView: View {
                 // 뷰에 진입하자마자 내채팅 조회 api 호출
                 viewModelWrapper.getChatRoomViewModel.getChatRoom()
                 viewStateManager.setCurrentView(self, selectedTab: selectedTab)
+                // 검색어 초기화하여 전체 목록 표시
+                viewModelWrapper.searchQuery = ""
+                chatRoomName = ""
             }
             .onChange(of: selectedTab) { newSelected in
                 viewStateManager.setCurrentView(self, selectedTab: newSelected)
@@ -125,7 +128,10 @@ struct ChatCellView: View {
 
     private var searchChatContainer: some View {
         VStack {
-            CustomInputView(inputText: $chatRoomName, placeholder: "원하는 주제를 찾아보세요", isSecureText: false, showSearchBtn: true)
+            CustomInputView(inputText: $chatRoomName, placeholder: "원하는 주제를 찾아보세요", onCommit: {
+                viewModelWrapper.searchQuery = chatRoomName // 엔터 키 입력 시 검색어 업데이트
+
+            }, isSecureText: false, showSearchBtn: true)
                 .onChange(of: chatRoomName) { newValue in
                     if newValue.count > maxLength {
                         chatRoomName = String(chatRoomName.suffix(19))
@@ -199,9 +205,19 @@ struct ChatCellView: View {
 
 final class ChatViewModelWrapper: ObservableObject {
     @Published var chatData: [ChatRoomItemModel] = []
+    @Published var searchQuery: String = "" // 검색어 추가
 
     var makeChatViewModel: any MakeChatRoomViewModel
     var getChatRoomViewModel: any GetChatRoomViewModel
+
+    var filteredChatData: [ChatRoomItemModel] {
+        if searchQuery.isEmpty {
+            return chatData
+        } else {
+            // title 속성에 검색어가 포함된 항목만 필터링 (대소문자 구분 없이)
+            return chatData.filter { $0.title.range(of: searchQuery, options: .caseInsensitive) != nil }
+        }
+    }
 
     init(makeChatViewModel: any MakeChatRoomViewModel, getChatRoomViewModel: any GetChatRoomViewModel) {
         self.makeChatViewModel = makeChatViewModel

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
@@ -7,7 +7,7 @@ struct MakeChatRoomView: View {
     @Environment(\.presentationMode) var presentationMode
     @State var roomTitle = "" // 채팅방 제목을 관리하는 함수
     @State var content = "" // 채팅방 설명을 관리하는 변수
-    @State private var isPublic: Bool = false // 토글 상태를 관리하는 변수
+    @State private var isPrivate: Bool = false // 토글 상태를 관리하는 변수
     @State var password = "" // 비밀번호 입력을 관리하는 변수
     @State private var showPopUpView = false // 사진 선택 팝업 표시여부를 관리하는 변수
     @State private var selectedUIImage: UIImage? // 이미지에서 선택된 이미지의 상태를 관리하는 변수
@@ -34,6 +34,8 @@ struct MakeChatRoomView: View {
                                 }
                                 chatViewModelWrapper.makeChatViewModel.roomData.value.title = newValue
                                 chatViewModelWrapper.makeChatViewModel.validateForm()
+                                Log.debug("title: \(roomTitle)")
+                                Log.debug("vmtitle: \(chatViewModelWrapper.makeChatViewModel.roomData.value.title)")
                             }
 
                         Spacer().frame(height: 23 * DynamicSizeFactor.factor())
@@ -99,9 +101,15 @@ struct MakeChatRoomView: View {
                 Log.debug("onChange실행중")
 
                 if isDismissed {
-                    self.presentationMode.wrappedValue.dismiss()
+                    DispatchQueue.main.async {
+                        self.presentationMode.wrappedValue.dismiss() // 강제로 dismiss 호출
+                    }
                     Log.debug("isDismissed")
                 }
+            }
+            .onAppear {
+                chatViewModelWrapper.makeChatViewModel.isFormValid = false
+                chatViewModelWrapper.makeChatViewModel.validateForm()
             }
 
             if showPopUpView {
@@ -180,12 +188,24 @@ struct MakeChatRoomView: View {
 
                 Spacer()
 
-                Toggle(isOn: $isPublic) {}
-                    .toggleStyle(CustomToggleStyle(hasAppeared: $isPublic))
+                Toggle(isOn: $isPrivate) {}
+                    .toggleStyle(CustomToggleStyle(hasAppeared: $isPrivate))
+                    .onChange(of: isPrivate) { newValue in
+                        chatViewModelWrapper.makeChatViewModel.isPrivate = newValue
+
+//                        if !newValue {
+//                            // 토글이 바뀔때마다 비밀번호를 초기화 시킴
+//                            chatViewModelWrapper.makeChatViewModel.roomData.value.password = ""
+//                            password = ""
+//                        }
+                        chatViewModelWrapper.makeChatViewModel.validateForm() // 유효성 검사 호출
+                        Log.debug("isPrivate: \(isPrivate)")
+                        Log.debug("??:\(chatViewModelWrapper.makeChatViewModel.isPrivate)")
+                    }
             }
             .padding(.horizontal, 20)
 
-            if isPublic {
+            if isPrivate {
                 Spacer().frame(height: 1)
 
                 CustomInputView(inputText: $password, placeholder: "6자리의 숫자 비밀번호가 필요해요", isSecureText: false)
@@ -200,6 +220,7 @@ struct MakeChatRoomView: View {
                         } else {
                             chatViewModelWrapper.makeChatViewModel.roomData.value.password = "" // 유효하지 않은 경우 초기화
                         }
+                        chatViewModelWrapper.makeChatViewModel.validateForm() // 유효성 검사 호출
                     }
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 // MARK: - MakeChatRoomView
@@ -13,7 +12,7 @@ struct MakeChatRoomView: View {
     @State private var selectedUIImage: UIImage? // 이미지에서 선택된 이미지의 상태를 관리하는 변수
     @State private var showImagePicker = false
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
-    @State private var isFormValid: Bool = false //뷰모델에서 isFormValid를 받아와 뷰에서 사용하는 변수
+    @State private var isFormValid: Bool = false // 뷰모델에서 isFormValid를 받아와 뷰에서 사용하는 변수
 
     @ObservedObject var chatViewModelWrapper: ChatViewModelWrapper
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
@@ -13,7 +13,6 @@ struct MakeChatRoomView: View {
     @State private var selectedUIImage: UIImage? // 이미지에서 선택된 이미지의 상태를 관리하는 변수
     @State private var showImagePicker = false
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
-
     @ObservedObject var chatViewModelWrapper: ChatViewModelWrapper
 
     let titleCustomTextList: [String] = ["제목*"]
@@ -34,8 +33,6 @@ struct MakeChatRoomView: View {
                                 }
                                 chatViewModelWrapper.makeChatViewModel.roomData.value.title = newValue
                                 chatViewModelWrapper.makeChatViewModel.validateForm()
-                                Log.debug("title: \(roomTitle)")
-                                Log.debug("vmtitle: \(chatViewModelWrapper.makeChatViewModel.roomData.value.title)")
                             }
 
                         Spacer().frame(height: 23 * DynamicSizeFactor.factor())
@@ -63,7 +60,13 @@ struct MakeChatRoomView: View {
                     let chatRoomData = MakeChatRoomItemModel(title: roomTitle, description: content, password: password)
 
                     if chatViewModelWrapper.makeChatViewModel.isFormValid {
-                        chatViewModelWrapper.makeChatViewModel.makeChatRoom()
+                        chatViewModelWrapper.makeChatViewModel.makeChatRoom { success in
+                            if success {
+                                self.presentationMode.wrappedValue.dismiss()
+                            } else {
+                                Log.debug("[MakeChatRoomView] 현재 창 닫기는 로직 에러")
+                            }
+                        }
                     }
 
                 }, label: "채팅방 생성", isFormValid: $chatViewModelWrapper.makeChatViewModel.isFormValid)
@@ -96,16 +99,6 @@ struct MakeChatRoomView: View {
             }) {
                 ImagePicker(image: $selectedUIImage, isActive: $showImagePicker, sourceType: sourceType)
                     .edgesIgnoringSafeArea(.bottom)
-            }
-            .onChange(of: chatViewModelWrapper.makeChatViewModel.isDismissView) { isDismissed in
-                Log.debug("onChange실행중")
-
-                if isDismissed {
-                    DispatchQueue.main.async {
-                        self.presentationMode.wrappedValue.dismiss() // 강제로 dismiss 호출
-                    }
-                    Log.debug("isDismissed")
-                }
             }
             .onAppear {
                 chatViewModelWrapper.makeChatViewModel.isFormValid = false
@@ -192,15 +185,7 @@ struct MakeChatRoomView: View {
                     .toggleStyle(CustomToggleStyle(hasAppeared: $isPrivate))
                     .onChange(of: isPrivate) { newValue in
                         chatViewModelWrapper.makeChatViewModel.isPrivate = newValue
-
-//                        if !newValue {
-//                            // 토글이 바뀔때마다 비밀번호를 초기화 시킴
-//                            chatViewModelWrapper.makeChatViewModel.roomData.value.password = ""
-//                            password = ""
-//                        }
                         chatViewModelWrapper.makeChatViewModel.validateForm() // 유효성 검사 호출
-                        Log.debug("isPrivate: \(isPrivate)")
-                        Log.debug("??:\(chatViewModelWrapper.makeChatViewModel.isPrivate)")
                     }
             }
             .padding(.horizontal, 20)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/View/MakeChatRoomView.swift
@@ -13,6 +13,8 @@ struct MakeChatRoomView: View {
     @State private var selectedUIImage: UIImage? // 이미지에서 선택된 이미지의 상태를 관리하는 변수
     @State private var showImagePicker = false
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
+    @State private var isFormValid: Bool = false //뷰모델에서 isFormValid를 받아와 뷰에서 사용하는 변수
+
     @ObservedObject var chatViewModelWrapper: ChatViewModelWrapper
 
     let titleCustomTextList: [String] = ["제목*"]
@@ -69,7 +71,7 @@ struct MakeChatRoomView: View {
                         }
                     }
 
-                }, label: "채팅방 생성", isFormValid: $chatViewModelWrapper.makeChatViewModel.isFormValid)
+                }, label: "채팅방 생성", isFormValid: $isFormValid)
                     .padding(.bottom, 34 * DynamicSizeFactor.factor())
             }
             .setTabBarVisibility(isHidden: true)
@@ -101,8 +103,13 @@ struct MakeChatRoomView: View {
                     .edgesIgnoringSafeArea(.bottom)
             }
             .onAppear {
-                chatViewModelWrapper.makeChatViewModel.isFormValid = false
+                isFormValid = false
                 chatViewModelWrapper.makeChatViewModel.validateForm()
+                chatViewModelWrapper.makeChatViewModel.isFormValid = false
+                Log.debug("????/:\(chatViewModelWrapper.makeChatViewModel.isFormValid)")
+            }
+            .onChange(of: chatViewModelWrapper.makeChatViewModel.isFormValid) { newValue in
+                isFormValid = newValue
             }
 
             if showPopUpView {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/ViewModel/MakeChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/ViewModel/MakeChatRoomViewModel.swift
@@ -16,6 +16,7 @@ protocol MakeChatRoomViewModelOutput {
     var roomData: Observable<MakeChatRoomItemModel> { get set }
     var isFormValid: Bool { get set }
     var isDismissView: Bool { get set }
+    var isPrivate: Bool { get set }
 }
 
 // MARK: - MakeChatRoomViewModel
@@ -27,6 +28,7 @@ protocol MakeChatRoomViewModel: MakeChatRoomViewModelInput, MakeChatRoomViewMode
 class DefaultMakeChatRoomViewModel: MakeChatRoomViewModel {
     @Published var isFormValid: Bool = false // 버튼 활성화 여부
     @Published var isDismissView: Bool = false // 뷰를 닫는 상태 여부
+    @Published var isPrivate: Bool = false // 공개 범위 설정 상태
     var roomData: Observable<MakeChatRoomItemModel>
 
     private let makeChatRoomUseCase: MakeChatRoomUseCase
@@ -48,7 +50,16 @@ class DefaultMakeChatRoomViewModel: MakeChatRoomViewModel {
     /// 제목의 유효성 검사 메서드
     func validateForm() {
         let title = roomData.value.title
-        isFormValid = !title.isEmpty && title.count <= 30
+        let isTitleValid = !title.isEmpty && title.count <= 30
+        let isPasswordValid = roomData.value.password.count == 6
+        // 1. 제목이 유효하고
+        // 2-1. 비공개방이 아니거나(isPrivate = false)
+        // 2-2. 비공개방이면서(isPrivate = true) 비밀번호가 유효한 경우(password.count == 6)
+        if isPrivate {
+            isFormValid = isTitleValid && isPasswordValid
+        } else {
+            isFormValid = isTitleValid
+        }
     }
 
     /// Presigned URL 생성
@@ -71,15 +82,15 @@ class DefaultMakeChatRoomViewModel: MakeChatRoomViewModel {
     /// 채팅방 생성 확정 요청
     func makeChatRoom() {
         makeChatRoomUseCase.makeChatRoom(roomData: roomData.value) { [weak self] success in
-            guard let self = self else {
-                return
-            }
+//            guard let self = self else {
+//                return
+//            }
 
             DispatchQueue.main.async {
                 if success {
                     Log.debug("[MakeChatRoomViewModel]: 채팅방 생성 확정 성공")
-                    self.isDismissView = true // 값이 변경되는지 확인
-                    Log.debug("isDismissView = \(self.isDismissView)")
+                    self?.isDismissView = true // 값이 변경되는지 확인
+                    Log.debug("isDismissView = \(self?.isDismissView)")
                 } else {
                     Log.debug("[MakeChatRoomViewModel]: 채팅방 생성 확정 실패")
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/ViewModel/MakeChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MakeChatRoom/ViewModel/MakeChatRoomViewModel.swift
@@ -1,4 +1,4 @@
-
+import Combine
 import Foundation
 import UIKit
 
@@ -7,7 +7,7 @@ import UIKit
 protocol MakeChatRoomViewModelInput {
     func validateForm()
     func uploadImage(image: UIImage)
-    func makeChatRoom()
+    func makeChatRoom(completion: @escaping (Bool) -> Void)
 }
 
 // MARK: - MakeChatRoomViewModelOutput
@@ -25,7 +25,7 @@ protocol MakeChatRoomViewModel: MakeChatRoomViewModelInput, MakeChatRoomViewMode
 
 // MARK: - DefaultMakeChatRoomViewModel
 
-class DefaultMakeChatRoomViewModel: MakeChatRoomViewModel {
+class DefaultMakeChatRoomViewModel: MakeChatRoomViewModel, ObservableObject {
     @Published var isFormValid: Bool = false // 버튼 활성화 여부
     @Published var isDismissView: Bool = false // 뷰를 닫는 상태 여부
     @Published var isPrivate: Bool = false // 공개 범위 설정 상태
@@ -80,19 +80,17 @@ class DefaultMakeChatRoomViewModel: MakeChatRoomViewModel {
     }
 
     /// 채팅방 생성 확정 요청
-    func makeChatRoom() {
+    func makeChatRoom(completion: @escaping (Bool) -> Void) {
         makeChatRoomUseCase.makeChatRoom(roomData: roomData.value) { [weak self] success in
-//            guard let self = self else {
-//                return
-//            }
-
-            DispatchQueue.main.async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 if success {
                     Log.debug("[MakeChatRoomViewModel]: 채팅방 생성 확정 성공")
                     self?.isDismissView = true // 값이 변경되는지 확인
                     Log.debug("isDismissView = \(self?.isDismissView)")
+                    completion(true)
                 } else {
                     Log.debug("[MakeChatRoomViewModel]: 채팅방 생성 확정 실패")
+                    completion(false)
                 }
             }
         }


### PR DESCRIPTION
## 작업 이유
- 채팅방 생성뷰에서 유효성 검사
- 채팅방 생성 완료시 바로 이전뷰 호출
- 내채팅 검색 기능 구현

<br/>

## 작업 사항
### **1️⃣ 채팅방 생성뷰에서 유효성 검사*
채팅방 생성 뷰에서 하단 채팅방 생성 버튼이 활성화되는 조건은 아래와 같다.
```
1. 채팅방 제목만 입력했을 경우  -> isFormValid = true
2. 채팅방과 토글이 활성화 됐을 경우 
   2-1 토글이 활성화 됐는데 비밀번호가 입력되지 않은 경우 -> isFormValid = false
   2-2 토글이 활성화 됐는데 비밀번호가 정수6자리를 만족하는 경우 -> isFormValid = true
3. 토글만 활성화 할 경우 -> isFormValid = false
``` 
위에 조건을 만족하기 위해 뷰모델에서 validateForm을 조건에 따라 구현하였다. 위에 조건을 토대로 isFormValid가 활성화되면 채팅방 생성이 가능하도록 하였는데 문제는 채팅방 생성 완료 -> 뒤로가기 해서 전체 채팅 조회 -> 다시 채팅방 생성에 진입했을 경우 isFormValid가 로그에는 false라고 찍혀있지만 제목과 토글을 모두 활성화 하지 않았음에도 불구하고 isFormValid가 활성화되어 있는 문제를 파악했다
(아마 Published로 선언한게 즉각적으로 뷰에 반영이 되지 않는 듯 하다..)

**해결방법**
따라서 뷰에서만 관리하는 isFormValid를 따로 생성하여서 onChange를 통해 뷰모델에 있는 isFormValid의 값이 변경되면 뷰에서 관리하는 isFormValid에 값을 넘겨받도록 구현하니 위에 발생한 문제를 해결할 수 있었다
```swift
.onChange(of: chatViewModelWrapper.makeChatViewModel.isFormValid) { newValue in
       isFormValid = newValue
 }
``` 
### **2️⃣ 채팅방 생성 완료시 바로 이전뷰 호출**
이슈가 발생했었던 것 중 하나인 채팅방 생성 완료시 뷰모델에서 isDissmissView를 true값으로 주고, 이 값을 뷰에 넘겨줘서 성공했을 때 창을 닫도록 하는 `self.presentationMode.wrappedValue.dismiss()`를 호출했었는데 반영되지 않는 문제가 있었다
문제 원인을 파악해보고자 로그를 찍어보니 레포지토리-UseCase-ViewModel까지만 실행되고 view에서는 로그조차 찍히지 않는 것을 확인했다.

그래서 뷰모델에서 completion을 통해 true/false값을 뷰에게 넘겨주고, 뷰에서 성공했을때 -> `self.presentationMode.wrappedValue.dismiss()`호출하도록 하니 성공했다!


**1번과 2번의 동작과정**
![Simulator Screen Recording - iPhone 15 - 2024-11-01 at 18 21 45](https://github.com/user-attachments/assets/de9ccc49-8129-449e-8809-39369a0ca952)

### **3️⃣ 내채팅 검색 기능 구현**
ChatViewModelWrapper에서 검색 필터링을 담는 String 변수 searchQuery를 추가하여 searchQuery가 비어있다면 기존 채팅방 셀 전체를 반환하도록 하였고, 비어있지 않다면 ChatData중에 title 속성과 비교하여 검색된 항목이 포함되어 있다면 그걸 필터링 하도록 구현하였다.

**동작과정**
![Simulator Screen Recording - iPhone 15 - 2024-10-31 at 17 17 34](https://github.com/user-attachments/assets/606519fd-c8f2-4865-8447-882dfda948b6)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
UI 수정해야 하는것들이랑 내채팅에서 검색 필터링 하는 부분 구현했습니다!

<br/>

## 발견한 이슈
1️⃣1,2 번 동작과정 보시면 약간 텀이 느리다,, T하나만 입력했을땐 감지를 못하고 두글자 이상부터 입력해야 감지를 한다.. 흠

2️⃣ 셀의 위치에 따라 하단 탭바에 opacity 적용 안됨
채팅방 셀 목록 중에 하단에 존재하는 채팅방들은 나가기를 했을때 전체 뷰에서 opacity가 적용되는데, 상위목록으로 갈 수록 탭바에 opacity가 적용되지 않음 ㅎ

![Simulator Screen Recording - iPhone 15 - 2024-11-01 at 18 49 20](https://github.com/user-attachments/assets/762e3eec-afca-4009-ad64-34e60b49d89b)
