### PR TITLE
📮 chatRoomDetail에 채팅방에 마지막으로 전송된 메시지 필드 추가 

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/GetChatRoomResponseDto.swift
@@ -29,9 +29,10 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
     let isAdmin: Bool
     let participantCount: Int32
     let createdAt: String?
+    let lastMessage: LastMessageData?
     let unreadMessageCount: Int64
 
-    public init(id: Int64, title: String, description: String, backgroundImageUrl: String, isPrivate: Bool, isAdmin: Bool, participantCount: Int32, createdAt: String?, unreadMessageCount: Int64) {
+    public init(id: Int64, title: String, description: String, backgroundImageUrl: String, isPrivate: Bool, isAdmin: Bool, participantCount: Int32, createdAt: String?, lastMessage: LastMessageData, unreadMessageCount: Int64) {
         self.id = id
         self.title = title
         self.description = description
@@ -40,6 +41,7 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
         self.isAdmin = isAdmin
         self.participantCount = participantCount
         self.createdAt = createdAt
+        self.lastMessage = lastMessage
         self.unreadMessageCount = unreadMessageCount
     }
 
@@ -53,4 +55,16 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
 
         return ChatRoom(id: dto.id, title: dto.title, description: dto.description, background_image_url: completeBackgroundImageUrl, isPrivate: dto.isPrivate, isAdmin: dto.isAdmin, participantCount: dto.participantCount, createdAt: dto.createdAt ?? "", unreadMessageCount: dto.unreadMessageCount)
     }
+}
+
+// MARK: - LastMessageData
+
+public struct LastMessageData: Codable {
+    let chatRoomId: Int64
+    let chatId: Int64
+    let content: String
+    let contentType: String
+    let categoryType: String
+    let createdAt: String
+    let senderId: Int64
 }


### PR DESCRIPTION
## 작업 이유
- chatRoomDetail에 미확인 메세지 dto 필드 추가

<br/>

## 작업 사항
### **1️⃣ chatRoomDetail에 미확인 메세지 dto 필드 추가**
채팅 리스트 조회시 사용되는 아래 LastMessageData 필드 추가했습니다!

<img width="387" alt="스크린샷 2024-11-14 오후 4 05 38" src="https://github.com/user-attachments/assets/7e4a22d3-07b7-4196-b7a8-e8385d123023">

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
dto만 추가해놓은 상태라 뷰에 반영하는건 다음주 테스크때 해야 될 거 같아요!
<br/>

## 발견한 이슈
x