### PR TITLE
📮🎨 채팅 상세 조회 api 연동 및 ui에 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		4A69C1522BE695FF00A27B82 /* FindUserNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A69C1512BE695FF00A27B82 /* FindUserNameViewModel.swift */; };
 		4A69C1562BE69DEA00A27B82 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A69C1552BE69DEA00A27B82 /* Log.swift */; };
 		4A6A9D112C331A9500394771 /* TargetAmountSetCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A9D102C331A9500394771 /* TargetAmountSetCompleteView.swift */; };
+		4A6AF72E2CDBE6EC0091CE77 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6AF72D2CDBE6EC0091CE77 /* ImageLoader.swift */; };
 		4A6C79D22C46310B009463E4 /* EditProfileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C79D12C46310B009463E4 /* EditProfileListView.swift */; };
 		4A6C79D42C463C0B009463E4 /* CustomRectangleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C79D32C463C0B009463E4 /* CustomRectangleButton.swift */; };
 		4A6C79D62C463DB1009463E4 /* EditIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C79D52C463DB1009463E4 /* EditIdView.swift */; };
@@ -607,6 +608,7 @@
 		4A69C1512BE695FF00A27B82 /* FindUserNameViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindUserNameViewModel.swift; sourceTree = "<group>"; };
 		4A69C1552BE69DEA00A27B82 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		4A6A9D102C331A9500394771 /* TargetAmountSetCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAmountSetCompleteView.swift; sourceTree = "<group>"; };
+		4A6AF72D2CDBE6EC0091CE77 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		4A6C79D12C46310B009463E4 /* EditProfileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileListView.swift; sourceTree = "<group>"; };
 		4A6C79D32C463C0B009463E4 /* CustomRectangleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRectangleButton.swift; sourceTree = "<group>"; };
 		4A6C79D52C463DB1009463E4 /* EditIdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIdView.swift; sourceTree = "<group>"; };
@@ -1353,6 +1355,7 @@
 				4A12FF1A2C9C4D7600DE10BC /* Extensions */,
 				4A12FF182C9C4D4600DE10BC /* Observable.swift */,
 				4A863A132CB461BE00BA2F2F /* TextHeightPreference.swift */,
+				4A6AF72D2CDBE6EC0091CE77 /* ImageLoader.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3259,6 +3262,7 @@
 				4AD824792C7626C400AEF371 /* LayoutView.swift in Sources */,
 				4AC320452C11D5AC00DDB4B6 /* SelectSpendingDayView.swift in Sources */,
 				4A6E62D62BA5F7FC00111246 /* PhoneVerificationContentView.swift in Sources */,
+				4A6AF72E2CDBE6EC0091CE77 /* ImageLoader.swift in Sources */,
 				4AE9B3422CB6E5A00044D3E1 /* SideMenuCell.swift in Sources */,
 				4AD824752C76263B00AEF371 /* NetworkMonitor.swift in Sources */,
 				D85927EE2BE6842A00653391 /* CustomPopUpView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -106,10 +106,8 @@
 		4A3DE21A2C3EF64000817589 /* GetCategorySpendingHistoryRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3DE2192C3EF64000817589 /* GetCategorySpendingHistoryRequestDto.swift */; };
 		4A3DE21C2C3EFC5B00817589 /* getCategorySpendingHistoryResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3DE21B2C3EFC5B00817589 /* getCategorySpendingHistoryResponseDto.swift */; };
 		4A3DE21E2C3EFCCC00817589 /* SpendingResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3DE21D2C3EFCCC00817589 /* SpendingResponseDto.swift */; };
-		4A45A1992CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A19A2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A19B2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		4A45A19D2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A19E2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A1A72CCBF9B700D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A1AB2CCBF9B700D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -193,7 +191,7 @@
 		4A762B072B99A262001C1188 /* TokenHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B062B99A262001C1188 /* TokenHandler.swift */; };
 		4A762B092B99A26C001C1188 /* TextExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B082B99A26C001C1188 /* TextExtensions.swift */; };
 		4A762B0B2B99A27A001C1188 /* NavigationAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */; };
-		4A8523EA2CB5297100AE90AF /* ChatDateHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8523E92CB5297100AE90AF /* ChatDateHeader.swift */; };
+		4A8523EA2CB5297100AE90AF /* ChatHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8523E92CB5297100AE90AF /* ChatHeader.swift */; };
 		4A8523ED2CB5A8AE00AE90AF /* ChatRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8523EC2CB5A8AE00AE90AF /* ChatRoom.swift */; };
 		4A8523EF2CB5A8C200AE90AF /* ChatMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8523EE2CB5A8C200AE90AF /* ChatMember.swift */; };
 		4A8571342BC650FA0082CE47 /* BaseUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8571322BC650FA0082CE47 /* BaseUrl.swift */; };
@@ -347,7 +345,6 @@
 		D8180C042BE5081F00F837FB /* FindIdContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8180C032BE5081F00F837FB /* FindIdContentView.swift */; };
 		D8180C062BE5083500F837FB /* FindIdPhoneVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8180C052BE5083500F837FB /* FindIdPhoneVerificationView.swift */; };
 		D8180C082BE5168800F837FB /* (null) in Sources */ = {isa = PBXBuildFile; };
-		D8180C0A2BE531C500F837FB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		D81D5A832C16B68D008E5939 /* DateFormatterUtil .swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D5A822C16B68D008E5939 /* DateFormatterUtil .swift */; };
 		D820675C2CC5500700102356 /* OSLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D820675B2CC5500700102356 /* OSLog.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		D82E30572C5B3FB4004244F1 /* EditUsernameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82E30562C5B3FB4004244F1 /* EditUsernameView.swift */; };
@@ -634,7 +631,7 @@
 		4A762B062B99A262001C1188 /* TokenHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHandler.swift; sourceTree = "<group>"; };
 		4A762B082B99A26C001C1188 /* TextExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExtensions.swift; sourceTree = "<group>"; };
 		4A762B0A2B99A27A001C1188 /* NavigationAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationAvailable.swift; sourceTree = "<group>"; };
-		4A8523E92CB5297100AE90AF /* ChatDateHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDateHeader.swift; sourceTree = "<group>"; };
+		4A8523E92CB5297100AE90AF /* ChatHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHeader.swift; sourceTree = "<group>"; };
 		4A8523EC2CB5A8AE00AE90AF /* ChatRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoom.swift; sourceTree = "<group>"; };
 		4A8523EE2CB5A8C200AE90AF /* ChatMember.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMember.swift; sourceTree = "<group>"; };
 		4A8571322BC650FA0082CE47 /* BaseUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseUrl.swift; sourceTree = "<group>"; };
@@ -2000,7 +1997,7 @@
 				4A863A082CB44D9D00BA2F2F /* ChatSendCell.swift */,
 				4A863A0A2CB44FAF00BA2F2F /* ChatBottomBar.swift */,
 				4A863A0C2CB4585300BA2F2F /* ChatContent.swift */,
-				4A8523E92CB5297100AE90AF /* ChatDateHeader.swift */,
+				4A8523E92CB5297100AE90AF /* ChatHeader.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -3011,7 +3008,7 @@
 				4A863A0B2CB44FAF00BA2F2F /* ChatBottomBar.swift in Sources */,
 				4A6C79D62C463DB1009463E4 /* EditIdView.swift in Sources */,
 				D8F9D7362C593B71005416FC /* PreparedView.swift in Sources */,
-				4A8523EA2CB5297100AE90AF /* ChatDateHeader.swift in Sources */,
+				4A8523EA2CB5297100AE90AF /* ChatHeader.swift in Sources */,
 				D8DCCF802CBD8D5700550A8B /* DeleteImageUseCase.swift in Sources */,
 				4A3701D72C090CD600F0AEBA /* Value.swift in Sources */,
 				4AC320592C11D5D500DDB4B6 /* CustomToastView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomDetailResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomDetailResponseDto.swift
@@ -15,13 +15,19 @@ struct GetChatRoomDetailResponseDto: Codable {
         let chatRoom: GetChatRoomDetail
 
         struct GetChatRoomDetail: Codable {
-            let myInfo: GetChatUserInfo
-            let recentParticipants: [GetChatUserInfo]
-            let otherParticipantIds: [Int64]
+            let myInfo: GetChatMember
+            let recentParticipants: [GetChatMember]
+            let otherParticipants: [GetOtherMember]
             let recentMessages: [GetMessage]
 
-            struct GetChatUserInfo: Codable {
+            struct GetOtherMember: Codable {
                 let id: Int64
+                let name: String
+            }
+
+            struct GetChatMember: Codable {
+                let id: Int64
+                let userId: Int64
                 let name: String
                 let role: Role
                 let notifyEnabled: Bool
@@ -42,23 +48,32 @@ struct GetChatRoomDetailResponseDto: Codable {
 
     static func to(dto: GetChatRoomDetailResponseDto) -> ChatRoomDetailInfo {
         return ChatRoomDetailInfo(
-            myInfo: ChatUserInfo(
+            myInfo: ChatMember(
                 id: dto.data.chatRoom.myInfo.id,
+                userId: dto.data.chatRoom.myInfo.userId,
                 name: dto.data.chatRoom.myInfo.name,
                 role: dto.data.chatRoom.myInfo.role,
                 notifyEnabled: dto.data.chatRoom.myInfo.notifyEnabled,
-                createdAt: dto.data.chatRoom.myInfo.createdAt
+                createdAt: dto.data.chatRoom.myInfo.createdAt, 
+                profileImage: ""
             ),
             recentParticipants: dto.data.chatRoom.recentParticipants.map {
-                ChatUserInfo(
+                ChatMember(
                     id: $0.id,
+                    userId: $0.userId,
                     name: $0.name,
                     role: $0.role,
                     notifyEnabled: $0.notifyEnabled,
-                    createdAt: $0.createdAt
+                    createdAt: $0.createdAt,
+                    profileImage: ""
                 )
             },
-            otherParticipantIds: dto.data.chatRoom.otherParticipantIds,
+            otherParticipants: dto.data.chatRoom.otherParticipants.map {
+                OtherMember(
+                    id: $0.id, 
+                    name: $0.name
+                )
+            },
             recentMessages: dto.data.chatRoom.recentMessages.map {
                 Message(
                     chatRoomId: $0.chatRoomId,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomDetailResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomDetailResponseDto.swift
@@ -30,7 +30,7 @@ struct GetChatRoomDetailResponseDto: Codable {
                 let userId: Int64
                 let name: String
                 let role: Role
-                let notifyEnabled: Bool
+                let notifyEnabled: Bool?
                 let createdAt: String
             }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -35,7 +35,24 @@ class DefaultChatStompRepository: NSObject, ChatStompRepository {
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
-    func sendMessage(message _: String, destination _: String) {}
+    func sendMessage(message: String, destination _: String) {
+        let destination = "/pub/chat.message.\(641_226_760_822_261_524)"
+        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")"]
+        let messageBody: [String: String] = [
+            "content": message,
+            "contentType": "TEXT"
+        ]
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
+                Log.debug("📤 [Send Message])")
+            }
+        } catch {
+            Log.error("Failed to serialize message body: \(error)")
+        }
+    }
 
     /// 특정 목적지로 Stomp 구독을 설정하는 메서드
     func subscribeToDestination(_: String) {}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -35,25 +35,7 @@ class DefaultChatStompRepository: NSObject, ChatStompRepository {
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
-    /// 메시지를 특정 목적지로 보내는 메서드
-    func sendMessage(message: String, destination _: String) {
-        let destination = "/pub/chat.message.\(641_226_760_822_261_524)"
-        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")"]
-        let messageBody: [String: String] = [
-            "content": message,
-            "contentType": "TEXT"
-        ]
-
-        do {
-            let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                Log.debug("📤 [Send Message])")
-            }
-        } catch {
-            Log.error("Failed to serialize message body: \(error)")
-        }
-    }
+    func sendMessage(message: String, destination _: String) {}
 
     /// 특정 목적지로 Stomp 구독을 설정하는 메서드
     func subscribeToDestination(_: String) {}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -35,24 +35,7 @@ class DefaultChatStompRepository: NSObject, ChatStompRepository {
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
-    func sendMessage(message: String, destination _: String) {
-        let destination = "/pub/chat.message.\(641_226_760_822_261_524)"
-        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")"]
-        let messageBody: [String: String] = [
-            "content": message,
-            "contentType": "TEXT"
-        ]
-
-        do {
-            let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                Log.debug("📤 [Send Message])")
-            }
-        } catch {
-            Log.error("Failed to serialize message body: \(error)")
-        }
-    }
+    func sendMessage(message _: String, destination _: String) {}
 
     /// 특정 목적지로 Stomp 구독을 설정하는 메서드
     func subscribeToDestination(_: String) {}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -35,7 +35,25 @@ class DefaultChatStompRepository: NSObject, ChatStompRepository {
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
-    func sendMessage(message _: String, destination _: String) {}
+    /// 메시지를 특정 목적지로 보내는 메서드
+    func sendMessage(message: String, destination _: String) {
+        let destination = "/pub/chat.message.\(641_226_760_822_261_524)"
+        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")"]
+        let messageBody: [String: String] = [
+            "content": message,
+            "contentType": "TEXT"
+        ]
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
+                Log.debug("📤 [Send Message])")
+            }
+        } catch {
+            Log.error("Failed to serialize message body: \(error)")
+        }
+    }
 
     /// 특정 목적지로 Stomp 구독을 설정하는 메서드
     func subscribeToDestination(_: String) {}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatMember.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatMember.swift
@@ -11,9 +11,18 @@ import Foundation
 
 struct ChatMember: Equatable, Identifiable {
     let id: Int64
-    let profile_image: String
-    let username: String
-    let role: String
-    let user_id: Int64
-    let chat_room_id: Int64
+    let userId: Int64
+    let name: String
+    let role: Role
+    let notifyEnabled: Bool
+    let createdAt: String
+    let profileImage: String?
+}
+
+
+// MARK: - OtherMember
+
+struct OtherMember: Equatable, Identifiable {
+    let id: Int64
+    let name: String
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatMember.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatMember.swift
@@ -14,7 +14,7 @@ struct ChatMember: Equatable, Identifiable {
     let userId: Int64
     let name: String
     let role: Role
-    let notifyEnabled: Bool
+    let notifyEnabled: Bool?
     let createdAt: String
     let profileImage: String?
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatMember.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatMember.swift
@@ -19,7 +19,6 @@ struct ChatMember: Equatable, Identifiable {
     let profileImage: String?
 }
 
-
 // MARK: - OtherMember
 
 struct OtherMember: Equatable, Identifiable {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatRoomDetailInfo.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatRoomDetailInfo.swift
@@ -10,18 +10,8 @@ import Foundation
 // MARK: - ChatRoomDetailInfo
 
 struct ChatRoomDetailInfo: Equatable {
-    let myInfo: ChatUserInfo // 내 정보
-    let recentParticipants: [ChatUserInfo] // 최근에 메시지를 보낸 사용자
-    let otherParticipantIds: [Int64] // 최근에 메시지를 보내지 않았지만 단톡방에 속해있는 사용자
+    let myInfo: ChatMember // 내 정보
+    let recentParticipants: [ChatMember] // 최근에 메시지를 보낸 사용자
+    let otherParticipants: [OtherMember] // 최근에 메시지를 보내지 않았지만 단톡방에 속해있는 사용자
     let recentMessages: [Message] // 최근 메시지 내용 15개
-}
-
-// MARK: - ChatUserInfo
-
-struct ChatUserInfo: Equatable {
-    let id: Int64
-    let name: String
-    let role: Role
-    let notifyEnabled: Bool
-    let createdAt: String
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -46,6 +46,8 @@ struct ChatBottomBar: View {
         return counter
     }
 
+    private let chatStompService = DefaultChatStompService.shared
+
     var body: some View {
         VStack {
             Spacer().frame(height: 11 * DynamicSizeFactor.factor())
@@ -119,6 +121,7 @@ struct ChatBottomBar: View {
             Spacer()
             if !message.isEmpty {
                 Button(action: {
+                    chatStompService.sendMessage(message: message, destination: "")
                     Log.debug("Message sent: \(message)")
                     message = ""
                 }) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -23,6 +23,7 @@ struct ChatBottomBar: View {
         message.components(separatedBy: "\n").count
     }
 
+    private let chatStompService = DefaultChatStompService.shared
     /// 텍스트 자동 줄바꿈으로 인한 줄 수 계산
     private var autoLineCount: Int {
         var counter: Int = 0
@@ -119,6 +120,7 @@ struct ChatBottomBar: View {
             Spacer()
             if !message.isEmpty {
                 Button(action: {
+                    chatStompService.sendMessage(message: message, destination: "")
                     Log.debug("Message sent: \(message)")
                     message = ""
                 }) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -46,8 +46,6 @@ struct ChatBottomBar: View {
         return counter
     }
 
-    private let chatStompService = DefaultChatStompService.shared
-
     var body: some View {
         VStack {
             Spacer().frame(height: 11 * DynamicSizeFactor.factor())
@@ -121,7 +119,6 @@ struct ChatBottomBar: View {
             Spacer()
             if !message.isEmpty {
                 Button(action: {
-                    chatStompService.sendMessage(message: message, destination: "")
                     Log.debug("Message sent: \(message)")
                     message = ""
                 }) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -23,7 +23,6 @@ struct ChatBottomBar: View {
         message.components(separatedBy: "\n").count
     }
 
-    private let chatStompService = DefaultChatStompService.shared
     /// 텍스트 자동 줄바꿈으로 인한 줄 수 계산
     private var autoLineCount: Int {
         var counter: Int = 0
@@ -120,7 +119,6 @@ struct ChatBottomBar: View {
             Spacer()
             if !message.isEmpty {
                 Button(action: {
-                    chatStompService.sendMessage(message: message, destination: "")
                     Log.debug("Message sent: \(message)")
                     message = ""
                 }) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -25,7 +25,7 @@ struct ChatContent: View {
                             Spacer().frame(height: 5 * DynamicSizeFactor.factor())
 
                             ForEach(groupedChatsByDate[date] ?? []) { chat in
-                                if let sender = members.first(where: { $0.user_id == chat.senderId }) {
+                                if let sender = members.first(where: { $0.userId == chat.senderId }) {
                                     if chat.senderId == currentUserId {
                                         ChatSendCell(chat: chat, sender: sender)
                                     } else {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -21,8 +21,8 @@ struct ChatContent: View {
                 LazyVStack(spacing: 14 * DynamicSizeFactor.factor()) {
                     ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
-                        Section(header: ChatDateHeader(date: date)) {
-                            Spacer().frame(height: 5 * DynamicSizeFactor.factor())
+                        Section(header: ChatHeader(data: date)) {
+                            Spacer().frame(height: 3)
 
                             ForEach(groupedChatsByDate[date] ?? []) { chat in
                                 if let sender = members.first(where: { $0.userId == chat.senderId }) {
@@ -30,6 +30,12 @@ struct ChatContent: View {
                                         ChatSendCell(chat: chat, sender: sender)
                                     } else {
                                         ChatReceiveCell(chat: chat, sender: sender)
+                                    }
+                                } else {
+                                    Spacer().frame(height: 3)
+
+                                    if chat.categoryType == CategoryType.system {
+                                        ChatHeader(data: chat.content)
                                     }
                                 }
                             }
@@ -54,11 +60,14 @@ struct ChatContent: View {
 
     private var groupedChatsByDate: [String: [MessageItemModel]] {
         let formatter = Date.chatDateFormatter()
-        return Dictionary(grouping: chats) { chat -> String in
+        let grouped = Dictionary(grouping: chats) { chat -> String in
             if let date = DateFormatterUtil.dateFromString(chat.createdAt) {
                 return formatter.string(from: date)
             }
             return ""
         }
+
+        // 각 날짜별 메시지 배열을 오래된순으로 저장
+        return grouped.mapValues { $0.reversed() }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ChatContent: View {
     let chats: [MessageItemModel]
-    let members: [ChatMember]
+    let members: [ChatMemberItemModel]
     let currentUserId: Int64
 
     @State private var scrollToBottom: Bool = false

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatHeader.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatHeader.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-struct ChatDateHeader: View {
-    let date: String
+struct ChatHeader: View {
+    let data: String
 
     var body: some View {
         ZStack {
@@ -17,7 +17,7 @@ struct ChatDateHeader: View {
                 .cornerRadius(19)
                 .frame(width: 106 * DynamicSizeFactor.factor(), height: 21 * DynamicSizeFactor.factor())
 
-            Text(date)
+            Text(data)
                 .font(.B3MediumFont())
                 .platformTextColor(color: Color("Gray05"))
                 .padding(.vertical, 6)
@@ -27,5 +27,5 @@ struct ChatDateHeader: View {
 }
 
 #Preview {
-    ChatDateHeader(date: "2020년 8월 21일 금요일")
+    ChatHeader(data: "2020년 8월 21일 금요일")
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
@@ -42,7 +42,7 @@ struct ChatMessage: View {
             .onPreferenceChange(TextWidthPreferenceKey.self) { width in
                 self.textWidth = width
             }
-            .frame(minWidth: textWidth, maxWidth: maxWidth)
+            .frame(minWidth: textWidth)
             .fixedSize(horizontal: false, vertical: true)
 
             if !isSender {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
@@ -10,6 +10,7 @@ import SwiftUI
 // MARK: - ChatReceiveCell
 
 struct ChatReceiveCell: View {
+    @State private var loadedImage: UIImage? = nil
     let chat: MessageItemModel
     let sender: ChatMemberItemModel
 
@@ -17,16 +18,20 @@ struct ChatReceiveCell: View {
         HStack(alignment: .top, spacing: 11 * DynamicSizeFactor.factor()) {
             // 프로필 이미지
 
-            ZStack {
-                Rectangle()
-                    .platformTextColor(color: Color("White01"))
-                    .frame(width: 27 * DynamicSizeFactor.factor(), height: 27 * DynamicSizeFactor.factor())
-                    .cornerRadius(3)
-                Image("icon_ current_spending")
+            if let image = loadedImage {
+                // 프로필 이미지가 다운로드되었을 때
+                Image(uiImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 27 * DynamicSizeFactor.factor(), height: 27 * DynamicSizeFactor.factor())
-                    .clipped()
+                    .cornerRadius(3)
+            } else {
+                // 이미지가 없을 경우 기본 이미지
+                Image("icon_illust_chat_no picture")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 27 * DynamicSizeFactor.factor(), height: 27 * DynamicSizeFactor.factor())
+                    .cornerRadius(3)
             }
 
             VStack(alignment: .leading, spacing: 5 * DynamicSizeFactor.factor()) {
@@ -41,5 +46,10 @@ struct ChatReceiveCell: View {
             Spacer()
         }
         .padding(.horizontal, 20)
+        .onAppear {
+            ImageLoader.loadImage(from: sender.profileImage ?? "") { loadedImage in
+                self.loadedImage = loadedImage
+            }
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ChatReceiveCell: View {
     let chat: MessageItemModel
-    let sender: ChatMember
+    let sender: ChatMemberItemModel
 
     var body: some View {
         HStack(alignment: .top, spacing: 11 * DynamicSizeFactor.factor()) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
@@ -31,7 +31,7 @@ struct ChatReceiveCell: View {
 
             VStack(alignment: .leading, spacing: 5 * DynamicSizeFactor.factor()) {
                 // 사용자 이름
-                Text(sender.username)
+                Text(sender.name)
                     .font(.B3MediumFont())
                     .platformTextColor(color: Color("Gray06"))
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatSendCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatSendCell.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ChatSendCell: View {
     let chat: MessageItemModel
-    let sender: ChatMember
+    let sender: ChatMemberItemModel
 
     var body: some View {
         ChatMessage(content: chat.content, createdAt: chat.createdAt, isSender: true)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -16,12 +16,13 @@ struct ChatRoomView: View {
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
     var chatRoom: ChatRoomItemModel
+    private let currentUserId = getUserData()!.id
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 GeometryReader { geometry in
-                    ChatContent(chats: viewModelWrapper.messageData, members: mockMembers, currentUserId: 102, keyboardManager: keyboardManager)
+                    ChatContent(chats: viewModelWrapper.messageData, members: viewModelWrapper.chatUserData, currentUserId: currentUserId, keyboardManager: keyboardManager)
                         .frame(height: geometry.size.height - keyboardManager.keyboardHeight) // ChatContent의 높이를 키보드 높이만큼 조정
                 }
 
@@ -125,7 +126,7 @@ let mockChatRoom = ChatRoom(
 let mockMembers: [ChatMember] = [
     ChatMember(
         id: 1,
-        userId: 101,
+        userId: 1,
         name: "바다오리",
         role: .user,
         notifyEnabled: true,
@@ -134,7 +135,7 @@ let mockMembers: [ChatMember] = [
     ),
     ChatMember(
         id: 2,
-        userId: 102,
+        userId: 2,
         name: "고래고래고래",
         role: .admin,
         notifyEnabled: false,
@@ -151,7 +152,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-9-04 19:46:19",
-        senderId: 101
+        senderId: 1
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -160,7 +161,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-9-04 19:46:19",
-        senderId: 102
+        senderId: 2
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -169,7 +170,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-9-04 19:46:19",
-        senderId: 101
+        senderId: 1
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -178,7 +179,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-9-04 19:46:19",
-        senderId: 101
+        senderId: 1
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -187,7 +188,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-10-21 19:46:19",
-        senderId: 102
+        senderId: 2
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -196,7 +197,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-10-21 19:46:19",
-        senderId: 102
+        senderId: 2
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -205,7 +206,7 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-11-5 19:46:19",
-        senderId: 102
+        senderId: 2
     ),
     MessageItemModel(
         chatRoomId: 1,
@@ -214,6 +215,6 @@ let mockChats: [MessageItemModel] = [
         contentType: .text,
         categoryType: .normal,
         createdAt: "2024-11-5 19:46:19",
-        senderId: 101
+        senderId: 1
     ),
 ]

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -15,7 +15,7 @@ struct ChatRoomView: View {
     @EnvironmentObject var viewStateManager: ViewStateManager
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
-    var chatRoom: ChatRoomProtocol
+    var chatRoom: ChatRoomItemModel
     private let currentUserId = getUserData()!.id
 
     var body: some View {
@@ -85,7 +85,7 @@ struct ChatRoomView: View {
 // MARK: - ChatRoomViewModelWrapper
 
 final class ChatRoomViewModelWrapper: ObservableObject {
-    @Published var roomData: ChatRoomProtocol? = nil
+    @Published var roomData: ChatRoomItemModel? = nil
     @Published var roomDetailData: ChatRoomDetailItemModel? = nil
     @Published var messageData: [MessageItemModel] = []
     @Published var chatUserData: [ChatMemberItemModel] = []
@@ -117,111 +117,3 @@ final class ChatRoomViewModelWrapper: ObservableObject {
         }
     }
 }
-
-// let mockChatRoom = ChatRoom(
-//    id: 1,
-//    title: "SwiftUI Chat Room",
-//    description: "A place to talk about SwiftUI",
-//    background_image_url: "https://example.com/background.jpg",
-//    isPrivate: true,
-//    isAdmin: true,
-//    participantCount: 0,
-//    createdAt: "2024-5-04 19:46:19",
-//    unreadMessageCount: 0
-// )
-//
-// let mockMembers: [ChatMember] = [
-//    ChatMember(
-//        id: 1,
-//        userId: 1,
-//        name: "바다오리",
-//        role: .user,
-//        notifyEnabled: true,
-//        createdAt: "2023-9-04 19:46:19", // 예시 날짜
-//        profileImage: "https://example.com/user1.jpg"
-//    ),
-//    ChatMember(
-//        id: 2,
-//        userId: 2,
-//        name: "고래고래고래",
-//        role: .admin,
-//        notifyEnabled: false,
-//        createdAt: "2023-9-04 19:46:19", // 예시 날짜
-//        profileImage: "https://example.com/user2.jpg"
-//    ),
-// ]
-
-let mockChats: [MessageItemModel] = [
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 1,
-        content: "Hey, how's it going?",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-9-04 19:46:19",
-        senderId: 1
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 2,
-        content: "All good here! How about you?",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-9-04 19:46:19",
-        senderId: 2
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 3,
-        content: "안녕하세요안녕하세요",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-9-04 19:46:19",
-        senderId: 1
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 4,
-        content: "Just working on some SwiftUI stuff.",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-9-04 19:46:19",
-        senderId: 1
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 5,
-        content: "Just working on some SwiftUI stuff.",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-10-21 19:46:19",
-        senderId: 2
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 6,
-        content: "Just working on some SwiftUI stuff.",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-10-21 19:46:19",
-        senderId: 2
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 7,
-        content: "Just working on some SwiftUI stuff.",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-11-5 19:46:19",
-        senderId: 2
-    ),
-    MessageItemModel(
-        chatRoomId: 1,
-        chatId: 8,
-        content: "Just working on some SwiftUI stuff.",
-        contentType: .text,
-        categoryType: .normal,
-        createdAt: "2024-11-5 19:46:19",
-        senderId: 1
-    ),
-]

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -85,7 +85,7 @@ struct ChatRoomView: View {
 final class ChatRoomViewModelWrapper: ObservableObject {
     @Published var roomDetailData: ChatRoomDetailItemModel? = nil
     @Published var messageData: [MessageItemModel] = []
-    @Published var chatUserData: [ChatUserInfoItemModel] = []
+    @Published var chatUserData: [ChatMemberItemModel] = []
 
     var chatRoomViewModel: any ChatRoomViewModel
 
@@ -118,26 +118,28 @@ let mockChatRoom = ChatRoom(
     isPrivate: true,
     isAdmin: true,
     participantCount: 0,
-    createdAt: "2024-10-25T06:09:41.472Z",
+    createdAt: "2024-5-04 19:46:19",
     unreadMessageCount: 0
 )
 
 let mockMembers: [ChatMember] = [
     ChatMember(
         id: 1,
-        profile_image: "https://example.com/user1.jpg",
-        username: "바다오리",
-        role: "Member",
-        user_id: 101,
-        chat_room_id: 1
+        userId: 101,
+        name: "바다오리",
+        role: .user,
+        notifyEnabled: true,
+        createdAt: "2023-9-04 19:46:19", // 예시 날짜
+        profileImage: "https://example.com/user1.jpg"
     ),
     ChatMember(
         id: 2,
-        profile_image: "https://example.com/user2.jpg",
-        username: "고래고래고래",
-        role: "Admin",
-        user_id: 102,
-        chat_room_id: 1
+        userId: 102,
+        name: "고래고래고래",
+        role: .admin,
+        notifyEnabled: false,
+        createdAt: "2023-9-04 19:46:19", // 예시 날짜
+        profileImage: "https://example.com/user2.jpg"
     ),
 ]
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -130,26 +130,26 @@ final class ChatRoomViewModelWrapper: ObservableObject {
 //    unreadMessageCount: 0
 // )
 //
-let mockMembers: [ChatMember] = [
-    ChatMember(
-        id: 1,
-        userId: 1,
-        name: "바다오리",
-        role: .user,
-        notifyEnabled: true,
-        createdAt: "2023-9-04 19:46:19", // 예시 날짜
-        profileImage: "https://example.com/user1.jpg"
-    ),
-    ChatMember(
-        id: 2,
-        userId: 2,
-        name: "고래고래고래",
-        role: .admin,
-        notifyEnabled: false,
-        createdAt: "2023-9-04 19:46:19", // 예시 날짜
-        profileImage: "https://example.com/user2.jpg"
-    ),
-]
+// let mockMembers: [ChatMember] = [
+//    ChatMember(
+//        id: 1,
+//        userId: 1,
+//        name: "바다오리",
+//        role: .user,
+//        notifyEnabled: true,
+//        createdAt: "2023-9-04 19:46:19", // 예시 날짜
+//        profileImage: "https://example.com/user1.jpg"
+//    ),
+//    ChatMember(
+//        id: 2,
+//        userId: 2,
+//        name: "고래고래고래",
+//        role: .admin,
+//        notifyEnabled: false,
+//        createdAt: "2023-9-04 19:46:19", // 예시 날짜
+//        profileImage: "https://example.com/user2.jpg"
+//    ),
+// ]
 
 let mockChats: [MessageItemModel] = [
     MessageItemModel(

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -15,7 +15,7 @@ struct ChatRoomView: View {
     @EnvironmentObject var viewStateManager: ViewStateManager
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
-    var chatRoom: ChatRoomItemModel
+    var chatRoom: ChatRoomProtocol
     private let currentUserId = getUserData()!.id
 
     var body: some View {
@@ -73,6 +73,7 @@ struct ChatRoomView: View {
             )
             .onAppear {
                 viewStateManager.setCurrentView(self)
+                viewModelWrapper.roomData = chatRoom // 현재 채팅방 정보 저장
 
                 // 채팅방 상세 정보 조회
                 viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: chatRoom.id)
@@ -84,6 +85,7 @@ struct ChatRoomView: View {
 // MARK: - ChatRoomViewModelWrapper
 
 final class ChatRoomViewModelWrapper: ObservableObject {
+    @Published var roomData: ChatRoomProtocol? = nil
     @Published var roomDetailData: ChatRoomDetailItemModel? = nil
     @Published var messageData: [MessageItemModel] = []
     @Published var chatUserData: [ChatMemberItemModel] = []
@@ -93,9 +95,14 @@ final class ChatRoomViewModelWrapper: ObservableObject {
     init(chatRoomViewModel: any ChatRoomViewModel) {
         self.chatRoomViewModel = chatRoomViewModel
 
+        roomData = chatRoomViewModel.roomData.value
         roomDetailData = chatRoomViewModel.roomDetailData.value
         messageData = chatRoomViewModel.messageData.value
         chatUserData = chatRoomViewModel.chatUserData.value
+
+        chatRoomViewModel.roomData.observe(on: self) { [weak self] newData in
+            self?.roomData = newData
+        }
 
         chatRoomViewModel.roomDetailData.observe(on: self) { [weak self] newData in
             self?.roomDetailData = newData
@@ -111,18 +118,18 @@ final class ChatRoomViewModelWrapper: ObservableObject {
     }
 }
 
-let mockChatRoom = ChatRoom(
-    id: 1,
-    title: "SwiftUI Chat Room",
-    description: "A place to talk about SwiftUI",
-    background_image_url: "https://example.com/background.jpg",
-    isPrivate: true,
-    isAdmin: true,
-    participantCount: 0,
-    createdAt: "2024-5-04 19:46:19",
-    unreadMessageCount: 0
-)
-
+// let mockChatRoom = ChatRoom(
+//    id: 1,
+//    title: "SwiftUI Chat Room",
+//    description: "A place to talk about SwiftUI",
+//    background_image_url: "https://example.com/background.jpg",
+//    isPrivate: true,
+//    isAdmin: true,
+//    participantCount: 0,
+//    createdAt: "2024-5-04 19:46:19",
+//    unreadMessageCount: 0
+// )
+//
 let mockMembers: [ChatMember] = [
     ChatMember(
         id: 1,

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
@@ -10,30 +10,37 @@ import Foundation
 // MARK: - ChatRoomDetailItemModel
 
 struct ChatRoomDetailItemModel {
-    var myInfo: ChatUserInfoItemModel
-    var recentParticipants: [ChatUserInfoItemModel]
-    var otherParticipantIds: [Int64]
+    var myInfo: ChatMemberItemModel
+    var recentParticipants: [ChatMemberItemModel]
+    var otherParticipants: [OtherMemberItemModel]
     var recentMessages: [MessageItemModel]
 
     static func from(model: ChatRoomDetailInfo) -> ChatRoomDetailItemModel {
         return ChatRoomDetailItemModel(
-            myInfo: ChatUserInfoItemModel(
+            myInfo: ChatMemberItemModel(
                 id: model.myInfo.id,
+                userId: model.myInfo.userId,
                 name: model.myInfo.name,
                 role: model.myInfo.role,
                 notifyEnabled: model.myInfo.notifyEnabled,
                 createdAt: model.myInfo.createdAt
             ),
             recentParticipants: model.recentParticipants.map {
-                ChatUserInfoItemModel(
+                ChatMemberItemModel(
                     id: $0.id,
+                    userId: $0.userId,
                     name: $0.name,
                     role: $0.role,
                     notifyEnabled: $0.notifyEnabled,
                     createdAt: $0.createdAt
                 )
             },
-            otherParticipantIds: model.otherParticipantIds,
+            otherParticipants: model.otherParticipants.map {
+                OtherMemberItemModel(
+                    id: $0.id,
+                    name: $0.name
+                )
+            },
             recentMessages: model.recentMessages.map {
                 MessageItemModel(
                     chatRoomId: $0.chatRoomId,
@@ -49,10 +56,18 @@ struct ChatRoomDetailItemModel {
     }
 }
 
-// MARK: - ChatUserInfoItemModel
+// MARK: - OtherMemberItemModel
 
-struct ChatUserInfoItemModel: Equatable, Identifiable {
+struct OtherMemberItemModel: Equatable, Identifiable {
+    let id: Int64
+    let name: String
+}
+
+// MARK: - ChatMemberItemModel
+
+struct ChatMemberItemModel: Equatable, Identifiable {
     var id: Int64
+    var userId: Int64
     var name: String
     var role: Role
     var notifyEnabled: Bool

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
@@ -77,7 +77,7 @@ struct ChatMemberItemModel: Equatable, Identifiable {
 // MARK: - MessageItemModel
 
 struct MessageItemModel: Equatable, Identifiable {
-    var id: Int64 { chatId } 
+    var id: Int64 { chatId }
     var chatRoomId: Int64
     var chatId: Int64
     var content: String

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
@@ -23,7 +23,8 @@ struct ChatRoomDetailItemModel {
                 name: model.myInfo.name,
                 role: model.myInfo.role,
                 notifyEnabled: model.myInfo.notifyEnabled,
-                createdAt: model.myInfo.createdAt
+                createdAt: model.myInfo.createdAt, 
+                profileImage: model.myInfo.profileImage
             ),
             recentParticipants: model.recentParticipants.map {
                 ChatMemberItemModel(
@@ -32,7 +33,8 @@ struct ChatRoomDetailItemModel {
                     name: $0.name,
                     role: $0.role,
                     notifyEnabled: $0.notifyEnabled,
-                    createdAt: $0.createdAt
+                    createdAt: $0.createdAt, 
+                    profileImage: $0.profileImage
                 )
             },
             otherParticipants: model.otherParticipants.map {
@@ -72,6 +74,7 @@ struct ChatMemberItemModel: Equatable, Identifiable {
     var role: Role
     var notifyEnabled: Bool?
     var createdAt: String
+    let profileImage: String?
 }
 
 // MARK: - MessageItemModel

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomDetailItemModel.swift
@@ -70,7 +70,7 @@ struct ChatMemberItemModel: Equatable, Identifiable {
     var userId: Int64
     var name: String
     var role: Role
-    var notifyEnabled: Bool
+    var notifyEnabled: Bool?
     var createdAt: String
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -16,7 +16,7 @@ protocol ChatRoomViewModelInput {
 // MARK: - ChatRoomViewModelOutput
 
 protocol ChatRoomViewModelOutput {
-    var roomData: Observable<ChatRoomProtocol?> { get set }
+    var roomData: Observable<ChatRoomItemModel?> { get set }
     var roomDetailData: Observable<ChatRoomDetailItemModel?> { get set }
     var messageData: Observable<[MessageItemModel]> { get set }
     var chatUserData: Observable<[ChatMemberItemModel]> { get set }
@@ -29,7 +29,7 @@ protocol ChatRoomViewModel: ChatRoomViewModelInput, ChatRoomViewModelOutput {}
 // MARK: - DefaultChatRoomViewModel
 
 class DefaultChatRoomViewModel: ChatRoomViewModel {
-    var roomData: Observable<ChatRoomProtocol?> = Observable(nil)
+    var roomData: Observable<ChatRoomItemModel?> = Observable(nil)
     var roomDetailData: Observable<ChatRoomDetailItemModel?> = Observable(nil)
     var messageData: Observable<[MessageItemModel]> = Observable([]) // 최근 메시지 목록
     var chatUserData: Observable<[ChatMemberItemModel]> = Observable([]) // 최근 사용자 + 자신

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -16,6 +16,7 @@ protocol ChatRoomViewModelInput {
 // MARK: - ChatRoomViewModelOutput
 
 protocol ChatRoomViewModelOutput {
+    var roomData: Observable<ChatRoomProtocol?> { get set }
     var roomDetailData: Observable<ChatRoomDetailItemModel?> { get set }
     var messageData: Observable<[MessageItemModel]> { get set }
     var chatUserData: Observable<[ChatMemberItemModel]> { get set }
@@ -28,6 +29,7 @@ protocol ChatRoomViewModel: ChatRoomViewModelInput, ChatRoomViewModelOutput {}
 // MARK: - DefaultChatRoomViewModel
 
 class DefaultChatRoomViewModel: ChatRoomViewModel {
+    var roomData: Observable<ChatRoomProtocol?> = Observable(nil)
     var roomDetailData: Observable<ChatRoomDetailItemModel?> = Observable(nil)
     var messageData: Observable<[MessageItemModel]> = Observable([]) // 최근 메시지 목록
     var chatUserData: Observable<[ChatMemberItemModel]> = Observable([]) // 최근 사용자 + 자신

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -18,7 +18,7 @@ protocol ChatRoomViewModelInput {
 protocol ChatRoomViewModelOutput {
     var roomDetailData: Observable<ChatRoomDetailItemModel?> { get set }
     var messageData: Observable<[MessageItemModel]> { get set }
-    var chatUserData: Observable<[ChatUserInfoItemModel]> { get set }
+    var chatUserData: Observable<[ChatMemberItemModel]> { get set }
 }
 
 // MARK: - ChatRoomViewModel
@@ -30,7 +30,7 @@ protocol ChatRoomViewModel: ChatRoomViewModelInput, ChatRoomViewModelOutput {}
 class DefaultChatRoomViewModel: ChatRoomViewModel {
     var roomDetailData: Observable<ChatRoomDetailItemModel?> = Observable(nil)
     var messageData: Observable<[MessageItemModel]> = Observable([])
-    var chatUserData: Observable<[ChatUserInfoItemModel]> = Observable([])
+    var chatUserData: Observable<[ChatMemberItemModel]> = Observable([])
 
     private let chatRoomUseCase: ChatRoomUseCase
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -29,8 +29,8 @@ protocol ChatRoomViewModel: ChatRoomViewModelInput, ChatRoomViewModelOutput {}
 
 class DefaultChatRoomViewModel: ChatRoomViewModel {
     var roomDetailData: Observable<ChatRoomDetailItemModel?> = Observable(nil)
-    var messageData: Observable<[MessageItemModel]> = Observable([])
-    var chatUserData: Observable<[ChatMemberItemModel]> = Observable([])
+    var messageData: Observable<[MessageItemModel]> = Observable([]) // 최근 메시지 목록
+    var chatUserData: Observable<[ChatMemberItemModel]> = Observable([]) // 최근 사용자 + 자신
 
     private let chatRoomUseCase: ChatRoomUseCase
 
@@ -48,8 +48,11 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
                     self?.messageData.value = recentMessages
                 }
                 if let recentParticipants = self?.roomDetailData.value?.recentParticipants {
-                    self?.chatUserData.value = recentParticipants
+                    if let myInfo = self?.roomDetailData.value?.myInfo {
+                        self?.chatUserData.value = [myInfo] + recentParticipants
+                    }
                 }
+
             case let .failure(error):
                 Log.error("채팅방 상세 정보 가져오기 실패: \(error.localizedDescription)")
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/Component/ChatUserCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/Component/ChatUserCell.swift
@@ -19,12 +19,12 @@ struct ChatUserCell: View {
                 .frame(width: 23 * DynamicSizeFactor.factor(), height: 23 * DynamicSizeFactor.factor())
                 .cornerRadius(5)
 
-            Text(member.username)
+            Text(member.name)
                 .font(.B3MediumFont())
                 .platformTextColor(color: Color("Gray07"))
                 .padding(.leading, 6 * DynamicSizeFactor.factor())
 
-            if member.user_id == currentUserId {
+            if member.userId == currentUserId {
                 CustomRoundedBtn(
                     title: "나",
                     fontColor: Color("Gray05"),
@@ -34,7 +34,7 @@ struct ChatUserCell: View {
                 )
             }
 
-            if member.role == "Admin" {
+            if member.role.rawValue == Role.admin.rawValue {
                 CustomRoundedBtn(
                     title: "방장",
                     fontColor: Color("Mint03"),

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/Component/ChatUserCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/Component/ChatUserCell.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ChatUserCell: View {
-    let member: ChatMember
+    let member: ChatMemberItemModel
     let currentUserId: Int64
 
     var body: some View {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -13,6 +13,8 @@ struct ChatSideMenuView: View {
     @Binding var isPresented: Bool
     @State private var isAlarmOn: Bool = false
     @State private var showExitPopUp: Bool = false
+    
+    @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
     var body: some View {
         ZStack {
@@ -26,7 +28,7 @@ struct ChatSideMenuView: View {
             
             if showExitPopUp {
                 CustomPopUpView(showingPopUp: $showExitPopUp,
-                                titleLabel: "\(mockChatRoom.title)",
+                                titleLabel: "\(viewModelWrapper.roomData?.title ?? "")",
                                 subTitleLabel: "채팅방을 나가시겠어요?",
                                 firstBtnAction: { self.showExitPopUp = false },
                                 firstBtnLabel: "취소",

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -13,7 +13,8 @@ struct ChatSideMenuView: View {
     @Binding var isPresented: Bool
     @State private var isAlarmOn: Bool = false
     @State private var showExitPopUp: Bool = false
-    
+    @State private var showChatUserView: Bool = false
+    @State private var selectedUser: ChatMemberItemModel? = nil
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
     var body: some View {
@@ -21,9 +22,11 @@ struct ChatSideMenuView: View {
             HStack(spacing: 0) {
                 Spacer()
                 
-                SideMenuContent(isAlarmOn: $isAlarmOn, showExitPopUp: $showExitPopUp, members: viewModelWrapper.chatUserData)
-                    .padding(.leading, 105 * DynamicSizeFactor.factor())
-                    .transition(.move(edge: .trailing))
+                SideMenuContent(isAlarmOn: $isAlarmOn, showExitPopUp: $showExitPopUp, members: viewModelWrapper.chatUserData, onUserSelect: { user in
+                    selectedUser = user
+                })
+                .padding(.leading, 105 * DynamicSizeFactor.factor())
+                .transition(.move(edge: .trailing))
             }
             
             if showExitPopUp {
@@ -50,11 +53,15 @@ struct ChatSideMenuView: View {
                     }
                 }
         )
-        // TODO: 유저 셀 클릭하면 상세 정보 뷰 나오도록
-        //        .fullScreenCover(isPresented: $showChatUserInfo) {
-        //                    ChatUserInfoView()
-        //                        .ignoresSafeArea()
-        //                }
+        .onChange(of: selectedUser) { newValue in
+            showChatUserView = newValue != nil
+        }
+        .fullScreenCover(isPresented: $showChatUserView) {
+            if let user = selectedUser {
+                ChatUserInfoView(user: user) // 선택된 사용자 정보를 전달
+                    .ignoresSafeArea()
+            }
+        }
     }
 }
 
@@ -64,6 +71,9 @@ private struct SideMenuContent: View {
     @Binding var isAlarmOn: Bool
     @Binding var showExitPopUp: Bool
     let members: [ChatMemberItemModel]
+    let onUserSelect: (ChatMemberItemModel) -> Void
+    
+    private let currentUserId = getUserData()!.id
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -97,7 +107,7 @@ private struct SideMenuContent: View {
     
     private var SideMenuCells: some View {
         VStack {
-            if members[0].role.rawValue == Role.admin.rawValue {//첫번째 사용자(나)가 방장인지 확인 후 ui
+            if members[0].role.rawValue == Role.admin.rawValue { // 첫번째 사용자(나)가 방장인지 확인 후 ui
                 SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone", isAlarmCell: false, isAlarmOn: .constant(false))
             }
             
@@ -120,7 +130,13 @@ private struct SideMenuContent: View {
 
     private var ChatUserCells: some View {
         ForEach(members) { user in
-            ChatUserCell(member: user, currentUserId: getUserData()!.id)
+            Button(action: {
+                if user.role == .admin, user.userId != currentUserId { // 내가 방장일 때, 자신이 아닌 사용자만 선택 가능
+                    onUserSelect(user)
+                }
+            }) {
+                ChatUserCell(member: user, currentUserId: currentUserId)
+            }
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -22,7 +22,7 @@ struct ChatSideMenuView: View {
             HStack(spacing: 0) {
                 Spacer()
                 
-                SideMenuContent(isAlarmOn: $isAlarmOn, showExitPopUp: $showExitPopUp, members: viewModelWrapper.chatUserData, onUserSelect: { user in
+                SideMenuContent(isAlarmOn: $isAlarmOn, showExitPopUp: $showExitPopUp, members: viewModelWrapper.chatUserData, myInfo: viewModelWrapper.roomDetailData?.myInfo, onUserSelect: { user in
                     selectedUser = user
                 })
                 .padding(.leading, 105 * DynamicSizeFactor.factor())
@@ -60,6 +60,9 @@ struct ChatSideMenuView: View {
             if let user = selectedUser {
                 ChatUserInfoView(user: user) // 선택된 사용자 정보를 전달
                     .ignoresSafeArea()
+                    .onDisappear {
+                        selectedUser = nil // 뷰가 닫힐 때 선택된 사용자 초기화
+                    }
             }
         }
     }
@@ -71,6 +74,7 @@ private struct SideMenuContent: View {
     @Binding var isAlarmOn: Bool
     @Binding var showExitPopUp: Bool
     let members: [ChatMemberItemModel]
+    let myInfo: ChatMemberItemModel?
     let onUserSelect: (ChatMemberItemModel) -> Void
     
     private let currentUserId = getUserData()!.id
@@ -131,7 +135,7 @@ private struct SideMenuContent: View {
     private var ChatUserCells: some View {
         ForEach(members) { user in
             Button(action: {
-                if user.role == .admin, user.userId != currentUserId { // 내가 방장일 때, 자신이 아닌 사용자만 선택 가능
+                if myInfo?.role == .admin, user.userId != currentUserId { // 내가 방장일 때, 자신이 아닌 사용자만 선택 가능
                     onUserSelect(user)
                 }
             }) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -138,6 +138,7 @@ private struct SideMenuContent: View {
                 if myInfo?.role == .admin, user.userId != currentUserId { // 내가 방장일 때, 자신이 아닌 사용자만 선택 가능
                     onUserSelect(user)
                 }
+                Log.debug("??\(user)")
             }) {
                 ChatUserCell(member: user, currentUserId: currentUserId)
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -21,7 +21,7 @@ struct ChatSideMenuView: View {
             HStack(spacing: 0) {
                 Spacer()
                 
-                SideMenuContent(isAlarmOn: $isAlarmOn, showExitPopUp: $showExitPopUp)
+                SideMenuContent(isAlarmOn: $isAlarmOn, showExitPopUp: $showExitPopUp, members: viewModelWrapper.chatUserData)
                     .padding(.leading, 105 * DynamicSizeFactor.factor())
                     .transition(.move(edge: .trailing))
             }
@@ -63,6 +63,7 @@ struct ChatSideMenuView: View {
 private struct SideMenuContent: View {
     @Binding var isAlarmOn: Bool
     @Binding var showExitPopUp: Bool
+    let members: [ChatMemberItemModel]
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -96,7 +97,7 @@ private struct SideMenuContent: View {
     
     private var SideMenuCells: some View {
         VStack {
-            if mockMembers[1].role.rawValue == Role.admin.rawValue {
+            if members[0].role.rawValue == Role.admin.rawValue {//첫번째 사용자(나)가 방장인지 확인 후 ui
                 SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone", isAlarmCell: false, isAlarmOn: .constant(false))
             }
             
@@ -118,8 +119,8 @@ private struct SideMenuContent: View {
     }
 
     private var ChatUserCells: some View {
-        ForEach(mockMembers) { user in
-            ChatUserCell(member: user, currentUserId: 102)
+        ForEach(members) { user in
+            ChatUserCell(member: user, currentUserId: getUserData()!.id)
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -94,7 +94,7 @@ private struct SideMenuContent: View {
     
     private var SideMenuCells: some View {
         VStack {
-            if mockMembers[1].role == "Admin" {
+            if mockMembers[1].role.rawValue == Role.admin.rawValue {
                 SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone", isAlarmCell: false, isAlarmOn: .constant(false))
             }
             

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatUserInfo/View/ChatUserInfoView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatUserInfo/View/ChatUserInfoView.swift
@@ -37,7 +37,7 @@ struct ChatUserInfoView: View {
             if showKickOutPopUp {
                 CustomPopUpView(showingPopUp: $showKickOutPopUp,
                                 titleLabel: "내보내기",
-                                subTitleLabel: "\(mockMembers[1].username)님을 내보낼까요?",
+                                subTitleLabel: "\(mockMembers[1].name)님을 내보낼까요?",
                                 firstBtnAction: { self.showKickOutPopUp = false },
                                 firstBtnLabel: "취소",
                                 secondBtnAction: {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatUserInfo/View/ChatUserInfoView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatUserInfo/View/ChatUserInfoView.swift
@@ -13,8 +13,7 @@ struct ChatUserInfoView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var showTransferPopUp: Bool = false // 방장 넘기기 팝업 상태
     @State private var showKickOutPopUp: Bool = false // 내보내기 팝업 상태
-
-    @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
+    let user: ChatMemberItemModel
 
     var body: some View {
         ZStack {
@@ -39,7 +38,7 @@ struct ChatUserInfoView: View {
             if showKickOutPopUp {
                 CustomPopUpView(showingPopUp: $showKickOutPopUp,
                                 titleLabel: "내보내기",
-                                subTitleLabel: "\(viewModelWrapper.chatUserData[0].name)님을 내보낼까요?",
+                                subTitleLabel: "\(user.name)님을 내보낼까요?",
                                 firstBtnAction: { self.showKickOutPopUp = false },
                                 firstBtnLabel: "취소",
                                 secondBtnAction: {
@@ -100,7 +99,7 @@ struct ChatUserInfoView: View {
                                 .stroke(.white01, lineWidth: 3)
                         )
 
-                    Text("걱정하는 바다오리")
+                    Text("\(user.name)")
                         .font(.H3SemiboldFont())
                         .platformTextColor(color: .gray07)
                 }
@@ -147,8 +146,4 @@ struct ChatUserInfoView: View {
             .buttonStyle(BasicButtonStyleUtil())
         }
     }
-}
-
-#Preview {
-    ChatUserInfoView()
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatUserInfo/View/ChatUserInfoView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatUserInfo/View/ChatUserInfoView.swift
@@ -14,6 +14,8 @@ struct ChatUserInfoView: View {
     @State private var showTransferPopUp: Bool = false // 방장 넘기기 팝업 상태
     @State private var showKickOutPopUp: Bool = false // 내보내기 팝업 상태
 
+    @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
+
     var body: some View {
         ZStack {
             UserInfoContent
@@ -37,7 +39,7 @@ struct ChatUserInfoView: View {
             if showKickOutPopUp {
                 CustomPopUpView(showingPopUp: $showKickOutPopUp,
                                 titleLabel: "내보내기",
-                                subTitleLabel: "\(mockMembers[1].name)님을 내보낼까요?",
+                                subTitleLabel: "\(viewModelWrapper.chatUserData[0].name)님을 내보낼까요?",
                                 firstBtnAction: { self.showKickOutPopUp = false },
                                 firstBtnLabel: "취소",
                                 secondBtnAction: {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -16,16 +16,20 @@ struct ChatRoomContent: View {
                 if isMyChat {
                     if let rooms = dummyChatRooms {
                         ForEach(rooms, id: \.id) { chatRoom in
-                            ChatRoomCell(chatRoom: chatRoom, isMyChat: true, onDelete: {
-                                isPopUp = true
-                                selectedChatRoom = chatRoom
-                            })
+                            NavigationLink(destination: ChatRoomView(chatRoom: chatRoom)) {
+                                ChatRoomCell(chatRoom: chatRoom, isMyChat: true, onDelete: {
+                                    isPopUp = true
+                                    selectedChatRoom = chatRoom
+                                })
+                            }
                             .transition(.move(edge: .trailing).combined(with: .opacity))
                         }
                     }
                 } else {
                     if let rooms = searchChatRooms {
                         ForEach(rooms, id: \.id) { chatRoom in
+                            // 수정 필요
+//                            NavigationLink(destination: ChatRoomView(chatRoom: chatRoom)) {
                             ChatRoomCell(chatRoom: chatRoom, isMyChat: false, onDelete: {
                                 isPopUp = true
                             })

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -28,11 +28,11 @@ struct ChatRoomContent: View {
                 } else {
                     if let rooms = searchChatRooms {
                         ForEach(rooms, id: \.id) { chatRoom in
-                            // 수정 필요
-//                            NavigationLink(destination: ChatRoomView(chatRoom: chatRoom)) {
-                            ChatRoomCell(chatRoom: chatRoom, isMyChat: false, onDelete: {
-                                isPopUp = true
-                            })
+                            NavigationLink(destination: ChatRoomView(chatRoom: chatRoom)) {
+                                ChatRoomCell(chatRoom: chatRoom, isMyChat: false, onDelete: {
+                                    isPopUp = true
+                                })
+                            }
                         }
                     }
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -28,11 +28,9 @@ struct ChatRoomContent: View {
                 } else {
                     if let rooms = searchChatRooms {
                         ForEach(rooms, id: \.id) { chatRoom in
-                            NavigationLink(destination: ChatRoomView(chatRoom: chatRoom)) {
-                                ChatRoomCell(chatRoom: chatRoom, isMyChat: false, onDelete: {
-                                    isPopUp = true
-                                })
-                            }
+                            ChatRoomCell(chatRoom: chatRoom, isMyChat: false, onDelete: {
+                                isPopUp = true
+                            })
                         }
                     }
                 }
@@ -184,25 +182,9 @@ struct ChatRoomCell: View {
             )
         }
         .onAppear {
-            loadImage(from: chatRoom.backgroundImageUrl)
-        }
-    }
-    
-    /// 이미지 URL에서 데이터를 다운로드하고 UIImage로 변환하는 함수
-    func loadImage(from urlString: String) {
-        guard let url = URL(string: urlString) else {
-            print("Invalid URL")
-            return
-        }
-
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            if let data = data, error == nil, let downloadedImage = UIImage(data: data) {
-                DispatchQueue.main.async {
-                    self.loadedImage = downloadedImage
-                }
-            } else {
-                print("Failed to load image for chat room: \(error?.localizedDescription ?? "Unknown error")")
+            ImageLoader.loadImage(from: chatRoom.backgroundImageUrl) { loadedImage in
+                self.loadedImage = loadedImage
             }
-        }.resume()
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ImageLoader.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ImageLoader.swift
@@ -1,0 +1,32 @@
+//
+//  ImageLoader.swift
+//  pennyway-client-iOS
+//
+//  Created by 최희진 on 11/7/24.
+//
+
+import UIKit
+
+class ImageLoader {
+    static func loadImage(from urlString: String, completion: @escaping (UIImage?) -> Void) {
+        guard let url = URL(string: urlString) else {
+            Log.debug("Invalid URL")
+            completion(nil)
+            return
+        }
+
+        // 이미지 다운로드 작업
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data, error == nil, let downloadedImage = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    completion(downloadedImage)
+                }
+            } else {
+                Log.fault("Failed to load image: \(error?.localizedDescription ?? "Unknown error")")
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+            }
+        }.resume()
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Constants/Value.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Constants/Value.swift
@@ -71,5 +71,5 @@ enum ContentType: String, Codable {
 
 enum CategoryType: String, Codable {
     case normal = "NORMAL"
-    case important = "SYSTEM"
+    case system = "SYSTEM"
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
@@ -7,7 +7,6 @@
 
 /// 내 채팅과 추천채팅에서 보여지는 공통 컴포넌트를 모아놓은 프로토콜
 protocol ChatRoomProtocol {
-    var id: Int64 { get }
     var title: String { get }
     var description: String { get }
     var isPrivate: Bool { get }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
@@ -2,11 +2,12 @@
 //  ChatRoomProtocol.swift
 //  pennyway-client-iOS
 //
-//  Created by 아우신얀 on 11/3/24.
+//  Created by 최희진, 아우신얀 on 11/3/24.
 //
 
 /// 내 채팅과 추천채팅에서 보여지는 공통 컴포넌트를 모아놓은 프로토콜
 protocol ChatRoomProtocol {
+    var id: Int64 { get }
     var title: String { get }
     var description: String { get }
     var isPrivate: Bool { get }


### PR DESCRIPTION
## 작업 이유

- [x] 채팅 이력과 받아온 유저 정보간 매핑 후 ui 반영
- [x] 사이드 메뉴에 유저 정보 보여주기

이전 pr #252에서 처리하지 못한 두가지 사항을 처리하였다.

<br/>

## 작업 사항

### 1️⃣ 채팅 이력과 받아온 유저 정보간 매핑 후 ui 반영

```
//응답 데이터
struct ChatRoomDetailInfo: Equatable {
    let myInfo: ChatUserInfo //내 정보
    let recentParticipants: [ChatUserInfo]//최근에 메시지를 보낸 사용자
    let otherParticipantIds: [Int64]//최근에 메시지를 보내지 않았지만 단톡방에 속해있는 사용자
    let recentMessages: [Message]//최근 메시지 내용 15개
}

```
- 받아온 최근 채팅 이력을 보여주기 위해 recentMessages의 senderId와 recentParticipants의 userId가 일치하는지 확인하여 채팅 메시지와 사용자를 매핑하였다.
- "사용자가 들어왔습니다", "사용자가 나갔습니다" 알림은 해당 메시지의 CategoryType이 system이기 때문에 이걸로 판단해서 ChatHeader로 넣어주었다.


<img src = "https://github.com/user-attachments/assets/9c88e99e-7943-4a02-8c41-ba5a59fae4c1" height = "550"/>

<img src = "https://github.com/user-attachments/assets/64d8e2ad-e080-4c61-8061-f6b3d1919673" height = "550"/>

<br/>


<br/>


### 2️⃣ 사이드 메뉴에 유저 정보 보여주기

사이드 메뉴에서 유저를 클릭하여 유저 정보를 보여줄 수 있는 경우는 다음과 같다.

1. 내가 방장이다.
2. 내가 아닌 다른 사용자여야 한다.

내가 방장이면서 내가 아닌 다른 사용자를 클릭해야만 유저 정보 화면을 볼 수 있다.

<img src = "https://github.com/user-attachments/assets/235a3d5f-6a90-4575-b50a-cf2aeb136c9e" height = "550"/>

<img src = "https://github.com/user-attachments/assets/d0ed4cbf-736c-48ba-9ef9-f374e6ed1d13" height = "550"/>

![Simulator Screen Recording - iPhone 15 Pro - 2024-11-07 at 03 32 45](https://github.com/user-attachments/assets/afcb0e41-334e-4d54-86db-9270f54b4a5e)


<br/>


<br/>

### 3️⃣ ImageLoader 유틸 파일로 구현

- Presentation - Utils 폴더에 ImageLoader파일을 만들어서 url 이미지를 다운 받을 수 있음

url 이미지를 다운 받아 ui에 보여줘야 하는 코드가 중복되어서 유틸로 구현하였다.

```
 @State private var loadedImage: UIImage? = nil //loadedImage 저장할 변수

ImageLoader.loadImage(from: "\(이미지 url)") { loadedImage in
    self.loadedImage = loadedImage//받은 이미지 저장
}
```


### 4️⃣ 필드 추가 및 네이밍 변경

- ChatUserInfo -> ChatMember

ChatUserInfo라고 네이밍 했다가 이전에 ChatMember으로 모델 컨벤션을 정해놓아서 ChatMember로 변경하였다.

- ChatRoomDetailInfo의 otherParticipants의 OtherMember 모델 추가
- ChatRoomDetailInfo의 recentParticipants의 userId 필드 추가


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

남은 채팅 상세 정보 조회 적용하는 부분 처리했습니다!
이상 있으면 말씀해주세요~


<br/>

## 발견한 이슈
없음