### PR TITLE
📮 채팅 이력 조회 API 연동 및 오류 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -133,6 +133,10 @@
 		4A4A567A2BADEFF90071D00E /* NavigationBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A56792BADEFF90071D00E /* NavigationBackButton.swift */; };
 		4A4D884D2BD81A62009EADB0 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D884C2BD81A62009EADB0 /* KeychainHelper.swift */; };
 		4A4D884F2BD81F82009EADB0 /* CryptoHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D884E2BD81F82009EADB0 /* CryptoHelper.swift */; };
+		4A4F1A3D2CE227E000105218 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A3C2CE227E000105218 /* GoogleService-Info.plist */; };
+		4A4F1A422CE227E600105218 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A3E2CE227E600105218 /* Debug.xcconfig */; };
+		4A4F1A432CE227E600105218 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A3F2CE227E600105218 /* Release.xcconfig */; };
+		4A4F1A442CE227E600105218 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A402CE227E600105218 /* Secrets.xcconfig */; };
 		4A5050332BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5050322BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift */; };
 		4A513BE82BEFCF5700D35964 /* LinkAccountToOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A513BE72BEFCF5600D35964 /* LinkAccountToOAuthViewModel.swift */; };
 		4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */; };
@@ -413,10 +417,6 @@
 		D8C9AC402BF661A2006D1FCD /* InquiryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */; };
 		D8C9AC422BF66BB3006D1FCD /* InquiryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */; };
 		D8CEFB732C32BDF000E61C51 /* MoreDetailSpendingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */; };
-		D8CFE18C2CDE2BEF00FD633E /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */; };
-		D8CFE18D2CDE2BEF00FD633E /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */; };
-		D8CFE18E2CDE2BEF00FD633E /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE18B2CDE2BEF00FD633E /* Secrets.xcconfig */; };
-		D8CFE1902CDE2BFF00FD633E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE18F2CDE2BFF00FD633E /* GoogleService-Info.plist */; };
 		D8DCCF742CBD8B4B00550A8B /* InputContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCCF6F2CBD8B4B00550A8B /* InputContent.swift */; };
 		D8DCCF752CBD8B4B00550A8B /* MakeChatRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCCF712CBD8B4B00550A8B /* MakeChatRoomView.swift */; };
 		D8DCCF802CBD8D5700550A8B /* DeleteImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCCF782CBD8D5700550A8B /* DeleteImageUseCase.swift */; };
@@ -580,6 +580,10 @@
 		4A4A56792BADEFF90071D00E /* NavigationBackButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBackButton.swift; sourceTree = "<group>"; };
 		4A4D884C2BD81A62009EADB0 /* KeychainHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		4A4D884E2BD81F82009EADB0 /* CryptoHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoHelper.swift; sourceTree = "<group>"; };
+		4A4F1A3C2CE227E000105218 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		4A4F1A3E2CE227E600105218 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4A4F1A3F2CE227E600105218 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		4A4F1A402CE227E600105218 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		4A5050322BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatterUtil.swift; sourceTree = "<group>"; };
 		4A513BE72BEFCF5600D35964 /* LinkAccountToOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAccountToOAuthViewModel.swift; sourceTree = "<group>"; };
 		4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomButton.swift; sourceTree = "<group>"; };
@@ -863,10 +867,6 @@
 		D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryView.swift; sourceTree = "<group>"; };
 		D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryListView.swift; sourceTree = "<group>"; };
 		D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreDetailSpendingView.swift; sourceTree = "<group>"; };
-		D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../../../../../Downloads/Debug.xcconfig; sourceTree = "<group>"; };
-		D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../../../../../Downloads/Release.xcconfig; sourceTree = "<group>"; };
-		D8CFE18B2CDE2BEF00FD633E /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Secrets.xcconfig; path = ../../../../../Downloads/Secrets.xcconfig; sourceTree = "<group>"; };
-		D8CFE18F2CDE2BFF00FD633E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D8DCCF6F2CBD8B4B00550A8B /* InputContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputContent.swift; sourceTree = "<group>"; };
 		D8DCCF712CBD8B4B00550A8B /* MakeChatRoomView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MakeChatRoomView.swift; sourceTree = "<group>"; };
 		D8DCCF782CBD8D5700550A8B /* DeleteImageUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteImageUseCase.swift; sourceTree = "<group>"; };
@@ -1701,6 +1701,16 @@
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
+		4A4F1A412CE227E600105218 /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				4A4F1A3E2CE227E600105218 /* Debug.xcconfig */,
+				4A4F1A3F2CE227E600105218 /* Release.xcconfig */,
+				4A4F1A402CE227E600105218 /* Secrets.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		4A57896D2BDBEFF000AFEB26 /* Error */ = {
 			isa = PBXGroup;
 			children = (
@@ -1863,8 +1873,8 @@
 		4A762AEB2B99A16B001C1188 /* pennyway-client-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				D8CFE18F2CDE2BFF00FD633E /* GoogleService-Info.plist */,
-				D8CFE1882CDE2BE400FD633E /* Xcconfig */,
+				4A4F1A3C2CE227E000105218 /* GoogleService-Info.plist */,
+				4A4F1A412CE227E600105218 /* Xcconfig */,
 				4A12FEE62C9C47D800DE10BC /* Clean */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
@@ -2669,16 +2679,6 @@
 			path = AddSpendingHistoryView;
 			sourceTree = "<group>";
 		};
-		D8CFE1882CDE2BE400FD633E /* Xcconfig */ = {
-			isa = PBXGroup;
-			children = (
-				D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */,
-				D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */,
-				D8CFE18B2CDE2BEF00FD633E /* Secrets.xcconfig */,
-			);
-			path = Xcconfig;
-			sourceTree = "<group>";
-		};
 		D8DCCF702CBD8B4B00550A8B /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -2893,18 +2893,18 @@
 			files = (
 				4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */,
 				4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */,
-				D8CFE1902CDE2BFF00FD633E /* GoogleService-Info.plist in Resources */,
+				4A4F1A3D2CE227E000105218 /* GoogleService-Info.plist in Resources */,
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
-				D8CFE18C2CDE2BEF00FD633E /* Debug.xcconfig in Resources */,
+				4A4F1A422CE227E600105218 /* Debug.xcconfig in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
-				D8CFE18E2CDE2BEF00FD633E /* Secrets.xcconfig in Resources */,
+				4A4F1A442CE227E600105218 /* Secrets.xcconfig in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
-				D8CFE18D2CDE2BEF00FD633E /* Release.xcconfig in Resources */,
+				4A4F1A432CE227E600105218 /* Release.xcconfig in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3538,7 +3538,6 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3584,7 +3583,6 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		4AC4FD0C2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift */; };
 		4AC9488E2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9488D2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift */; };
 		4AC948902BC1C563008DBC1F /* OAuthAccountLinkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9488F2BC1C563008DBC1F /* OAuthAccountLinkingView.swift */; };
+		4ACB61152CE4C20C0018E78A /* GetPreviousChatRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACB61142CE4C20C0018E78A /* GetPreviousChatRequestDto.swift */; };
 		4ACE1FEF2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACE1FEE2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift */; };
 		4AD0D8422BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */; };
 		4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */; };
@@ -721,6 +722,7 @@
 		4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC9488D2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthRegistrationManager.swift; sourceTree = "<group>"; };
 		4AC9488F2BC1C563008DBC1F /* OAuthAccountLinkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAccountLinkingView.swift; sourceTree = "<group>"; };
+		4ACB61142CE4C20C0018E78A /* GetPreviousChatRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPreviousChatRequestDto.swift; sourceTree = "<group>"; };
 		4ACE1FEE2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsContentView.swift; sourceTree = "<group>"; };
 		4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTabBarVisibilityExtension.swift; sourceTree = "<group>"; };
 		4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifierExtension.swift; sourceTree = "<group>"; };
@@ -2788,6 +2790,7 @@
 				4A2C3A8A2CD3DCF0006B6804 /* GetJoinedChatRoomsRequestDto.swift */,
 				D85FC58D2CCC029B0068553A /* SearchChatRoomRequestDto.swift */,
 				D8E889E32CDB796B008FC22E /* JoinChatRoomRequestDto.swift */,
+				4ACB61142CE4C20C0018E78A /* GetPreviousChatRequestDto.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -3114,6 +3117,7 @@
 				4A762B072B99A262001C1188 /* TokenHandler.swift in Sources */,
 				4A3701BD2C08F7B600F0AEBA /* TargetAmountViewModel.swift in Sources */,
 				4A2C3A852CD3C965006B6804 /* DefaultLogoutRepository.swift in Sources */,
+				4ACB61152CE4C20C0018E78A /* GetPreviousChatRequestDto.swift in Sources */,
 				4A12FF152C9C4BDE00DE10BC /* RootComponent.swift in Sources */,
 				4A2C3A762CD3C93C006B6804 /* LoginRepository.swift in Sources */,
 				4A0BC6982BF53D6F0036D900 /* SpendingHistoryViewModel.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		4A4F1A422CE227E600105218 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A3E2CE227E600105218 /* Debug.xcconfig */; };
 		4A4F1A432CE227E600105218 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A3F2CE227E600105218 /* Release.xcconfig */; };
 		4A4F1A442CE227E600105218 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4F1A402CE227E600105218 /* Secrets.xcconfig */; };
+		4A4F1A462CE25F9500105218 /* GetPreviousChatResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F1A452CE25F9500105218 /* GetPreviousChatResponseDto.swift */; };
 		4A5050332BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5050322BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift */; };
 		4A513BE82BEFCF5700D35964 /* LinkAccountToOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A513BE72BEFCF5600D35964 /* LinkAccountToOAuthViewModel.swift */; };
 		4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */; };
@@ -584,6 +585,7 @@
 		4A4F1A3E2CE227E600105218 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		4A4F1A3F2CE227E600105218 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		4A4F1A402CE227E600105218 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		4A4F1A452CE25F9500105218 /* GetPreviousChatResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPreviousChatResponseDto.swift; sourceTree = "<group>"; };
 		4A5050322BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatterUtil.swift; sourceTree = "<group>"; };
 		4A513BE72BEFCF5600D35964 /* LinkAccountToOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAccountToOAuthViewModel.swift; sourceTree = "<group>"; };
 		4A51D2AB2BB1855A0080083D /* CustomBottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomButton.swift; sourceTree = "<group>"; };
@@ -2774,6 +2776,7 @@
 				D85FC58F2CCC03920068553A /* SearchChatRoomResponseDto.swift */,
 				D89263272CD3AD080057AAD6 /* GetChatRoomResponseDto.swift */,
 				4AF3A3032CD93A6D0099967F /* GetChatRoomDetailResponseDto.swift */,
+				4A4F1A452CE25F9500105218 /* GetPreviousChatResponseDto.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -3304,6 +3307,7 @@
 				4A6E62D62BA5F7FC00111246 /* PhoneVerificationContentView.swift in Sources */,
 				4AE9B3422CB6E5A00044D3E1 /* SideMenuCell.swift in Sources */,
 				4AD824752C76263B00AEF371 /* NetworkMonitor.swift in Sources */,
+				4A4F1A462CE25F9500105218 /* GetPreviousChatResponseDto.swift in Sources */,
 				D85927EE2BE6842A00653391 /* CustomPopUpView.swift in Sources */,
 				4A28821B2C65184300AE50C7 /* ProfileImageViewModel.swift in Sources */,
 				D8C9AC422BF66BB3006D1FCD /* InquiryListView.swift in Sources */,
@@ -3538,6 +3542,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A4F1A3E2CE227E600105218 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3583,6 +3588,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A4F1A3F2CE227E600105218 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Alamofire/ChatRoomAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Alamofire/ChatRoomAlamofire.swift
@@ -27,8 +27,8 @@ class ChatRoomAlamofire {
     }
     
     /// 채팅 이력 조회
-    func getChatData(_ chatRoomId: Int64, _ lastMessageId: Int64, completion: @escaping (Result<Data?, Error>) -> Void) {
-        Log.info("ChatRoomAlamofire - getChatData() called \(chatRoomId) \(lastMessageId)")
+    func getPreviousChat(_ chatRoomId: Int64, _ lastMessageId: Int64, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("ChatRoomAlamofire - getPreviousChat() called \(chatRoomId) \(lastMessageId)")
         
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: ChatRoomRouter.getChatData(chatRoomId: chatRoomId, lastMessageId: lastMessageId), completion: completion)
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Alamofire/ChatRoomAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Alamofire/ChatRoomAlamofire.swift
@@ -25,4 +25,11 @@ class ChatRoomAlamofire {
         
         ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: ChatRoomRouter.getChatRoomDetail(chatRoomId: chatRoomId), completion: completion)
     }
+    
+    /// 채팅 이력 조회
+    func getChatData(_ chatRoomId: Int64, _ lastMessageId: Int64, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("ChatRoomAlamofire - getChatData() called \(chatRoomId) \(lastMessageId)")
+        
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: ChatRoomRouter.getChatData(chatRoomId: chatRoomId, lastMessageId: lastMessageId), completion: completion)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Alamofire/ChatRoomAlamofire.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Alamofire/ChatRoomAlamofire.swift
@@ -27,9 +27,9 @@ class ChatRoomAlamofire {
     }
     
     /// 채팅 이력 조회
-    func getPreviousChat(_ chatRoomId: Int64, _ lastMessageId: Int64, completion: @escaping (Result<Data?, Error>) -> Void) {
-        Log.info("ChatRoomAlamofire - getPreviousChat() called \(chatRoomId) \(lastMessageId)")
+    func getPreviousChat(_ chatRoomId: Int64, _ dto: GetPreviousChatRequestDto, completion: @escaping (Result<Data?, Error>) -> Void) {
+        Log.info("ChatRoomAlamofire - getPreviousChat() called \(chatRoomId) \(dto.lastMessageId)")
         
-        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: ChatRoomRouter.getChatData(chatRoomId: chatRoomId, lastMessageId: lastMessageId), completion: completion)
+        ApiRequstHandler.shared.requestWithErrorHandling(session: session, router: ChatRoomRouter.getPreviousChat(chatRoomId: chatRoomId, dto: dto), completion: completion)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Request/GetPreviousChatRequestDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Request/GetPreviousChatRequestDto.swift
@@ -1,0 +1,18 @@
+//
+//  GetChatDataRequestDto.swift
+//  pennyway-client-iOS
+//
+//  Created by 최희진 on 11/13/24.
+//
+
+import Foundation
+
+public struct GetPreviousChatRequestDto: Encodable {
+    let lastMessageId: Int64
+
+    public init(
+        lastMessageId: Int64
+    ) {
+        self.lastMessageId = lastMessageId
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetPreviousChatResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetPreviousChatResponseDto.swift
@@ -1,0 +1,49 @@
+//
+//  GetPreviousChatResponseDto.swift
+//  pennyway-client-iOS
+//
+//  Created by 최희진 on 11/12/24.
+//
+
+import Foundation
+
+// MARK: - GetPreviousChatResponseDto
+
+struct GetPreviousChatResponseDto: Codable {
+    let code: String
+    let data: GetPreviousMessage
+
+    struct GetPreviousMessage: Codable {
+        let chats: PreviousMessageDto
+    }
+
+    struct PreviousMessageDto: Codable {
+        let contents: [GetMessage]
+        let currentPageNumber: Int
+        let pageSize: Int
+        let numberOfElements: Int
+        let hasNext: Bool
+    }
+
+    static func to(dto: GetPreviousChatResponseDto) -> PreviousMessage {
+        let messages = dto.data.chats.contents.map { previousMessage in
+            Message(
+                chatRoomId: previousMessage.chatRoomId,
+                chatId: previousMessage.chatId,
+                content: previousMessage.content,
+                contentType: previousMessage.contentType,
+                categoryType: previousMessage.categoryType,
+                createdAt: previousMessage.createdAt,
+                senderId: previousMessage.senderId
+            )
+        }
+
+        return PreviousMessage(
+            contents: messages,
+            currentPageNumber: dto.data.chats.currentPageNumber,
+            pageSize: dto.data.chats.pageSize,
+            numberOfElements: dto.data.chats.numberOfElements,
+            hasNext: dto.data.chats.hasNext
+        )
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Router/ChatRoomRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Router/ChatRoomRouter.swift
@@ -10,11 +10,11 @@ import Foundation
 
 enum ChatRoomRouter: URLRequestConvertible {
     case getChatRoomDetail(chatRoomId: Int64)
-    case getChatData(chatRoomId: Int64, lastMessageId: Int64)
+    case getPreviousChat(chatRoomId: Int64, dto: GetPreviousChatRequestDto)
 
     var method: HTTPMethod {
         switch self {
-        case .getChatRoomDetail, .getChatData:
+        case .getChatRoomDetail, .getPreviousChat:
             return .get
         }
     }
@@ -27,14 +27,14 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case let .getChatRoomDetail(chatRoomId):
             return "v2/chat-rooms/\(chatRoomId)"
-        case let .getChatData(chatRoomId, _):
+        case let .getPreviousChat(chatRoomId, _):
             return "v2/chat-rooms/\(chatRoomId)/chats"
         }
     }
 
     var bodyParameters: Parameters? {
         switch self {
-        case .getChatRoomDetail, .getChatData:
+        case .getChatRoomDetail, .getPreviousChat:
             return [:]
         }
     }
@@ -43,8 +43,8 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case .getChatRoomDetail:
             return [:]
-        case let .getChatData(_, lastMessageId):
-            return ["lastMessageId": lastMessageId]
+        case let .getPreviousChat(_, dto):
+            return try? dto.asDictionary()
         }
     }
 
@@ -55,7 +55,7 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case .getChatRoomDetail:
             request = URLRequest.createURLRequest(url: url, method: method)
-        case .getChatData:
+        case .getPreviousChat:
             let queryDatas = queryParameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
             request = URLRequest.createURLRequest(url: url, method: method, queryParameters: queryDatas)
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Router/ChatRoomRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Router/ChatRoomRouter.swift
@@ -36,7 +36,6 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case .getChatRoomDetail, .getChatData:
             return [:]
-            
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Router/ChatRoomRouter.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Router/ChatRoomRouter.swift
@@ -10,10 +10,11 @@ import Foundation
 
 enum ChatRoomRouter: URLRequestConvertible {
     case getChatRoomDetail(chatRoomId: Int64)
+    case getChatData(chatRoomId: Int64, lastMessageId: Int64)
 
     var method: HTTPMethod {
         switch self {
-        case .getChatRoomDetail:
+        case .getChatRoomDetail, .getChatData:
             return .get
         }
     }
@@ -26,13 +27,16 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case let .getChatRoomDetail(chatRoomId):
             return "v2/chat-rooms/\(chatRoomId)"
+        case let .getChatData(chatRoomId, _):
+            return "v2/chat-rooms/\(chatRoomId)/chats"
         }
     }
 
     var bodyParameters: Parameters? {
         switch self {
-        case .getChatRoomDetail:
+        case .getChatRoomDetail, .getChatData:
             return [:]
+            
         }
     }
 
@@ -40,6 +44,8 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case .getChatRoomDetail:
             return [:]
+        case let .getChatData(_, lastMessageId):
+            return ["lastMessageId": lastMessageId]
         }
     }
 
@@ -50,6 +56,9 @@ enum ChatRoomRouter: URLRequestConvertible {
         switch self {
         case .getChatRoomDetail:
             request = URLRequest.createURLRequest(url: url, method: method)
+        case .getChatData:
+            let queryDatas = queryParameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+            request = URLRequest.createURLRequest(url: url, method: method, queryParameters: queryDatas)
         }
         return request
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatRoomRepository.swift
@@ -34,4 +34,31 @@ class DefaultChatRoomRepository: ChatRoomRepository {
             }
         }
     }
+
+    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64, completion: @escaping (Result<PreviousMessage, Error>) -> Void) {
+        ChatRoomAlamofire.shared.getPreviousChat(chatRoomId, lastMessageId) { result in
+            switch result {
+            case let .success(data):
+                if let responseData = data {
+                    do {
+                        let response = try JSONDecoder().decode(GetPreviousChatResponseDto.self, from: responseData)
+                        let previousMessage = GetPreviousChatResponseDto.to(dto: response)
+
+                        Log.debug("[DefaultChatRoomRepository]: 채팅 상세 정보 조회 api 성공: \(response)")
+                        completion(.success(previousMessage))
+                    } catch {
+                        Log.fault("Error parsing response JSON: \(error)")
+                        completion(.failure(error))
+                    }
+                }
+            case let .failure(error):
+                if let statusSpecificError = error as? StatusSpecificError {
+                    Log.info("StatusSpecificError occurred: \(statusSpecificError)")
+                } else {
+                    Log.error("Network request failed: \(error)")
+                }
+                completion(.failure(error))
+            }
+        }
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatRoomRepository.swift
@@ -36,7 +36,9 @@ class DefaultChatRoomRepository: ChatRoomRepository {
     }
 
     func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64, completion: @escaping (Result<PreviousMessage, Error>) -> Void) {
-        ChatRoomAlamofire.shared.getPreviousChat(chatRoomId, lastMessageId) { result in
+        let dto = GetPreviousChatRequestDto(lastMessageId: lastMessageId)
+
+        ChatRoomAlamofire.shared.getPreviousChat(chatRoomId, dto) { result in
             switch result {
             case let .success(data):
                 if let responseData = data {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -148,6 +148,15 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
 
     func stompClientDidDisconnect(client _: StompClientLib!) {
         Log.debug("Socket disconnected")
+        
+        connect { result in
+            switch result {
+            case .success:
+                Log.debug("[DefaultChatStompRepository] 재연결 시도 성공")
+            case let .failure(error):
+                Log.error("재연결 시도 실패: \(error)")
+            }
+        }
     }
 
     func stompClient(client _: StompClientLib!, didReceiveMessageWithJSONBody body: AnyObject?, akaStringBody akaStringBody: String?, withHeader _: [String: String]?, withDestination _: String) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -148,7 +148,7 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
 
     func stompClientDidDisconnect(client _: StompClientLib!) {
         Log.debug("Socket disconnected")
-        
+
         connect { result in
             switch result {
             case .success:

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/ChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/ChatRoomRepository.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol ChatRoomRepository {
     func getChatRoomDetail(chatRoomId: Int64, completion: @escaping (Result<ChatRoomDetailInfo, Error>) -> Void)
+    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64, completion: @escaping (Result<PreviousMessage, Error>) -> Void)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/Message.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/Message.swift
@@ -18,3 +18,13 @@ struct Message: Equatable {
     let createdAt: String
     let senderId: Int64
 }
+
+// MARK: - PreviousMessage
+
+struct PreviousMessage: Equatable {
+    let contents: [Message]
+    let currentPageNumber: Int
+    let pageSize: Int
+    let numberOfElements: Int
+    let hasNext: Bool
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/Message.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/Message.swift
@@ -27,4 +27,18 @@ struct PreviousMessage: Equatable {
     let pageSize: Int
     let numberOfElements: Int
     let hasNext: Bool
+
+    static func to(model: PreviousMessage) -> [MessageItemModel] {
+        return model.contents.map { message in
+            MessageItemModel(
+                chatRoomId: message.chatRoomId,
+                chatId: message.chatId,
+                content: message.content,
+                contentType: message.contentType,
+                categoryType: message.categoryType,
+                createdAt: message.createdAt,
+                senderId: message.senderId
+            )
+        }
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/ChatRoomUseCase.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/ChatRoomUseCase.swift
@@ -11,6 +11,7 @@ import Foundation
 
 protocol ChatRoomUseCase {
     func getChatRoomDetail(chatRoomId: Int64, completion: @escaping (Result<ChatRoomDetailInfo, Error>) -> Void)
+    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64, completion: @escaping (Result<PreviousMessage, Error>) -> Void)
 }
 
 // MARK: - DefaultChatRoomUseCase
@@ -24,5 +25,9 @@ class DefaultChatRoomUseCase: ChatRoomUseCase {
 
     func getChatRoomDetail(chatRoomId: Int64, completion: @escaping (Result<ChatRoomDetailInfo, Error>) -> Void) {
         repository.getChatRoomDetail(chatRoomId: chatRoomId, completion: completion)
+    }
+
+    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64, completion: @escaping (Result<PreviousMessage, Error>) -> Void) {
+        repository.getPreviousChat(chatRoomId: chatRoomId, lastMessageId: lastMessageId, completion: completion)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -116,7 +116,7 @@ struct ChatContent: View {
         isLoadingViewShown = true
         isReloadViewShown = false
 
-        var retryWorkItem: DispatchWorkItem?
+        var retryWorkItem: DispatchWorkItem
 
         retryWorkItem = DispatchWorkItem {
             Log.debug("API 응답이 10초 이상 걸림")
@@ -129,7 +129,7 @@ struct ChatContent: View {
             }
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: retryWorkItem!)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: retryWorkItem)
 
         // 10초가 지나기 전에 API가 성공하면 타이머 취소
         viewModelWrapper.chatRoomViewModel.getPreviousChat { result in
@@ -150,7 +150,7 @@ struct ChatContent: View {
                     isReloadViewShown = true
                 }
             }
-            retryWorkItem?.cancel()
+            retryWorkItem.cancel()
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -31,6 +31,7 @@ struct ChatContent: View {
                                 if geometry.frame(in: .global).minY >= 0 {
                                     scrollToTop = true
 
+                                    // previousMessageData가 nil일 경우 또는 hasNext가 true인 경우에만 채팅을 불러옴
                                     if viewModelWrapper.previousMessageData == nil || (viewModelWrapper.previousMessageData?.hasNext == true) {
                                         self.loadPreviousChat()
                                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -15,11 +15,15 @@ struct ChatContent: View {
     @State private var scrollToBottom: Bool = false
     @ObservedObject var keyboardManager: KeyboardManager
 
+    @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 14 * DynamicSizeFactor.factor()) {
-                    ForEach(groupedChatsByDate.keys.sorted(by: >), id: \.self) { date in
+                    
+
+                    ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                         Section(header: ChatHeader(data: date)) {
                             Spacer().frame(height: 3)
@@ -56,7 +60,8 @@ struct ChatContent: View {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
-            }.onAppear {
+            }
+            .onAppear {
                 // 처음 열릴 때 가장 아래로 스크롤
                 proxy.scrollTo("bottom", anchor: .bottom)
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -12,7 +12,7 @@ struct ChatContent: View {
     let members: [ChatMemberItemModel]
     let currentUserId: Int64
 
-    @State private var scrollToBottom: Bool = false
+    @State private var scrollToTop: Bool = false//위쪽으로 스크롤 했는지 여부
     @ObservedObject var keyboardManager: KeyboardManager
 
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
@@ -21,7 +21,22 @@ struct ChatContent: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 14 * DynamicSizeFactor.factor()) {
-                    
+                    GeometryReader { geometry in
+                        Color.clear
+                            .onAppear {
+                                // 스크롤 뷰가 가장 위쪽에 도달했을 때 getPreviousChat 호출
+                                if geometry.frame(in: .global).minY >= 0 {
+                                    if let roomId = viewModelWrapper.roomData?.id, let lastMessageId = chats.last?.chatId {
+                                        scrollToTop = true
+                                        viewModelWrapper.chatRoomViewModel.getPreviousChat(chatRoomId: roomId, lastMessageId: lastMessageId)
+                                    }
+                                }
+                            }
+                            .onDisappear {
+                                scrollToTop = false
+                            }
+                    }
+                    .frame(height: 1)
 
                     ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
@@ -52,8 +67,10 @@ struct ChatContent: View {
                 }
             }
             .onChange(of: chats) { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    proxy.scrollTo("bottom", anchor: .bottom)
+                if !scrollToTop {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
                 }
             }
             .onChange(of: keyboardManager.keyboardHeight) { _ in

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -19,7 +19,7 @@ struct ChatContent: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 14 * DynamicSizeFactor.factor()) {
-                    ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
+                    ForEach(groupedChatsByDate.keys.sorted(by: >), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                         Section(header: ChatHeader(data: date)) {
                             Spacer().frame(height: 3)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -12,9 +12,12 @@ struct ChatContent: View {
     let members: [ChatMemberItemModel]
     let currentUserId: Int64
 
-    @State private var scrollToTop: Bool = false//위쪽으로 스크롤 했는지 여부
-    @ObservedObject var keyboardManager: KeyboardManager
+    @State private var isLoadingViewShown: Bool = false
+    @State private var isReloadViewShown: Bool = false
+    @State private var animateLoadingView: Bool = false
+    @State private var scrollToTop: Bool = false // 위쪽으로 스크롤 했는지 여부
 
+    @ObservedObject var keyboardManager: KeyboardManager
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
     var body: some View {
@@ -26,9 +29,10 @@ struct ChatContent: View {
                             .onAppear {
                                 // 스크롤 뷰가 가장 위쪽에 도달했을 때 getPreviousChat 호출
                                 if geometry.frame(in: .global).minY >= 0 {
-                                    if let roomId = viewModelWrapper.roomData?.id, let lastMessageId = chats.last?.chatId {
-                                        scrollToTop = true
-                                        viewModelWrapper.chatRoomViewModel.getPreviousChat(chatRoomId: roomId, lastMessageId: lastMessageId)
+                                    scrollToTop = true
+
+                                    if viewModelWrapper.previousMessageData == nil || (viewModelWrapper.previousMessageData?.hasNext == true) {
+                                        self.loadPreviousChat()
                                     }
                                 }
                             }
@@ -37,6 +41,14 @@ struct ChatContent: View {
                             }
                     }
                     .frame(height: 1)
+
+                    if isLoadingViewShown {
+                        LoadingView(startAnimate: $animateLoadingView)
+                    }
+
+                    if isReloadViewShown {
+                        ReloadView(action: retryLoadPreviousChat)
+                    }
 
                     ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
@@ -96,5 +108,67 @@ struct ChatContent: View {
 
         // 각 날짜별 메시지 배열을 오래된순으로 저장
         return grouped.mapValues { $0.reversed() }
+    }
+
+    private func loadPreviousChat() {
+        // LoadingView를 표시하고, 10초 후에 ReloadView를 표시할 타이머 설정
+        isLoadingViewShown = true
+        isReloadViewShown = false
+
+        var retryWorkItem: DispatchWorkItem?
+
+        retryWorkItem = DispatchWorkItem {
+            Log.debug("API 응답이 10초 이상 걸림")
+
+            // 로딩 뷰 사라지고, 재로드 뷰 나타남
+            animateLoadingView = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                isLoadingViewShown = false
+                isReloadViewShown = true
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: retryWorkItem!)
+
+        // 10초가 지나기 전에 API가 성공하면 타이머 취소
+        viewModelWrapper.chatRoomViewModel.getPreviousChat { result in
+            switch result {
+            case .success:
+                // 로딩 뷰와 재로드 뷰 사라짐
+                animateLoadingView = false
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isLoadingViewShown = false
+                    isReloadViewShown = false
+                }
+            case .failure:
+                // 로딩 뷰 사라지고, 재로드 뷰 나타남
+                animateLoadingView = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isLoadingViewShown = false
+                    isReloadViewShown = true
+                }
+            }
+            retryWorkItem?.cancel()
+        }
+    }
+
+    private func retryLoadPreviousChat() {
+        // ReloadView가 클릭되었을 때 다시 데이터를 요청하는 함수
+        isLoadingViewShown = true
+        isReloadViewShown = false
+
+        // getPreviousChat 다시 호출
+        viewModelWrapper.chatRoomViewModel.getPreviousChat { result in
+            switch result {
+            case .success:
+                // 데이터가 성공적으로 로드되었으면 LoadingView 숨김
+                self.isLoadingViewShown = false
+            case .failure:
+                // 실패 시에도 LoadingView 숨김
+                self.isLoadingViewShown = false
+                self.isReloadViewShown = true
+            }
+        }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
@@ -22,10 +22,6 @@ struct ChatMessage: View {
             }
 
             ZStack(alignment: .topLeading) {
-                Rectangle()
-                    .fill(isSender ? Color("Yellow01") : Color("White01"))
-                    .cornerRadius(6)
-                    .frame(width: textWidth)
 
                 Text(content)
                     .font(.B1MediumFont())
@@ -33,15 +29,22 @@ struct ChatMessage: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .background(
+                        // Rectangle을 Text의 배경으로 사용
+                        Rectangle()
+                            .fill(isSender ? Color("Yellow01") : Color("White01"))
+                            .cornerRadius(6)
+                    )
+                    .background(
                         GeometryReader { geo in
                             Color.clear.preference(key: TextHeightPreferenceKey.self, value: geo.size.height)
                             Color.clear.preference(key: TextWidthPreferenceKey.self, value: geo.size.width)
                         }
                     )
+                    .onPreferenceChange(TextWidthPreferenceKey.self) { width in
+                        self.textWidth = width
+                    }
             }
-            .onPreferenceChange(TextWidthPreferenceKey.self) { width in
-                self.textWidth = width
-            }
+
             .frame(minWidth: textWidth)
             .fixedSize(horizontal: false, vertical: true)
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
@@ -22,7 +22,6 @@ struct ChatMessage: View {
             }
 
             ZStack(alignment: .topLeading) {
-
                 Text(content)
                     .font(.B1MediumFont())
                     .platformTextColor(color: Color("Gray07"))
@@ -44,7 +43,6 @@ struct ChatMessage: View {
                         self.textWidth = width
                     }
             }
-
             .frame(minWidth: textWidth)
             .fixedSize(horizontal: false, vertical: true)
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -92,6 +92,7 @@ final class ChatRoomViewModelWrapper: ObservableObject {
     @Published var roomDetailData: ChatRoomDetailItemModel? = nil
     @Published var messageData: [MessageItemModel] = []
     @Published var chatUserData: [ChatMemberItemModel] = []
+    @Published var previousMessageData: PreviousMessage? = nil
 
     var chatRoomViewModel: any ChatRoomViewModel
 
@@ -102,6 +103,7 @@ final class ChatRoomViewModelWrapper: ObservableObject {
         roomDetailData = chatRoomViewModel.roomDetailData.value
         messageData = chatRoomViewModel.messageData.value
         chatUserData = chatRoomViewModel.chatUserData.value
+        previousMessageData = chatRoomViewModel.previousMessageData.value
 
         chatRoomViewModel.roomData.observe(on: self) { [weak self] newData in
             self?.roomData = newData
@@ -117,6 +119,10 @@ final class ChatRoomViewModelWrapper: ObservableObject {
 
         chatRoomViewModel.chatUserData.observe(on: self) { [weak self] newData in
             self?.chatUserData = newData
+        }
+
+        chatRoomViewModel.previousMessageData.observe(on: self) { [weak self] newData in
+            self?.previousMessageData = newData
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -78,6 +78,9 @@ struct ChatRoomView: View {
                 // 채팅방 상세 정보 조회
                 viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: chatRoom.id)
             }
+            .onDisappear {
+                viewModelWrapper.chatRoomViewModel.reset()
+            }
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 // MARK: - ChatRoomViewModelInput
 
 protocol ChatRoomViewModelInput {
+    func reset()
     func getChatRoomDetail(chatRoomId: Int64)
     func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64)
     func sendMessage(message: String, destination: Int64, contentType: String)
@@ -37,6 +38,8 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
     var messageData: Observable<[MessageItemModel]> = Observable([]) // 최근 메시지 목록
     var chatUserData: Observable<[ChatMemberItemModel]> = Observable([]) // 최근 사용자 + 자신
 
+    private var previousMessageData: Observable<PreviousMessage?> = Observable(nil)
+
     private let chatRoomUseCase: ChatRoomUseCase
     private let sendChatUseCase: SendChatUseCase
 
@@ -55,6 +58,14 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    func reset() {
+        roomData.value = nil
+        roomDetailData.value = nil
+        messageData.value = []
+        chatUserData.value = []
+        previousMessageData.value = nil
     }
 
     /// 채팅방 상세 정보 조회
@@ -79,14 +90,26 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
     }
 
     func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64) {
-        chatRoomUseCase.getPreviousChat(chatRoomId: chatRoomId, lastMessageId: lastMessageId) { [weak self] result in
-            switch result {
-            case let .success(chatData):
-                Log.debug("성공 \(chatData)")
+        // previousMessageData가 nil일 경우 또는 hasNext가 true인 경우에만 채팅을 불러옴
+        if previousMessageData.value == nil || (previousMessageData.value?.hasNext == true) {
+            chatRoomUseCase.getPreviousChat(chatRoomId: chatRoomId, lastMessageId: lastMessageId) { [weak self] result in
+                switch result {
+                case let .success(previousMessage):
+                    // PreviousMessage를 MessageItemModel로 변환
+                    let messages = PreviousMessage.to(model: previousMessage)
 
-            case let .failure(error):
-                Log.error("[DefaultChatRoomViewModel] 채팅방 상세 정보 가져오기 실패: \(error.localizedDescription)")
+                    // 이전 메시지 데이터 업데이트
+                    self?.previousMessageData.value = previousMessage
+                    self?.messageData.value.append(contentsOf: messages)
+                    Log.debug("[DefaultChatRoomViewModel] 이전 채팅 조회 성공: \(previousMessage)")
+
+                case let .failure(error):
+                    Log.error("[DefaultChatRoomViewModel] 이전 채팅 조회 실패: \(error.localizedDescription)")
+                }
             }
+        } else {
+            // 이전 메시지가 더 이상 없으면 호출하지 않음
+            Log.debug("[DefaultChatRoomViewModel] 이전 메시지가 더 이상 없음.")
         }
     }
 
@@ -101,7 +124,7 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
             case .success:
                 Log.debug("[DefaultChatRoomViewModel] 채팅 메시지 전송 성공")
             case let .failure(error):
-                Log.error("[DefaultChatRoomViewModel]  채팅 메시지 전송 실패: \(error.localizedDescription)")
+                Log.error("[DefaultChatRoomViewModel] 채팅 메시지 전송 실패: \(error.localizedDescription)")
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -13,7 +13,7 @@ import Foundation
 protocol ChatRoomViewModelInput {
     func reset()
     func getChatRoomDetail(chatRoomId: Int64)
-    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64)
+    func getPreviousChat(completion: @escaping (Result<Void, Error>) -> Void)
     func sendMessage(message: String, destination: Int64, contentType: String)
 }
 
@@ -24,6 +24,7 @@ protocol ChatRoomViewModelOutput {
     var roomDetailData: Observable<ChatRoomDetailItemModel?> { get set }
     var messageData: Observable<[MessageItemModel]> { get set }
     var chatUserData: Observable<[ChatMemberItemModel]> { get set }
+    var previousMessageData: Observable<PreviousMessage?> { get set }
 }
 
 // MARK: - ChatRoomViewModel
@@ -35,10 +36,9 @@ protocol ChatRoomViewModel: ChatRoomViewModelInput, ChatRoomViewModelOutput {}
 class DefaultChatRoomViewModel: ChatRoomViewModel {
     var roomData: Observable<ChatRoomItemModel?> = Observable(nil)
     var roomDetailData: Observable<ChatRoomDetailItemModel?> = Observable(nil)
-    var messageData: Observable<[MessageItemModel]> = Observable([]) // 최근 메시지 목록
+    var messageData: Observable<[MessageItemModel]> = Observable([]) // 메시지 목록
     var chatUserData: Observable<[ChatMemberItemModel]> = Observable([]) // 최근 사용자 + 자신
-
-    private var previousMessageData: Observable<PreviousMessage?> = Observable(nil)
+    var previousMessageData: Observable<PreviousMessage?> = Observable(nil)
 
     private let chatRoomUseCase: ChatRoomUseCase
     private let sendChatUseCase: SendChatUseCase
@@ -89,22 +89,25 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
         }
     }
 
-    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64) {
+    func getPreviousChat(completion: @escaping (Result<Void, Error>) -> Void) {
         // previousMessageData가 nil일 경우 또는 hasNext가 true인 경우에만 채팅을 불러옴
         if previousMessageData.value == nil || (previousMessageData.value?.hasNext == true) {
-            chatRoomUseCase.getPreviousChat(chatRoomId: chatRoomId, lastMessageId: lastMessageId) { [weak self] result in
-                switch result {
-                case let .success(previousMessage):
-                    // PreviousMessage를 MessageItemModel로 변환
-                    let messages = PreviousMessage.to(model: previousMessage)
+            if let message = messageData.value.last {
+                chatRoomUseCase.getPreviousChat(chatRoomId: message.chatRoomId, lastMessageId: message.chatId) { [weak self] result in
+                    switch result {
+                    case let .success(previousMessage):
+                        let messages = PreviousMessage.to(model: previousMessage)
 
-                    // 이전 메시지 데이터 업데이트
-                    self?.previousMessageData.value = previousMessage
-                    self?.messageData.value.append(contentsOf: messages)
-                    Log.debug("[DefaultChatRoomViewModel] 이전 채팅 조회 성공: \(previousMessage)")
+                        // 이전 메시지 데이터 업데이트
+                        self?.previousMessageData.value = previousMessage
+                        self?.messageData.value.append(contentsOf: messages)
+                        Log.debug("[DefaultChatRoomViewModel] 이전 채팅 조회 성공: \(previousMessage)")
+                        completion(.success(()))
 
-                case let .failure(error):
-                    Log.error("[DefaultChatRoomViewModel] 이전 채팅 조회 실패: \(error.localizedDescription)")
+                    case let .failure(error):
+                        Log.error("[DefaultChatRoomViewModel] 이전 채팅 조회 실패: \(error.localizedDescription)")
+                        completion(.failure(error))
+                    }
                 }
             }
         } else {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -90,29 +90,23 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
     }
 
     func getPreviousChat(completion: @escaping (Result<Void, Error>) -> Void) {
-        // previousMessageData가 nil일 경우 또는 hasNext가 true인 경우에만 채팅을 불러옴
-        if previousMessageData.value == nil || (previousMessageData.value?.hasNext == true) {
-            if let message = messageData.value.last {
-                chatRoomUseCase.getPreviousChat(chatRoomId: message.chatRoomId, lastMessageId: message.chatId) { [weak self] result in
-                    switch result {
-                    case let .success(previousMessage):
-                        let messages = PreviousMessage.to(model: previousMessage)
+        if let message = messageData.value.last {
+            chatRoomUseCase.getPreviousChat(chatRoomId: message.chatRoomId, lastMessageId: message.chatId) { [weak self] result in
+                switch result {
+                case let .success(previousMessage):
+                    let messages = PreviousMessage.to(model: previousMessage)
 
-                        // 이전 메시지 데이터 업데이트
-                        self?.previousMessageData.value = previousMessage
-                        self?.messageData.value.append(contentsOf: messages)
-                        Log.debug("[DefaultChatRoomViewModel] 이전 채팅 조회 성공: \(previousMessage)")
-                        completion(.success(()))
+                    // 이전 메시지 데이터 업데이트
+                    self?.previousMessageData.value = previousMessage
+                    self?.messageData.value.append(contentsOf: messages)
+                    Log.debug("[DefaultChatRoomViewModel] 이전 채팅 조회 성공: \(previousMessage)")
+                    completion(.success(()))
 
-                    case let .failure(error):
-                        Log.error("[DefaultChatRoomViewModel] 이전 채팅 조회 실패: \(error.localizedDescription)")
-                        completion(.failure(error))
-                    }
+                case let .failure(error):
+                    Log.error("[DefaultChatRoomViewModel] 이전 채팅 조회 실패: \(error.localizedDescription)")
+                    completion(.failure(error))
                 }
             }
-        } else {
-            // 이전 메시지가 더 이상 없으면 호출하지 않음
-            Log.debug("[DefaultChatRoomViewModel] 이전 메시지가 더 이상 없음.")
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -12,6 +12,7 @@ import Foundation
 
 protocol ChatRoomViewModelInput {
     func getChatRoomDetail(chatRoomId: Int64)
+    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64)
     func sendMessage(message: String, destination: Int64, contentType: String)
 }
 
@@ -70,6 +71,18 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
                         self?.chatUserData.value = [myInfo] + recentParticipants
                     }
                 }
+
+            case let .failure(error):
+                Log.error("[DefaultChatRoomViewModel] 채팅방 상세 정보 가져오기 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func getPreviousChat(chatRoomId: Int64, lastMessageId: Int64) {
+        chatRoomUseCase.getPreviousChat(chatRoomId: chatRoomId, lastMessageId: lastMessageId) { [weak self] result in
+            switch result {
+            case let .success(chatData):
+                Log.debug("성공 \(chatData)")
 
             case let .failure(error):
                 Log.error("[DefaultChatRoomViewModel] 채팅방 상세 정보 가져오기 실패: \(error.localizedDescription)")


### PR DESCRIPTION
## 작업 이유

- 채팅 이력 조회
- 소켓 연결 끊긴 경우 재연결 시도
- 채팅 메시지 박스 오류 해결


<br/>

## 작업 사항

### 1️⃣ 채팅 이력 조회

구현 위치: ChatRoomAlamofire - ChatRoomRouter - .getPreviousChat
GET `/v2/chat-rooms/\(chatRoomId)/chats`

ChatRoomView의 채팅 내역들이 있는 ChatContent의 상단 부분으로 스크롤 하면 채팅 이력 조회 api를 요청해야 한다.

```swift
struct PreviousMessage: Equatable {
    let contents: [Message]
    let currentPageNumber: Int //현재 페이지 넘버
    let pageSize: Int //전체 페이지 사이즈
    let numberOfElements: Int //데이터 개수
    let hasNext: Bool //다음 페이지 있는지 여부
```

PreviousMessage의 모델 타입에 따라서 채팅 이력 조회 api를 요청하는 경우는 다음과 같다.

- 받아온 이전 채팅 내역이 없는 경우
- 받아온 이전 채팅 내역의 hasNext가 true인 경우 

또한 무한 스크롤으로 구현해야 하기 때문에 LoadingView와 ReloadView를 사용해서 이전과 같이 api 요청 후 10초동안 응답이 돌아오지 않으면 LoadingView에서 ReloadView로 전환되도록 하였다.

<br/>

### 2️⃣ 소켓 연결 끊긴 경우 재연결 시도

DefaultChatStompRepository에서 소켓 연결이 끊긴 경우 실행되는 stompClientDidDisconnect() 함수 안에 재연결을 시도하는 로직을 넣어서 처리해주었다.

<br/>

### 3️⃣ 채팅 메시지 배경 오류 해결

채팅 메시지의 배경이 사라지는 문제가 자주 발생했다. 
처음에 ZStack 안에 Rectangle과 Text를 넣어 구현했는데, 채팅이 빠르게 전송되어 데이터가 변경될 때마다 Rectangle이 Text의 너비를 판별하는 데 지연이 생겨 Rectangle이 사라져 보이는 현상이 발생했다.

이 문제를 해결하기 위해 Text의 background에 Rectangle을 넣어 배경 처리를 하니 제대로 동작하였다.

```
 Text(content)
      .background(
          // Rectangle을 Text의 배경으로 사용
          Rectangle()
              .fill(isSender ? Color("Yellow01") : Color("White01"))
              .cornerRadius(6)
      )
```


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅 이력 조회하는 api 무한 스크롤으로 처리하였고, 다른 오류도 같이 처리했습니다!
확인해보시고 이상 있으면 말씀해주세요~~


<br/>

## 발견한 이슈

- 처음 채팅 뷰에 진입했을 때 받아온 데이터는 잘 나오는데, 무한 스크롤으로 이전 채팅 내역을 받아와서 ui에 보여주면 메시지 사이의 간격 오류가 발생한다,,

<img src ="https://github.com/user-attachments/assets/72c2723c-90dd-4f52-9d27-73bbcccf03d8" width = "350"/>
