### PR TITLE
💻 채팅 이력 저장 자료구조 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		4AC9488E2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9488D2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift */; };
 		4AC948902BC1C563008DBC1F /* OAuthAccountLinkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9488F2BC1C563008DBC1F /* OAuthAccountLinkingView.swift */; };
 		4ACB61132CE4C09D0018E78A /* ChatHistoryBinaryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACB61122CE4C09D0018E78A /* ChatHistoryBinaryList.swift */; };
+		4ACB611D2CE4CC8A0018E78A /* ChatHistoryListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACB611C2CE4CC8A0018E78A /* ChatHistoryListTest.swift */; };
 		4ACE1FEF2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACE1FEE2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift */; };
 		4AD0D8422BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */; };
 		4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */; };
@@ -458,6 +459,16 @@
 		D8F9D7432C5A0596005416FC /* ProfileAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7422C5A0596005416FC /* ProfileAlarmView.swift */; };
 		D8F9D7452C5A09ED005416FC /* ArrivedAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F9D7442C5A09EC005416FC /* ArrivedAlarmView.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4ACB611E2CE4CC8A0018E78A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4A762AE12B99A16B001C1188 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A762AE82B99A16B001C1188;
+			remoteInfo = "pennyway-client-iOS";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		4258164B818E9C142AE01116 /* Pods-pennyway-client-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pennyway-client-iOS.release.xcconfig"; path = "Target Support Files/Pods-pennyway-client-iOS/Pods-pennyway-client-iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -721,6 +732,8 @@
 		4AC9488D2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthRegistrationManager.swift; sourceTree = "<group>"; };
 		4AC9488F2BC1C563008DBC1F /* OAuthAccountLinkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAccountLinkingView.swift; sourceTree = "<group>"; };
 		4ACB61122CE4C09D0018E78A /* ChatHistoryBinaryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryBinaryList.swift; sourceTree = "<group>"; };
+		4ACB611A2CE4CC8A0018E78A /* pennyway-client-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "pennyway-client-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4ACB611C2CE4CC8A0018E78A /* ChatHistoryListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryListTest.swift; sourceTree = "<group>"; };
 		4ACE1FEE2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsContentView.swift; sourceTree = "<group>"; };
 		4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTabBarVisibilityExtension.swift; sourceTree = "<group>"; };
 		4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifierExtension.swift; sourceTree = "<group>"; };
@@ -917,6 +930,13 @@
 			files = (
 				D820675C2CC5500700102356 /* OSLog.framework in Frameworks */,
 				7C0E38D4CE51A896B5A498EE /* Pods_pennyway_client_iOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4ACB61172CE4CC8A0018E78A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1858,6 +1878,7 @@
 			isa = PBXGroup;
 			children = (
 				4A762AEB2B99A16B001C1188 /* pennyway-client-iOS */,
+				4ACB611B2CE4CC8A0018E78A /* pennyway-client-iOSTests */,
 				4A762AEA2B99A16B001C1188 /* Products */,
 				41951791426F03880A100F2C /* Pods */,
 				4A4B454C2BD16EE500D41C9A /* Recovered References */,
@@ -1869,6 +1890,7 @@
 			isa = PBXGroup;
 			children = (
 				4A762AE92B99A16B001C1188 /* pennyway-client-iOS.app */,
+				4ACB611A2CE4CC8A0018E78A /* pennyway-client-iOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2224,6 +2246,14 @@
 				4A513BE72BEFCF5600D35964 /* LinkAccountToOAuthViewModel.swift */,
 			);
 			path = OAuthViewModel;
+			sourceTree = "<group>";
+		};
+		4ACB611B2CE4CC8A0018E78A /* pennyway-client-iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				4ACB611C2CE4CC8A0018E78A /* ChatHistoryListTest.swift */,
+			);
+			path = "pennyway-client-iOSTests";
 			sourceTree = "<group>";
 		};
 		4AD0D83E2BFD0F4400A0808F /* View */ = {
@@ -2856,6 +2886,24 @@
 			productReference = 4A762AE92B99A16B001C1188 /* pennyway-client-iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
+		4ACB61192CE4CC8A0018E78A /* pennyway-client-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4ACB61222CE4CC8A0018E78A /* Build configuration list for PBXNativeTarget "pennyway-client-iOSTests" */;
+			buildPhases = (
+				4ACB61162CE4CC8A0018E78A /* Sources */,
+				4ACB61172CE4CC8A0018E78A /* Frameworks */,
+				4ACB61182CE4CC8A0018E78A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4ACB611F2CE4CC8A0018E78A /* PBXTargetDependency */,
+			);
+			name = "pennyway-client-iOSTests";
+			productName = "pennyway-client-iOSTests";
+			productReference = 4ACB611A2CE4CC8A0018E78A /* pennyway-client-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -2863,11 +2911,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1520;
+				LastSwiftUpdateCheck = 1540;
 				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					4A762AE82B99A16B001C1188 = {
 						CreatedOnToolsVersion = 15.2;
+					};
+					4ACB61192CE4CC8A0018E78A = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 4A762AE82B99A16B001C1188;
 					};
 				};
 			};
@@ -2885,6 +2937,7 @@
 			projectRoot = "";
 			targets = (
 				4A762AE82B99A16B001C1188 /* pennyway-client-iOS */,
+				4ACB61192CE4CC8A0018E78A /* pennyway-client-iOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -2909,6 +2962,13 @@
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
 				4A4028C22CE3CD4C0050C6ED /* Release.xcconfig in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4ACB61182CE4CC8A0018E78A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3416,7 +3476,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4ACB61162CE4CC8A0018E78A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4ACB611D2CE4CC8A0018E78A /* ChatHistoryListTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		4ACB611F2CE4CC8A0018E78A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4A762AE82B99A16B001C1188 /* pennyway-client-iOS */;
+			targetProxy = 4ACB611E2CE4CC8A0018E78A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		4A762AF52B99A16D001C1188 /* Debug */ = {
@@ -3631,6 +3707,52 @@
 			};
 			name = Release;
 		};
+		4ACB61202CE4CC8A0018E78A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q8UK3SWSPM;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.heejin.pennyway-client-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pennyway-client-iOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pennyway-client-iOS";
+			};
+			name = Debug;
+		};
+		4ACB61212CE4CC8A0018E78A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q8UK3SWSPM;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.heejin.pennyway-client-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pennyway-client-iOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pennyway-client-iOS";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3648,6 +3770,15 @@
 			buildConfigurations = (
 				4A762AF82B99A16D001C1188 /* Debug */,
 				4A762AF92B99A16D001C1188 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4ACB61222CE4CC8A0018E78A /* Build configuration list for PBXNativeTarget "pennyway-client-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4ACB61202CE4CC8A0018E78A /* Debug */,
+				4ACB61212CE4CC8A0018E78A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -108,6 +108,10 @@
 		4A3DE21A2C3EF64000817589 /* GetCategorySpendingHistoryRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3DE2192C3EF64000817589 /* GetCategorySpendingHistoryRequestDto.swift */; };
 		4A3DE21C2C3EFC5B00817589 /* getCategorySpendingHistoryResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3DE21B2C3EFC5B00817589 /* getCategorySpendingHistoryResponseDto.swift */; };
 		4A3DE21E2C3EFCCC00817589 /* SpendingResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3DE21D2C3EFCCC00817589 /* SpendingResponseDto.swift */; };
+		4A4028BC2CE3CD490050C6ED /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4A4028BB2CE3CD490050C6ED /* GoogleService-Info.plist */; };
+		4A4028C12CE3CD4C0050C6ED /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4028BD2CE3CD4C0050C6ED /* Debug.xcconfig */; };
+		4A4028C22CE3CD4C0050C6ED /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4028BE2CE3CD4C0050C6ED /* Release.xcconfig */; };
+		4A4028C32CE3CD4C0050C6ED /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A4028BF2CE3CD4C0050C6ED /* Secrets.xcconfig */; };
 		4A45A19A2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A19B2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A45A19E2CCBF9A300D47F10 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -266,6 +270,7 @@
 		4AC4FD0C2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift */; };
 		4AC9488E2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9488D2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift */; };
 		4AC948902BC1C563008DBC1F /* OAuthAccountLinkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9488F2BC1C563008DBC1F /* OAuthAccountLinkingView.swift */; };
+		4ACB61132CE4C09D0018E78A /* ChatHistoryBinaryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACB61122CE4C09D0018E78A /* ChatHistoryBinaryList.swift */; };
 		4ACE1FEF2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACE1FEE2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift */; };
 		4AD0D8422BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */; };
 		4AD0D8442BFD1B5600A0808F /* NavigationBarModifierExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */; };
@@ -413,10 +418,6 @@
 		D8C9AC402BF661A2006D1FCD /* InquiryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */; };
 		D8C9AC422BF66BB3006D1FCD /* InquiryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */; };
 		D8CEFB732C32BDF000E61C51 /* MoreDetailSpendingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */; };
-		D8CFE18C2CDE2BEF00FD633E /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */; };
-		D8CFE18D2CDE2BEF00FD633E /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */; };
-		D8CFE18E2CDE2BEF00FD633E /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE18B2CDE2BEF00FD633E /* Secrets.xcconfig */; };
-		D8CFE1902CDE2BFF00FD633E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D8CFE18F2CDE2BFF00FD633E /* GoogleService-Info.plist */; };
 		D8DCCF742CBD8B4B00550A8B /* InputContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCCF6F2CBD8B4B00550A8B /* InputContent.swift */; };
 		D8DCCF752CBD8B4B00550A8B /* MakeChatRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCCF712CBD8B4B00550A8B /* MakeChatRoomView.swift */; };
 		D8DCCF802CBD8D5700550A8B /* DeleteImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCCF782CBD8D5700550A8B /* DeleteImageUseCase.swift */; };
@@ -562,6 +563,10 @@
 		4A3DE2192C3EF64000817589 /* GetCategorySpendingHistoryRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCategorySpendingHistoryRequestDto.swift; sourceTree = "<group>"; };
 		4A3DE21B2C3EFC5B00817589 /* getCategorySpendingHistoryResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getCategorySpendingHistoryResponseDto.swift; sourceTree = "<group>"; };
 		4A3DE21D2C3EFCCC00817589 /* SpendingResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendingResponseDto.swift; sourceTree = "<group>"; };
+		4A4028BB2CE3CD490050C6ED /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		4A4028BD2CE3CD4C0050C6ED /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4A4028BE2CE3CD4C0050C6ED /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		4A4028BF2CE3CD4C0050C6ED /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		4A4703892BCEA3B700AEE04E /* OAuthLoginRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthLoginRequestDto.swift; sourceTree = "<group>"; };
 		4A47038B2BCEA43500AEE04E /* OAuthVerificationCodeRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthVerificationCodeRequestDto.swift; sourceTree = "<group>"; };
 		4A47038D2BCEA47600AEE04E /* OAuthVerificationRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthVerificationRequestDto.swift; sourceTree = "<group>"; };
@@ -715,6 +720,7 @@
 		4AC4FD0B2BBE8AFC0027ACD5 /* AppleOAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAuthViewModel.swift; sourceTree = "<group>"; };
 		4AC9488D2BC1AD8F008DBC1F /* OAuthRegistrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthRegistrationManager.swift; sourceTree = "<group>"; };
 		4AC9488F2BC1C563008DBC1F /* OAuthAccountLinkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAccountLinkingView.swift; sourceTree = "<group>"; };
+		4ACB61122CE4C09D0018E78A /* ChatHistoryBinaryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryBinaryList.swift; sourceTree = "<group>"; };
 		4ACE1FEE2BBB1D9600BB4F0A /* TermsAndConditionsContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsContentView.swift; sourceTree = "<group>"; };
 		4AD0D8412BFD12AE00A0808F /* SetTabBarVisibilityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTabBarVisibilityExtension.swift; sourceTree = "<group>"; };
 		4AD0D8432BFD1B5600A0808F /* NavigationBarModifierExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifierExtension.swift; sourceTree = "<group>"; };
@@ -863,10 +869,6 @@
 		D8C9AC3F2BF661A2006D1FCD /* InquiryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryView.swift; sourceTree = "<group>"; };
 		D8C9AC412BF66BB3006D1FCD /* InquiryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryListView.swift; sourceTree = "<group>"; };
 		D8CEFB722C32BDF000E61C51 /* MoreDetailSpendingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreDetailSpendingView.swift; sourceTree = "<group>"; };
-		D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../../../../../Downloads/Debug.xcconfig; sourceTree = "<group>"; };
-		D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../../../../../Downloads/Release.xcconfig; sourceTree = "<group>"; };
-		D8CFE18B2CDE2BEF00FD633E /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Secrets.xcconfig; path = ../../../../../Downloads/Secrets.xcconfig; sourceTree = "<group>"; };
-		D8CFE18F2CDE2BFF00FD633E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D8DCCF6F2CBD8B4B00550A8B /* InputContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputContent.swift; sourceTree = "<group>"; };
 		D8DCCF712CBD8B4B00550A8B /* MakeChatRoomView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MakeChatRoomView.swift; sourceTree = "<group>"; };
 		D8DCCF782CBD8D5700550A8B /* DeleteImageUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteImageUseCase.swift; sourceTree = "<group>"; };
@@ -1371,6 +1373,7 @@
 				4A12FF1A2C9C4D7600DE10BC /* Extensions */,
 				4A12FF182C9C4D4600DE10BC /* Observable.swift */,
 				4A863A132CB461BE00BA2F2F /* TextHeightPreference.swift */,
+				4ACB61122CE4C09D0018E78A /* ChatHistoryBinaryList.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1632,6 +1635,16 @@
 			path = SpendingCategory;
 			sourceTree = "<group>";
 		};
+		4A4028C02CE3CD4C0050C6ED /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				4A4028BD2CE3CD4C0050C6ED /* Debug.xcconfig */,
+				4A4028BE2CE3CD4C0050C6ED /* Release.xcconfig */,
+				4A4028BF2CE3CD4C0050C6ED /* Secrets.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		4A4703972BCED80000AEE04E /* Response */ = {
 			isa = PBXGroup;
 			children = (
@@ -1863,8 +1876,8 @@
 		4A762AEB2B99A16B001C1188 /* pennyway-client-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				D8CFE18F2CDE2BFF00FD633E /* GoogleService-Info.plist */,
-				D8CFE1882CDE2BE400FD633E /* Xcconfig */,
+				4A4028C02CE3CD4C0050C6ED /* Xcconfig */,
+				4A4028BB2CE3CD490050C6ED /* GoogleService-Info.plist */,
 				4A12FEE62C9C47D800DE10BC /* Clean */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
@@ -2669,16 +2682,6 @@
 			path = AddSpendingHistoryView;
 			sourceTree = "<group>";
 		};
-		D8CFE1882CDE2BE400FD633E /* Xcconfig */ = {
-			isa = PBXGroup;
-			children = (
-				D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */,
-				D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */,
-				D8CFE18B2CDE2BEF00FD633E /* Secrets.xcconfig */,
-			);
-			path = Xcconfig;
-			sourceTree = "<group>";
-		};
 		D8DCCF702CBD8B4B00550A8B /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -2893,18 +2896,18 @@
 			files = (
 				4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */,
 				4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */,
-				D8CFE1902CDE2BFF00FD633E /* GoogleService-Info.plist in Resources */,
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
+				4A4028BC2CE3CD490050C6ED /* GoogleService-Info.plist in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
-				D8CFE18C2CDE2BEF00FD633E /* Debug.xcconfig in Resources */,
+				4A4028C12CE3CD4C0050C6ED /* Debug.xcconfig in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
-				D8CFE18E2CDE2BEF00FD633E /* Secrets.xcconfig in Resources */,
+				4A4028C32CE3CD4C0050C6ED /* Secrets.xcconfig in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
-				D8CFE18D2CDE2BEF00FD633E /* Release.xcconfig in Resources */,
+				4A4028C22CE3CD4C0050C6ED /* Release.xcconfig in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3261,6 +3264,7 @@
 				D8DCCFB32CBEB08C00550A8B /* ChatRootComponent.swift in Sources */,
 				4A4703922BCEA55500AEE04E /* OAuthSignUpRequestDto.swift in Sources */,
 				4A12FF052C9C4AC300DE10BC /* UserProfileViewModel.swift in Sources */,
+				4ACB61132CE4C09D0018E78A /* ChatHistoryBinaryList.swift in Sources */,
 				4A0BC6AF2BF6459B0036D900 /* DateExtensions.swift in Sources */,
 				4A5789812BDC1FF300AFEB26 /* InternalServerErrorCode.swift in Sources */,
 				4A3560802BEBE99A00BA58F3 /* LoginOAuthButtonView.swift in Sources */,
@@ -3538,7 +3542,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D8CFE1892CDE2BEF00FD633E /* Debug.xcconfig */;
+			baseConfigurationReference = 4A4028BD2CE3CD4C0050C6ED /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3584,7 +3588,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D8CFE18A2CDE2BEF00FD633E /* Release.xcconfig */;
+			baseConfigurationReference = 4A4028BE2CE3CD4C0050C6ED /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-Release.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-Release.xcscheme
@@ -38,6 +38,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ACB61192CE4CC8A0018E78A"
+               BuildableName = "pennyway-client-iOSTests.xctest"
+               BlueprintName = "pennyway-client-iOSTests"
+               ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-debug.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-debug.xcscheme
@@ -38,6 +38,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ACB61192CE4CC8A0018E78A"
+               BuildableName = "pennyway-client-iOSTests.xctest"
+               BlueprintName = "pennyway-client-iOSTests"
+               ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/pennyway-client-iOS-Debug.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/pennyway-client-iOS-Debug.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ACB61192CE4CC8A0018E78A"
+               BuildableName = "pennyway-client-iOSTests.xctest"
+               BlueprintName = "pennyway-client-iOSTests"
+               ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/pennyway-client-iOS-Release.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/pennyway-client-iOS-Release.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ACB61192CE4CC8A0018E78A"
+               BuildableName = "pennyway-client-iOSTests.xctest"
+               BlueprintName = "pennyway-client-iOSTests"
+               ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -41,16 +41,20 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(chatRoomUseCase: ChatRoomUseCase, sendChatUseCase: SendChatUseCase) {
+    private let chatHistory: ChatHistoryList
+
+    init(chatHistory: ChatHistoryList = ChatHistoryBinaryList(), chatRoomUseCase: ChatRoomUseCase, sendChatUseCase: SendChatUseCase) {
+        self.chatHistory = chatHistory
         self.chatRoomUseCase = chatRoomUseCase
         self.sendChatUseCase = sendChatUseCase
+        self.chatHistory.delegate = self
 
         // NotificationCenter에서 메시지 알림 구독
         NotificationCenter.default.publisher(for: .didReceiveMessage)
             .sink { [weak self] notification in
 
                 if let message = notification.object as? MessageItemModel {
-                    self?.messageData.value.insert(message, at: 0)
+                    self?.handleNewMessage(message)
                 }
             }
             .store(in: &cancellables)
@@ -91,5 +95,27 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
                 Log.error("[DefaultChatRoomViewModel]  채팅 메시지 전송 실패: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// 새로운 메시지를 수신하여 chatHistory에 삽입
+    private func handleNewMessage(_ message: MessageItemModel) {
+        chatHistory.insert(message)
+    }
+
+    /// 기존 메시지 로드 (예: 초기 로드 또는 특정 시점에서 로드 필요 시 사용)
+    private func loadHistoricalMessages(_ messages: [MessageItemModel]) {
+        chatHistory.insertMessages(messages)
+    }
+}
+
+// MARK: ChatHistoryDelegate
+
+extension DefaultChatRoomViewModel: ChatHistoryDelegate {
+    func chatHistoryDidAdd(_ messages: [MessageItemModel]) {
+        messageData.value.insert(contentsOf: messages, at: 0)
+    }
+
+    func chatHistoryDidUpdate(_ messages: [MessageItemModel]) {
+        messageData.value = messages
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -131,7 +131,7 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
 
     /// 단일 메시지 삽입
     private func handleNewMessage(_ message: MessageItemModel) {
-        chatHistoryList.insert(message)
+        chatHistoryList.insert(message, true)
     }
 
     /// 여러 메시지 삽입

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -38,16 +38,15 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
 
     private let chatRoomUseCase: ChatRoomUseCase
     private let sendChatUseCase: SendChatUseCase
+    private let chatHistoryList: ChatHistoryList
 
     private var cancellables = Set<AnyCancellable>()
 
-    private let chatHistory: ChatHistoryList
-
-    init(chatHistory: ChatHistoryList = ChatHistoryBinaryList(), chatRoomUseCase: ChatRoomUseCase, sendChatUseCase: SendChatUseCase) {
-        self.chatHistory = chatHistory
+    init(chatHistoryList: ChatHistoryList = ChatHistoryBinaryList(), chatRoomUseCase: ChatRoomUseCase, sendChatUseCase: SendChatUseCase) {
+        self.chatHistoryList = chatHistoryList
         self.chatRoomUseCase = chatRoomUseCase
         self.sendChatUseCase = sendChatUseCase
-        self.chatHistory.delegate = self
+        self.chatHistoryList.delegate = self
 
         // NotificationCenter에서 메시지 알림 구독
         NotificationCenter.default.publisher(for: .didReceiveMessage)
@@ -97,14 +96,14 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
         }
     }
 
-    /// 새로운 메시지를 수신하여 chatHistory에 삽입
+    /// 단일 메시지 삽입
     private func handleNewMessage(_ message: MessageItemModel) {
-        chatHistory.insert(message)
+        chatHistoryList.insert(message)
     }
 
-    /// 기존 메시지 로드 (예: 초기 로드 또는 특정 시점에서 로드 필요 시 사용)
-    private func loadHistoricalMessages(_ messages: [MessageItemModel]) {
-        chatHistory.insertMessages(messages)
+    /// 여러 메시지 삽입
+    private func handleNewMessages(_ messages: [MessageItemModel]) {
+        chatHistoryList.insertMessages(messages)
     }
 }
 
@@ -113,9 +112,5 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
 extension DefaultChatRoomViewModel: ChatHistoryDelegate {
     func chatHistoryDidAdd(_ messages: [MessageItemModel]) {
         messageData.value.insert(contentsOf: messages, at: 0)
-    }
-
-    func chatHistoryDidUpdate(_ messages: [MessageItemModel]) {
-        messageData.value = messages
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
@@ -5,14 +5,13 @@
 //  Created by 최희진 on 11/13/24.
 //
 
+import Foundation
+
 // MARK: - ChatHistoryDelegate
 
 protocol ChatHistoryDelegate: AnyObject {
     /// 새로운 메시지가 추가되었을 때 호출
     func chatHistoryDidAdd(_ messages: [MessageItemModel])
-    
-    /// 전체 메시지가 업데이트되었을 때 호출
-    func chatHistoryDidUpdate(_ messages: [MessageItemModel])
 }
 
 // MARK: - ChatHistoryList
@@ -22,7 +21,6 @@ protocol ChatHistoryList: AnyObject {
     
     func insert(_ message: MessageItemModel)
     func insertMessages(_ messages: [MessageItemModel])
-    func getAllMessages() -> [MessageItemModel]
 }
 
 // MARK: - ChatHistoryBinaryList
@@ -78,10 +76,6 @@ final class ChatHistoryBinaryList: ChatHistoryList {
                 self.delegate?.chatHistoryDidAdd(sortedMessages)
             }
         }
-    }
-    
-    func getAllMessages() -> [MessageItemModel] {
-        queue.sync { messages }
     }
     
     // MARK: - Private Methods

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
@@ -22,7 +22,7 @@ protocol ChatHistoryDelegate: AnyObject {
 protocol ChatHistoryList: AnyObject {
     var delegate: ChatHistoryDelegate? { get set }
     
-    func insert(_ message: MessageItemModel)
+    func insert(_ message: MessageItemModel, _ ascending: Bool)
     func insertMessages(_ messages: [MessageItemModel])
     func getAllMessages() -> [MessageItemModel]
 }
@@ -39,13 +39,13 @@ final class ChatHistoryBinaryList: ChatHistoryList {
     /// 스레드 안전성을 위한 직렬 큐
     private let queue = DispatchQueue(label: "com.app.chat.history")
     
-    func insert(_ message: MessageItemModel) {
+    func insert(_ message: MessageItemModel, _ ascending: Bool = true) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
             }
             
-            let index = self.findInsertionIndex(for: message)
+            let index = self.findInsertionIndex(for: message, ascending: ascending)
             guard index >= self.messages.count || self.messages[index].chatId != message.chatId else {
                 return
             }
@@ -89,16 +89,26 @@ final class ChatHistoryBinaryList: ChatHistoryList {
     // MARK: - Private Methods
     
     /// 이진 탐색으로 삽입 위치 찾기
-    private func findInsertionIndex(for message: MessageItemModel) -> Int {
+    private func findInsertionIndex(for message: MessageItemModel, ascending: Bool = true) -> Int {
         var low = 0
         var high = messages.count
         
         while low < high {
             let mid = (low + high) / 2
-            if messages[mid].chatId < message.chatId {
-                low = mid + 1
+            if ascending {
+                // 오름차순: chatId가 더 작으면 왼쪽으로 이동
+                if messages[mid].chatId < message.chatId {
+                    low = mid + 1
+                } else {
+                    high = mid
+                }
             } else {
-                high = mid
+                // 내림차순: chatId가 더 크면 왼쪽으로 이동
+                if messages[mid].chatId > message.chatId {
+                    low = mid + 1
+                } else {
+                    high = mid
+                }
             }
         }
         
@@ -112,10 +122,10 @@ final class ChatHistoryBinaryList: ChatHistoryList {
         var index2 = 0
         
         while index1 < array1.count && index2 < array2.count {
-            if array1[index1].chatId < array2[index2].chatId {
+            if array1[index1].chatId > array2[index2].chatId {
                 result.append(array1[index1])
                 index1 += 1
-            } else if array1[index1].chatId > array2[index2].chatId {
+            } else if array1[index1].chatId < array2[index2].chatId {
                 result.append(array2[index2])
                 index2 += 1
             } else {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
@@ -1,0 +1,131 @@
+//
+//  ChatHistoryBinaryList.swift
+//  pennyway-client-iOS
+//
+//  Created by 최희진 on 11/13/24.
+//
+
+// MARK: - ChatHistoryDelegate
+
+protocol ChatHistoryDelegate: AnyObject {
+    /// 새로운 메시지가 추가되었을 때 호출
+    func chatHistoryDidAdd(_ messages: [MessageItemModel])
+    
+    /// 전체 메시지가 업데이트되었을 때 호출
+    func chatHistoryDidUpdate(_ messages: [MessageItemModel])
+}
+
+// MARK: - ChatHistoryList
+
+protocol ChatHistoryList: AnyObject {
+    var delegate: ChatHistoryDelegate? { get set }
+    
+    func insert(_ message: MessageItemModel)
+    func insertMessages(_ messages: [MessageItemModel])
+    func getAllMessages() -> [MessageItemModel]
+}
+
+// MARK: - ChatHistoryBinaryList
+
+final class ChatHistoryBinaryList: ChatHistoryList {
+    /// 상태 변경을 수신할 delegate
+    weak var delegate: ChatHistoryDelegate?
+    
+    /// 정렬된 상태로 저장되는 메시지 배열
+    private var messages: [MessageItemModel] = []
+    
+    /// 스레드 안전성을 위한 직렬 큐
+    private let queue = DispatchQueue(label: "com.app.chat.history")
+    
+    func insert(_ message: MessageItemModel) {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            
+            let index = self.findInsertionIndex(for: message)
+            guard index >= self.messages.count || self.messages[index].chatId != message.chatId else {
+                return
+            }
+            
+            self.messages.insert(message, at: index)
+            
+            DispatchQueue.main.async {
+                self.delegate?.chatHistoryDidAdd([message])
+            }
+        }
+    }
+    
+    func insertMessages(_ messages: [MessageItemModel]) {
+        guard !messages.isEmpty else {
+            return
+        }
+        
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            
+            let sortedMessages = messages.sorted(by: { $0.chatId < $1.chatId })
+            
+            if self.messages.isEmpty {
+                self.messages = sortedMessages
+            } else {
+                self.messages = self.mergeSortedArrays(self.messages, sortedMessages)
+            }
+            
+            DispatchQueue.main.async {
+                self.delegate?.chatHistoryDidAdd(sortedMessages)
+            }
+        }
+    }
+    
+    func getAllMessages() -> [MessageItemModel] {
+        queue.sync { messages }
+    }
+    
+    // MARK: - Private Methods
+    
+    /// 이진 탐색으로 삽입 위치 찾기
+    private func findInsertionIndex(for message: MessageItemModel) -> Int {
+        var low = 0
+        var high = messages.count
+        
+        while low < high {
+            let mid = (low + high) / 2
+            if messages[mid].chatId < message.chatId {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        
+        return low
+    }
+    
+    /// 정렬된 두 배열 병합
+    private func mergeSortedArrays(_ array1: [MessageItemModel], _ array2: [MessageItemModel]) -> [MessageItemModel] {
+        var result: [MessageItemModel] = []
+        var index1 = 0
+        var index2 = 0
+        
+        while index1 < array1.count && index2 < array2.count {
+            if array1[index1].chatId < array2[index2].chatId {
+                result.append(array1[index1])
+                index1 += 1
+            } else if array1[index1].chatId > array2[index2].chatId {
+                result.append(array2[index2])
+                index2 += 1
+            } else {
+                result.append(array1[index1])
+                index1 += 1
+                index2 += 1
+            }
+        }
+        
+        result.append(contentsOf: array1[index1...])
+        result.append(contentsOf: array2[index2...])
+        
+        return result
+    }
+}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/ChatHistoryBinaryList.swift
@@ -21,6 +21,7 @@ protocol ChatHistoryList: AnyObject {
     
     func insert(_ message: MessageItemModel)
     func insertMessages(_ messages: [MessageItemModel])
+    func getAllMessages() -> [MessageItemModel]
 }
 
 // MARK: - ChatHistoryBinaryList
@@ -76,6 +77,10 @@ final class ChatHistoryBinaryList: ChatHistoryList {
                 self.delegate?.chatHistoryDidAdd(sortedMessages)
             }
         }
+    }
+    
+    func getAllMessages() -> [MessageItemModel] {
+        queue.sync { messages }
     }
     
     // MARK: - Private Methods

--- a/pennyway-client-iOS/pennyway-client-iOSTests/ChatHistoryListTest.swift
+++ b/pennyway-client-iOS/pennyway-client-iOSTests/ChatHistoryListTest.swift
@@ -124,7 +124,7 @@ final class UserUnitTestTests: XCTestCase {
         
         mockDelegate.onAdd = { addedMessages in
             XCTAssertEqual(addedMessages.count, 5)
-            XCTAssertEqual(addedMessages.map { $0.chatId }, [1, 2, 3, 4, 5])
+            XCTAssertEqual(addedMessages.map { $0.chatId }, [5, 4, 3, 2, 1])
             expectation.fulfill()
         }
         
@@ -133,7 +133,7 @@ final class UserUnitTestTests: XCTestCase {
         
         // Then
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(sut.getAllMessages().map { $0.chatId }, [1, 2, 3, 4, 5])
+        XCTAssertEqual(sut.getAllMessages().map { $0.chatId }, [5, 4, 3, 2, 1])
     }
     
     // MARK: - Edge Cases Tests
@@ -149,14 +149,14 @@ final class UserUnitTestTests: XCTestCase {
         
         // Extreme values
         let extremeMessages = [
-            createMessage(chatId: Int64(Int.min)),
+            createMessage(chatId: Int64(Int.max)),
             createMessage(chatId: 0),
-            createMessage(chatId: Int64(Int.max))
+            createMessage(chatId: Int64(Int.min))
         ]
         sut.insertMessages(extremeMessages)
         XCTAssertEqual(sut.getAllMessages().count, 3)
-        XCTAssertEqual(sut.getAllMessages().first?.chatId, Int64(Int.min))
-        XCTAssertEqual(sut.getAllMessages().last?.chatId, Int64(Int.max))
+        XCTAssertEqual(sut.getAllMessages().first?.chatId, Int64(Int.max))
+        XCTAssertEqual(sut.getAllMessages().last?.chatId, Int64(Int.min))
     }
     
     // MARK: - Concurrency Tests
@@ -223,7 +223,7 @@ final class UserUnitTestTests: XCTestCase {
         for i in 0 ..< singleInsertCount {
             queue.async(group: dispatchGroup) {
                 let chatId = batchCount * batchSize + i
-                self.sut.insert(self.createMessage(chatId: Int64(chatId)))
+                self.sut.insert(self.createMessage(chatId: Int64(chatId)), false)
             }
         }
         
@@ -235,8 +235,8 @@ final class UserUnitTestTests: XCTestCase {
             
             // 정렬 및 중복 검증
             let chatIds = messages.map { $0.chatId }
-            XCTAssertEqual(chatIds, Array(Set(chatIds)).sorted())
-            
+            XCTAssertEqual(chatIds, Array(Set(chatIds)).sorted(by: >))
+
             expectation.fulfill()
         }
         

--- a/pennyway-client-iOS/pennyway-client-iOSTests/ChatHistoryListTest.swift
+++ b/pennyway-client-iOS/pennyway-client-iOSTests/ChatHistoryListTest.swift
@@ -1,0 +1,241 @@
+//
+//  ChatHistoryListTest.swift
+//  pennyway-client-iOSTests
+//
+//  Created by 최희진 on 11/13/24.
+//
+
+@testable import pennyway_client_iOS
+import XCTest
+
+// MARK: - MockChatHistoryDelegate
+
+class MockChatHistoryDelegate: ChatHistoryDelegate {
+    var onAdd: (([MessageItemModel]) -> Void)?
+    
+    func chatHistoryDidAdd(_ messages: [MessageItemModel]) {
+        onAdd?(messages)
+    }
+}
+
+// MARK: - UserUnitTestTests
+
+final class UserUnitTestTests: XCTestCase {
+    private var sut: ChatHistoryBinaryList!
+    private var mockDelegate: MockChatHistoryDelegate!
+    
+    override func setUp() {
+        super.setUp()
+        sut = ChatHistoryBinaryList()
+        mockDelegate = MockChatHistoryDelegate()
+        sut.delegate = mockDelegate
+    }
+    
+    override func tearDown() {
+        mockDelegate = nil
+        sut = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Helper Methods
+    
+    /// 테스트용 메시지 생성
+    private func createMessage(roomId: Int64 = 1, chatId: Int64, content: String = "test") -> MessageItemModel {
+        return MessageItemModel(
+            chatRoomId: roomId,
+            chatId: chatId,
+            content: content,
+            contentType: .text,
+            categoryType: .normal,
+            createdAt: "2024-11-13 20:59:44",
+            senderId: 1
+        )
+    }
+    
+    // MARK: - Basic Operation Tests
+    
+    /// 단일 메시지 삽입 테스트
+    /// - 메시지가 정상적으로 저장되는지 확인
+    /// - delegate에 정확한 이벤트가 전달되는지 확인
+    /// - 저장된 메시지를 정상적으로 조회할 수 있는지 확인
+    func testSingleMessageInsert() {
+        // Given
+        let message = createMessage(chatId: 1)
+        let expectation = expectation(description: "Message insert")
+        mockDelegate.onAdd = { messages in
+            // Then
+            XCTAssertEqual(messages.count, 1)
+            XCTAssertEqual(messages[0].chatId, 1)
+            expectation.fulfill()
+        }
+        
+        // When
+        sut.insert(message)
+        
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(sut.getAllMessages().count, 1)
+    }
+    
+    /// 중복 메시지 삽입 테스트
+    /// - 동일한 chatId를 가진 메시지 삽입 시 처리 검증
+    /// - 첫 번째 메시지만 유지되어야 함
+    /// - delegate 이벤트가 한 번만 발생해야 함
+    func testDuplicateMessageInsert() {
+        // Given
+        let message1 = createMessage(chatId: 1, content: "first")
+        let message2 = createMessage(chatId: 1, content: "second")
+        var eventCount = 0
+        
+        mockDelegate.onAdd = { _ in
+            eventCount += 1
+        }
+        
+        // When
+        sut.insert(message1)
+        sut.insert(message2)
+        
+        // Then
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(eventCount, 1)
+            XCTAssertEqual(self.sut.getAllMessages().count, 1)
+            XCTAssertEqual(self.sut.getAllMessages().first?.content, "first")
+        }
+    }
+    
+    // MARK: - Bulk Operation Tests
+    
+    /// 정렬되지 않은 메시지 일괄 삽입 테스트
+    /// - 순서가 섞인 메시지들이 정렬되어 저장되는지 확인
+    /// - delegate 이벤트가 정상적으로 발생하는지 확인
+    func testUnorderedBulkInsert() {
+        // Given
+        let messages = [
+            createMessage(chatId: 5),
+            createMessage(chatId: 2),
+            createMessage(chatId: 4),
+            createMessage(chatId: 1),
+            createMessage(chatId: 3)
+        ]
+        let expectation = expectation(description: "Bulk insert")
+        
+        mockDelegate.onAdd = { addedMessages in
+            XCTAssertEqual(addedMessages.count, 5)
+            XCTAssertEqual(addedMessages.map { $0.chatId }, [1, 2, 3, 4, 5])
+            expectation.fulfill()
+        }
+        
+        // When
+        sut.insertMessages(messages)
+        
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(sut.getAllMessages().map { $0.chatId }, [1, 2, 3, 4, 5])
+    }
+    
+    // MARK: - Edge Cases Tests
+    
+    /// 경계값 테스트
+    /// - 빈 배열 삽입
+    /// - Int.min, Int.max chatId 처리
+    /// - 범위를 벗어난 조회
+    func testEdgeCases() {
+        // Empty array insert
+        sut.insertMessages([])
+        XCTAssertTrue(sut.getAllMessages().isEmpty)
+        
+        // Extreme values
+        let extremeMessages = [
+            createMessage(chatId: Int64(Int.min)),
+            createMessage(chatId: 0),
+            createMessage(chatId: Int64(Int.max))
+        ]
+        sut.insertMessages(extremeMessages)
+        XCTAssertEqual(sut.getAllMessages().count, 3)
+        XCTAssertEqual(sut.getAllMessages().first?.chatId, Int64(Int.min))
+        XCTAssertEqual(sut.getAllMessages().last?.chatId, Int64(Int.max))
+    }
+    
+    // MARK: - Concurrency Tests
+    
+    /// 동시성 테스트
+    /// - 여러 스레드에서 동시에 메시지 삽입
+    /// - 데이터 일관성 검증
+    /// - 정렬 상태 유지 확인
+    func testConcurrentInserts() {
+        // Given
+        let messageCount = 100
+        let expectation = self.expectation(description: "Concurrent inserts")
+        let dispatchGroup = DispatchGroup()
+        let queue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
+        
+        // When
+        for i in 0 ..< messageCount {
+            queue.async(group: dispatchGroup) {
+                self.sut.insert(self.createMessage(chatId: Int64(i)))
+            }
+        }
+        
+        // Then
+        dispatchGroup.notify(queue: .main) {
+            let messages = self.sut.getAllMessages()
+            XCTAssertEqual(messages.count, messageCount)
+            
+            // 정렬 확인
+            for i in 0 ..< (messages.count - 1) {
+                XCTAssertLessThan(messages[i].chatId, messages[i + 1].chatId)
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    /// 동시성 스트레스 테스트
+    /// - 단일 삽입과 일괄 삽입을 동시에 수행
+    /// - 대량의 데이터로 성능과 안정성 검증
+    /// - 메모리 누수 확인
+    func testConcurrencyStress() {
+        // Given
+        let batchCount = 5
+        let batchSize = 100
+        let singleInsertCount = 50
+        let expectation = self.expectation(description: "Stress test")
+        let dispatchGroup = DispatchGroup()
+        let queue = DispatchQueue(label: "test.stress", attributes: .concurrent)
+        
+        // When
+        // 배치 삽입
+        for i in 0 ..< batchCount {
+            queue.async(group: dispatchGroup) {
+                let startId = i * batchSize
+                let messages = (startId ..< (startId + batchSize)).map {
+                    self.createMessage(chatId: Int64($0))
+                }
+                self.sut.insertMessages(messages)
+            }
+        }
+        
+        // 개별 삽입
+        for i in 0 ..< singleInsertCount {
+            queue.async(group: dispatchGroup) {
+                let chatId = batchCount * batchSize + i
+                self.sut.insert(self.createMessage(chatId: Int64(chatId)))
+            }
+        }
+        
+        // Then
+        dispatchGroup.notify(queue: .main) {
+            let messages = self.sut.getAllMessages()
+            let expectedCount = (batchCount * batchSize) + singleInsertCount
+            XCTAssertEqual(messages.count, expectedCount)
+            
+            // 정렬 및 중복 검증
+            let chatIds = messages.map { $0.chatId }
+            XCTAssertEqual(chatIds, Array(Set(chatIds)).sorted())
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 10.0)
+    }
+}


### PR DESCRIPTION
## 작업 이유

- 채팅 이력 저장 자료구조 구현
- test 코드 작성

> 이전 채팅 이력 조회 pr 병합된 후 좀 더 test 해보고 draft 해제해놓을게요~

<br/>

## 작업 사항

## 1️⃣ 채팅 이력 저장 자료구조 구현

원래 채팅 추가하는 로직을 구현할 때 DefaultChatRoomViewModel에서 messageData 배열에 바로 데이터를 추가하였다.

- 문제

여러 사용자가 동시에 채팅을 보내는 경우 계속 정렬을 해줘야하는데 너무 비효율적이다.

- 해결

자료구조를 만들어서 채팅을 추가하면 이진탐색으로 자동 정렬하도록 구현하자.
그래서 ChatHistoryBinaryList를 구현하여 채팅 데이터를 넣으면 자동 정렬하도록 하였다.

- 설계

![스크린샷 2024-11-14 오전 3 11 52](https://github.com/user-attachments/assets/e774caab-aca3-4406-877c-42b562b7c5c1)

> ChatHistoryBinaryList는 View와 관련된 클래스명이 아니고, 자료구조를 의미하는 List여서 Cell이 아니라 List로 네이밍 했습니다.

<br/>

### DefaultChatRoomViewModel의 messageData에 데이터를 추가하는 경우 

  1. 사용자가 메시지 전송
  2. ChatHistoryBinaryList의 insert함수를 호출해 정렬하여 추가
  3. ChatHistoryDelegate로 추가된 후 데이터를 DefaultChatRoomViewModel의 messageData로 돌려준다.



<br/>

### 2️⃣  test 코드 작성

총 6개의 테스트를 수행하였다.

```swift
func testSingleMessageInsert() /// 단일 메시지 삽입 테스트
func testDuplicateMessageInsert() /// 중복 메시지 삽입 테스트
func testUnorderedBulkInsert()  /// 정렬되지 않은 메시지 일괄 삽입 테스트
func testEdgeCases() /// 경계값 테스트
func testConcurrentInserts() /// 동시성 테스트
func testConcurrencyStress() /// 동시성 스트레스 테스트
```



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅 관련된 자료구조 구현하였고, 이상있으면 말씀해주세요~

<br/>

## 발견한 이슈
