### PR TITLE
🎨 마지막 메시지, 읽지 않은 메시지 개수 UI 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -52,10 +52,6 @@
 		4A148B602C370123005C6D4E /* CustomSpendingRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A148B5F2C370123005C6D4E /* CustomSpendingRow.swift */; };
 		4A1C59882BC51AAE00EA2B49 /* OAuthAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1C59872BC51AAE00EA2B49 /* OAuthAlamofire.swift */; };
 		4A1C598A2BC51AEB00EA2B49 /* OAuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1C59892BC51AEB00EA2B49 /* OAuthRouter.swift */; };
-		4A23E7BC2CE871F5006FD4E2 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A23E7B82CE871F5006FD4E2 /* Debug.xcconfig */; };
-		4A23E7BD2CE871F5006FD4E2 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A23E7B92CE871F5006FD4E2 /* Release.xcconfig */; };
-		4A23E7BE2CE871F5006FD4E2 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A23E7BA2CE871F5006FD4E2 /* Secrets.xcconfig */; };
-		4A23E7C02CE871F9006FD4E2 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4A23E7BF2CE871F9006FD4E2 /* GoogleService-Info.plist */; };
 		4A23E7C22CE874E5006FD4E2 /* GetChatMembersRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A23E7C12CE874E5006FD4E2 /* GetChatMembersRequestDto.swift */; };
 		4A23E7C42CE8771C006FD4E2 /* GetChatMembersReponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A23E7C32CE8771C006FD4E2 /* GetChatMembersReponseDto.swift */; };
 		4A2881FA2C64CC1200AE50C7 /* MoveCategoryRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2881F92C64CC1200AE50C7 /* MoveCategoryRequestDto.swift */; };
@@ -385,6 +381,7 @@
 		D85E465A2CD7727200715169 /* ChatRoomProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85E46592CD7727200715169 /* ChatRoomProtocol.swift */; };
 		D85FC58E2CCC029B0068553A /* SearchChatRoomRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85FC58D2CCC029B0068553A /* SearchChatRoomRequestDto.swift */; };
 		D85FC5902CCC03920068553A /* SearchChatRoomResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85FC58F2CCC03920068553A /* SearchChatRoomResponseDto.swift */; };
+		D862343A2CEC627800663845 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D86234392CEC627800663845 /* GoogleService-Info.plist */; };
 		D86773042C76C90700C68728 /* PrivatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86773032C76C90700C68728 /* PrivatePolicy.swift */; };
 		D86773062C76CA0100C68728 /* KeyboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86773052C76CA0100C68728 /* KeyboardManager.swift */; };
 		D874F52B2C32888E00936886 /* DetailSpendingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D874F52A2C32888E00936886 /* DetailSpendingView.swift */; };
@@ -410,6 +407,9 @@
 		D89FB7822BD97A2F0019DE3C /* FindUserNameResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7812BD97A2F0019DE3C /* FindUserNameResponseDto.swift */; };
 		D89FB7842BD97B660019DE3C /* FindUserNameRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */; };
 		D8A67ACA2CC1423800749B85 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A67AC92CC1423800749B85 /* LoginUseCase.swift */; };
+		D8ACB7222CEC64AF00D2CBB2 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8ACB71F2CEC64AF00D2CBB2 /* Secrets.xcconfig */; };
+		D8ACB7232CEC64AF00D2CBB2 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8ACB7202CEC64AF00D2CBB2 /* Debug.xcconfig */; };
+		D8ACB7242CEC64AF00D2CBB2 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8ACB7212CEC64AF00D2CBB2 /* Release.xcconfig */; };
 		D8B0A9242C4E5D6400716ECB /* AddSpendingFormFieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A9232C4E5D6400716ECB /* AddSpendingFormFieldsView.swift */; };
 		D8B0A9282C4EA7FC00716ECB /* ValidatePwRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */; };
 		D8B0A92A2C4EB8E500716ECB /* ResetMyPwRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B0A9292C4EB8E500716ECB /* ResetMyPwRequestDto.swift */; };
@@ -522,10 +522,6 @@
 		4A148B5F2C370123005C6D4E /* CustomSpendingRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSpendingRow.swift; sourceTree = "<group>"; };
 		4A1C59872BC51AAE00EA2B49 /* OAuthAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAlamofire.swift; sourceTree = "<group>"; };
 		4A1C59892BC51AEB00EA2B49 /* OAuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthRouter.swift; sourceTree = "<group>"; };
-		4A23E7B82CE871F5006FD4E2 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		4A23E7B92CE871F5006FD4E2 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		4A23E7BA2CE871F5006FD4E2 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
-		4A23E7BF2CE871F9006FD4E2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4A23E7C12CE874E5006FD4E2 /* GetChatMembersRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChatMembersRequestDto.swift; sourceTree = "<group>"; };
 		4A23E7C32CE8771C006FD4E2 /* GetChatMembersReponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChatMembersReponseDto.swift; sourceTree = "<group>"; };
 		4A2881F92C64CC1200AE50C7 /* MoveCategoryRequestDto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoveCategoryRequestDto.swift; sourceTree = "<group>"; };
@@ -850,6 +846,7 @@
 		D85E46592CD7727200715169 /* ChatRoomProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomProtocol.swift; sourceTree = "<group>"; };
 		D85FC58D2CCC029B0068553A /* SearchChatRoomRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchChatRoomRequestDto.swift; sourceTree = "<group>"; };
 		D85FC58F2CCC03920068553A /* SearchChatRoomResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchChatRoomResponseDto.swift; sourceTree = "<group>"; };
+		D86234392CEC627800663845 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D86773032C76C90700C68728 /* PrivatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivatePolicy.swift; sourceTree = "<group>"; };
 		D86773052C76CA0100C68728 /* KeyboardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardManager.swift; sourceTree = "<group>"; };
 		D874F52A2C32888E00936886 /* DetailSpendingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSpendingView.swift; sourceTree = "<group>"; };
@@ -877,6 +874,9 @@
 		D89FB7832BD97B660019DE3C /* FindUserNameRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FindUserNameRequestDto.swift; path = "pennyway-client-iOS/API/Domain/AuthDomain/Dto/Request/FindUserNameRequestDto.swift"; sourceTree = SOURCE_ROOT; };
 		D89FB7882BDA925F0019DE3C /* FindUserNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindUserNameViewModel.swift; sourceTree = "<group>"; };
 		D8A67AC92CC1423800749B85 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
+		D8ACB71F2CEC64AF00D2CBB2 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Secrets.xcconfig; path = ../../../../Secrets.xcconfig; sourceTree = "<group>"; };
+		D8ACB7202CEC64AF00D2CBB2 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../../../../Debug.xcconfig; sourceTree = "<group>"; };
+		D8ACB7212CEC64AF00D2CBB2 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../../../../Release.xcconfig; sourceTree = "<group>"; };
 		D8B0A9232C4E5D6400716ECB /* AddSpendingFormFieldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSpendingFormFieldsView.swift; sourceTree = "<group>"; };
 		D8B0A9272C4EA7FC00716ECB /* ValidatePwRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatePwRequestDto.swift; sourceTree = "<group>"; };
 		D8B0A9292C4EB8E500716ECB /* ResetMyPwRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetMyPwRequestDto.swift; sourceTree = "<group>"; };
@@ -1430,16 +1430,6 @@
 			path = View;
 			sourceTree = "<group>";
 		};
-		4A23E7BB2CE871F5006FD4E2 /* Xcconfig */ = {
-			isa = PBXGroup;
-			children = (
-				4A23E7B82CE871F5006FD4E2 /* Debug.xcconfig */,
-				4A23E7B92CE871F5006FD4E2 /* Release.xcconfig */,
-				4A23E7BA2CE871F5006FD4E2 /* Secrets.xcconfig */,
-			);
-			path = Xcconfig;
-			sourceTree = "<group>";
-		};
 		4A23E7C52CE87720006FD4E2 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
@@ -1948,8 +1938,8 @@
 		4A762AEB2B99A16B001C1188 /* pennyway-client-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				4A23E7BF2CE871F9006FD4E2 /* GoogleService-Info.plist */,
-				4A23E7BB2CE871F5006FD4E2 /* Xcconfig */,
+				D8ACB71E2CEC64A100D2CBB2 /* Xcconfig */,
+				D86234392CEC627800663845 /* GoogleService-Info.plist */,
 				4A12FEE62C9C47D800DE10BC /* Clean */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
@@ -2751,6 +2741,16 @@
 			path = LoginView;
 			sourceTree = "<group>";
 		};
+		D8ACB71E2CEC64A100D2CBB2 /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				D8ACB7202CEC64AF00D2CBB2 /* Debug.xcconfig */,
+				D8ACB7212CEC64AF00D2CBB2 /* Release.xcconfig */,
+				D8ACB71F2CEC64AF00D2CBB2 /* Secrets.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		D8B0A9222C4E5CDA00716ECB /* AddSpendingHistoryView */ = {
 			isa = PBXGroup;
 			children = (
@@ -2991,18 +2991,18 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A23E7BE2CE871F5006FD4E2 /* Secrets.xcconfig in Resources */,
+				D862343A2CEC627800663845 /* GoogleService-Info.plist in Resources */,
+				D8ACB7242CEC64AF00D2CBB2 /* Release.xcconfig in Resources */,
 				4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */,
-				4A23E7C02CE871F9006FD4E2 /* GoogleService-Info.plist in Resources */,
 				4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */,
-				4A23E7BD2CE871F5006FD4E2 /* Release.xcconfig in Resources */,
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
+				D8ACB7222CEC64AF00D2CBB2 /* Secrets.xcconfig in Resources */,
+				D8ACB7232CEC64AF00D2CBB2 /* Debug.xcconfig in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,
-				4A23E7BC2CE871F5006FD4E2 /* Debug.xcconfig in Resources */,
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
@@ -3666,7 +3666,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A23E7B82CE871F5006FD4E2 /* Debug.xcconfig */;
+			baseConfigurationReference = D8ACB7202CEC64AF00D2CBB2 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3714,7 +3714,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A23E7B92CE871F5006FD4E2 /* Release.xcconfig */;
+			baseConfigurationReference = D8ACB7212CEC64AF00D2CBB2 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3761,6 +3761,7 @@
 		};
 		4ACB61202CE4CC8A0018E78A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8ACB7202CEC64AF00D2CBB2 /* Debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -3785,6 +3786,7 @@
 		};
 		4ACB61212CE4CC8A0018E78A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8ACB7212CEC64AF00D2CBB2 /* Release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/Chat/GetChatRoomResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/Chat/GetChatRoomResponseDto.swift
@@ -53,7 +53,36 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
         // 이미지 url을 http형식으로 변환
         let completeBackgroundImageUrl = createFullURL(with: cdnUrl, pathComponent: dto.backgroundImageUrl)
 
-        return ChatRoom(id: dto.id, title: dto.title, description: dto.description, background_image_url: completeBackgroundImageUrl, isPrivate: dto.isPrivate, isAdmin: dto.isAdmin, participantCount: dto.participantCount, createdAt: dto.createdAt ?? "", unreadMessageCount: dto.unreadMessageCount)
+        // lastMessage가 nil일 경우 기본 LastMessage 생성
+        let defaultLastMessage = LastMessage(
+            chatRoomId: 0,
+            chatId: 0,
+            content: "",
+            contentType: "",
+            categoryType: "",
+            createdAt: "",
+            senderId: 0
+        )
+
+        return ChatRoom(
+            id: dto.id,
+            title: dto.title,
+            description: dto.description,
+            background_image_url: completeBackgroundImageUrl,
+            isPrivate: dto.isPrivate,
+            isAdmin: dto.isAdmin,
+            participantCount: dto.participantCount,
+            createdAt: dto.createdAt ?? "",
+            lastMassage: dto.lastMessage != nil ? LastMessage(
+                chatRoomId: dto.lastMessage!.chatRoomId,
+                chatId: dto.lastMessage!.chatId,
+                content: dto.lastMessage!.content,
+                contentType: dto.lastMessage!.contentType,
+                categoryType: dto.lastMessage!.categoryType,
+                createdAt: dto.lastMessage!.createdAt,
+                senderId: dto.lastMessage!.senderId
+            ) : defaultLastMessage,
+            unreadMessageCount: dto.unreadMessageCount)
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatRoom.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatRoom.swift
@@ -18,5 +18,18 @@ struct ChatRoom: Equatable, Identifiable {
     let isAdmin: Bool
     let participantCount: Int32
     let createdAt: String
+    let lastMassage: LastMessage?
     let unreadMessageCount: Int64
+}
+
+// MARK: - LastMessage
+
+struct LastMessage: Equatable {
+    let chatRoomId: Int64
+    let chatId: Int64
+    let content: String
+    let contentType: String
+    let categoryType: String
+    let createdAt: String
+    let senderId: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/GetChatRoomUseCase.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/GetChatRoomUseCase.swift
@@ -37,7 +37,9 @@ class DefaultGetChatRoomUseCase: GetChatRoomUseCase {
                         backgroundImageUrl: chatRoom.background_image_url,
                         isPrivate: chatRoom.isPrivate,
                         isAdmin: chatRoom.isAdmin,
-                        participantCount: chatRoom.participantCount
+                        participantCount: chatRoom.participantCount,
+                        lastMassage: chatRoom.lastMassage,
+                        unreadMessageCount: chatRoom.unreadMessageCount
                     )
                 }
                 Log.debug("[GetChatRoomUseCase] 내 채팅 조회 성공")

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/SearchChatRoomUseCase.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/SearchChatRoomUseCase.swift
@@ -38,7 +38,9 @@ class DefaultSearchChatRoomUseCase: SearchChatRoomUseCase {
                         description: chatRoom.description, 
                         isPrivate: chatRoom.isPrivate,
                         backgroundImageUrl: chatRoom.backgroundImageUrl,
-                        participantCount: chatRoom.participantCount)
+                        participantCount: chatRoom.participantCount,
+                        unreadMessageCount: chatRoom.unreadMessageCount
+                    )
                 }
                 Log.debug("[SearchChatRoomUseCase] 채팅 검색 성공")
                 completion(true, chatRoomItemModels, hasNext)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -15,7 +15,7 @@ struct ChatRoomView: View {
     @EnvironmentObject var viewStateManager: ViewStateManager
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
-    var chatRoom: ChatRoomItemModel
+    var chatRoom: ChatRoomProtocol
     private let currentUserId = getUserData()!.id
 
     var body: some View {
@@ -68,7 +68,7 @@ struct ChatRoomView: View {
                 viewModelWrapper.roomData = chatRoom // 현재 채팅방 정보 저장
 
                 // 채팅방 상세 정보 조회
-                viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: chatRoom.id)
+                viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: Int64(chatRoom.id) ?? 0)
             }
             .onDisappear {
                 viewModelWrapper.chatRoomViewModel.reset()
@@ -94,7 +94,7 @@ struct ChatRoomView: View {
 // MARK: - ChatRoomViewModelWrapper
 
 final class ChatRoomViewModelWrapper: ObservableObject {
-    @Published var roomData: ChatRoomItemModel? = nil
+    @Published var roomData: ChatRoomProtocol? = nil
     @Published var roomDetailData: ChatRoomDetailItemModel? = nil
     @Published var messageData: [MessageItemModel] = []
     @Published var chatUserData: [ChatMemberItemModel] = []

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/ChatRoomDetailView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/ChatRoomDetailView.swift
@@ -3,77 +3,86 @@ import SwiftUI
 
 struct ChatRoomDetailView: View, ImageLoadable {
     let chatRoom: SearchChatRoomItemModel?
-    @State private var isNavigate = false
+    @State private var isNavigateToSecretRoom = false // 비밀번호 입력방으로 들어가기 위한 변수
     @State private var loadedImage: UIImage? = nil
+    @State private var isNavigateToChatRoom = false // 채팅방 내부로 들어가기 위한 변수
 
     @ObservedObject var viewModelWrapper: ChatViewModelWrapper
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Spacer().frame(height: 17 * DynamicSizeFactor.factor())
-
-            if let image = loadedImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: .infinity, maxHeight: 236 * DynamicSizeFactor.factor())
-
-            } else {
-                Image("illust_chat_no_BG_picture")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: .infinity, maxHeight: 236 * DynamicSizeFactor.factor())
-            }
-
-            Spacer().frame(height: 19 * DynamicSizeFactor.factor())
-
-            tagSection
-
-            Spacer().frame(height: 13 * DynamicSizeFactor.factor())
-
+        ZStack {
             VStack(alignment: .leading) {
-                if let title = chatRoom?.title {
-                    Text("\(title)")
-                        .font(.H2SemiboldFont())
-                        .platformTextColor(color: Color("Gray07"))
-                }
-
-                Spacer().frame(height: 7 * DynamicSizeFactor.factor())
-
-                if let description = chatRoom?.description {
-                    Text("\(description)")
-                        .font(.B1MediumFont())
-                        .platformTextColor(color: Color("Gray04"))
-                }
-            }
-            .padding(.horizontal, 20)
-
-            Spacer()
-
-            CustomBottomButton(action: {
-                if chatRoom?.isPrivate ?? false {
-                    isNavigate = true
+                Spacer().frame(height: 17 * DynamicSizeFactor.factor())
+                
+                if let image = loadedImage {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity, maxHeight: 236 * DynamicSizeFactor.factor())
+                    
                 } else {
-                    if let chatRoomId = chatRoom?.id {
-                        Log.debug("[ChatRoomDetailView]: id까지 진입")
-
-                        viewModelWrapper.joinChatRoomViewModel.joinChatRoom(chatRoomId: chatRoomId, password: "") { success in
-                            Log.debug("[ChatRoomDetailView]: joinChatRoom까지 진입")
-
-                            if success {
-                                Log.debug("[ChatRoomDetailView]: 채팅방 가입 성공")
-                            } else {
-                                Log.debug("[ChatRoomDetailView]: 채팅방 가입 실패")
+                    Image("illust_chat_no_BG_picture")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity, maxHeight: 236 * DynamicSizeFactor.factor())
+                }
+                
+                Spacer().frame(height: 19 * DynamicSizeFactor.factor())
+                
+                tagSection
+                
+                Spacer().frame(height: 13 * DynamicSizeFactor.factor())
+                
+                VStack(alignment: .leading) {
+                    if let title = chatRoom?.title {
+                        Text("\(title)")
+                            .font(.H2SemiboldFont())
+                            .platformTextColor(color: Color("Gray07"))
+                    }
+                    
+                    Spacer().frame(height: 7 * DynamicSizeFactor.factor())
+                    
+                    if let description = chatRoom?.description {
+                        Text("\(description)")
+                            .font(.B1MediumFont())
+                            .platformTextColor(color: Color("Gray04"))
+                    }
+                }
+                .padding(.horizontal, 20)
+                
+                Spacer()
+                
+                CustomBottomButton(action: {
+                    if chatRoom?.isPrivate ?? false {
+                        isNavigateToSecretRoom = true
+                    } else {
+                        if let chatRoomId = chatRoom?.id {
+                            Log.debug("[ChatRoomDetailView]: id까지 진입")
+                            
+                            viewModelWrapper.joinChatRoomViewModel.joinChatRoom(chatRoomId: chatRoomId, password: "") { success in
+                                Log.debug("[ChatRoomDetailView]: joinChatRoom까지 진입")
+                                
+                                if success {
+                                    Log.debug("[ChatRoomDetailView]: 채팅방 가입 성공")
+                                    isNavigateToChatRoom = true
+                                } else {
+                                    Log.debug("[ChatRoomDetailView]: 채팅방 가입 실패")
+                                }
                             }
                         }
                     }
-                }
-            }, label: "채팅 참여하기", isFormValid: .constant(true))
-                .padding(.bottom, 34 * DynamicSizeFactor.factor())
-
+                }, label: "채팅 참여하기", isFormValid: .constant(true))
+                    .padding(.bottom, 34 * DynamicSizeFactor.factor())
+            }
             if let chatRoomId = chatRoom?.id {
                 if chatRoom?.isPrivate == true {
-                    NavigationLink(destination: SecretRoomView(chatRoom: chatRoom ?? nil, chatRoomId: Int64(chatRoomId), viewModelWrapper: viewModelWrapper), isActive: $isNavigate) {}
+                    NavigationLink(destination: SecretRoomView(chatRoom: chatRoom ?? nil, chatRoomId: Int64(chatRoomId), viewModelWrapper: viewModelWrapper), isActive: $isNavigateToSecretRoom) {}
+                        .hidden()
+                } else {
+                    NavigationLink(
+                        destination: ChatRoomView(chatRoom: chatRoom!),
+                        isActive: $isNavigateToChatRoom
+                    ) {}
                         .hidden()
                 }
             }
@@ -103,7 +112,7 @@ struct ChatRoomDetailView: View, ImageLoadable {
             }
         }
     }
-
+    
     private var tagSection: some View {
         HStack(spacing: 9 * DynamicSizeFactor.factor()) {
             if let isPrivate = chatRoom?.isPrivate, isPrivate {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/SecretRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/SecretRoomView.swift
@@ -6,6 +6,7 @@ struct SecretRoomView: View {
     let chatRoomId: Int64
     @State private var password = ""
     @State private var isPasswordMatch = false // 비밀번호 일치 여부를 관리하는 변수
+    @State private var isNavigateToChatRoom = false
 
     @ObservedObject var viewModelWrapper: ChatViewModelWrapper
 
@@ -54,6 +55,7 @@ struct SecretRoomView: View {
                     viewModelWrapper.joinChatRoomViewModel.joinChatRoom(chatRoomId: chatRoomId, password: password) { success in
                         if success {
                             Log.debug("[SecretRoomView]: 채팅방 가입 성공")
+                            isNavigateToChatRoom = true
                         } else {
                             if viewModelWrapper.joinChatRoomViewModel.isPasswordInvalid {
                                 isPasswordMatch = true
@@ -64,6 +66,12 @@ struct SecretRoomView: View {
                 }
             }, label: "채팅 참여하기", isFormValid: $viewModelWrapper.joinChatRoomViewModel.isFormValid)
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
+
+            NavigationLink(
+                destination: ChatRoomView(chatRoom: chatRoom!),
+                isActive: $isNavigateToChatRoom
+            ) {}
+                .hidden()
         }
         .navigationBarColor(UIColor(named: "White01"), title: "\(chatRoom?.title ?? "")")
         .edgesIgnoringSafeArea(.bottom)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -130,7 +130,7 @@ struct ChatRoomCell: View, ImageLoadable {
                                 Spacer()
                                 // TODO: 채팅방에 마지막으로 접속한 날짜 -> 웹 소켓 연결 후 수정 필요
                                 VStack(alignment: .trailing) {
-                                    Text("어제")
+                                    Text(DateFormatterUtil.formatRelativeDate(from: chatRoom.lastMassage?.createdAt ?? ""))
                                         .font(.B3MediumFont())
                                         .platformTextColor(color: Color("Gray04"))
                                 }
@@ -139,12 +139,19 @@ struct ChatRoomCell: View, ImageLoadable {
                             
                         Spacer().frame(height: 4 * DynamicSizeFactor.factor())
                             
-                        Text(chatRoom.description)
-                            .font(.B3MediumFont())
-                            .platformTextColor(color: Color("Gray07"))
+                        // 내 채팅인 경우 categoryType이 NORMAL인 경우만 뷰에 표시되도록 함
+                        if isMyChat {
+                            Text(chatRoom.lastMassage?.categoryType == "NORMAL" ? chatRoom.lastMassage?.content ?? "" : "")
+                                .font(.B3MediumFont())
+                                .platformTextColor(color: Color("Gray07"))
+                        } else {
+                            Text(chatRoom.description)
+                                .font(.B3MediumFont())
+                                .platformTextColor(color: Color("Gray07"))
+                        }
                             
                         Spacer().frame(height: 3 * DynamicSizeFactor.factor())
-                            
+                        
                         Text("\(chatRoom.participantCount)명")
                             .font(.B3MediumFont())
                             .platformTextColor(color: Color("Gray04"))
@@ -153,21 +160,20 @@ struct ChatRoomCell: View, ImageLoadable {
                     .frame(maxWidth: .infinity, alignment: .leading)
                         
                     if isMyChat {
-                        // TODO: 읽지 않은 채팅방 수 -> 웹 소켓 연결 후 수정 필요
-                        // if chatRoom.notify_enabled {
-                        ZStack {
-                            Text("24")
-                                .font(.B3MediumFont())
-                                .platformTextColor(color: Color("White01"))
-                                .padding(.vertical, 3 * DynamicSizeFactor.factor())
-                                .padding(.horizontal, 4 * DynamicSizeFactor.factor())
-                                .background(Rectangle()
-                                    .cornerRadius(12)
-                                    .platformTextColor(color: Color("Mint03")))
+                        if chatRoom.unreadMessageCount > 0 {
+                            ZStack {
+                                Text("\(chatRoom.unreadMessageCount)")
+                                    .font(.B3MediumFont())
+                                    .platformTextColor(color: Color("White01"))
+                                    .padding(.vertical, 3 * DynamicSizeFactor.factor())
+                                    .padding(.horizontal, 4 * DynamicSizeFactor.factor())
+                                    .background(Rectangle()
+                                        .cornerRadius(12)
+                                        .platformTextColor(color: Color("Mint03")))
+                            }
+                            .offset(x: 105 * DynamicSizeFactor.factor(), y: 10 * DynamicSizeFactor.factor())
                         }
-                        .offset(x: 105 * DynamicSizeFactor.factor(), y: 10 * DynamicSizeFactor.factor())
                     }
-                    // }
                 }
             }
             .padding(.vertical, 8)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/ChatRoomItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/ChatRoomItemModel.swift
@@ -17,4 +17,6 @@ struct ChatRoomItemModel: Equatable, Identifiable, ChatRoomProtocol {
     var isPrivate: Bool
     var isAdmin: Bool
     var participantCount: Int32
+    var lastMassage: LastMessage?
+    var unreadMessageCount: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/GetChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/GetChatRoomViewModel.swift
@@ -71,7 +71,9 @@ class DefaultGetChatRoomViewModel: GetChatRoomViewModel {
                                 backgroundImageUrl: chatRoomDetail.backgroundImageUrl,
                                 isPrivate: chatRoomDetail.isPrivate,
                                 isAdmin: chatRoomDetail.isAdmin,
-                                participantCount: chatRoomDetail.participantCount
+                                participantCount: chatRoomDetail.participantCount,
+                                lastMassage: chatRoomDetail.lastMassage,
+                                unreadMessageCount: chatRoomDetail.unreadMessageCount
                             )
                         }
                         Log.debug("[ChatViewModel]: 내 채팅방 조회 성공")

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/SearchChatRoomItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/SearchChatRoomItemModel.swift
@@ -16,4 +16,6 @@ struct SearchChatRoomItemModel: Equatable, Identifiable, ChatRoomProtocol {
     var isPrivate: Bool
     var backgroundImageUrl: String
     var participantCount: Int32
+    var lastMassage: LastMessage?
+    var unreadMessageCount: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
@@ -5,11 +5,14 @@
 //  Created by 최희진, 아우신얀 on 11/3/24.
 //
 
-/// 내 채팅과 추천채팅에서 보여지는 공통 컴포넌트를 모아놓은 프로토콜
+/// ChatRoomCell 컴포넌트에 필요한 채팅방 정보들
 protocol ChatRoomProtocol {
+    var id: Int64 { get }
     var title: String { get }
     var description: String { get }
     var isPrivate: Bool { get }
     var participantCount: Int32 { get }
     var backgroundImageUrl: String { get }
+    var lastMassage: LastMessage? { get }
+    var unreadMessageCount: Int64 { get }
 }


### PR DESCRIPTION
## 작업 이유
* 마지막 메시지, 읽지 않은 메시지 개수 UI 반영
* 채팅 가입 성공했을 경우 채팅방 내부로 navigate


<br/>

## 작업 사항
### **1️⃣ 마지막 메시지, 읽지 않은 메시지 개수 UI 반영**

**동작과정**

<img src ="https://github.com/user-attachments/assets/096cbbff-592e-46f7-a58d-a863f08b412a" height = "650" width = "350">

chatCellView의 해당하는 한개의 셀에 제목, 마지막 메세지, 읽지 않은 채팅수, 마지막 메세지 시간, 참가자를 표시하도록 수정하였다.

읽지 않은 채팅수는 1개이상인 경우에만 뷰에 표시되도록 하였고, 마지막 메세지 시간은 dto에서 받아온 createdAt 시간을 통해 현 시점을 기준으로 2시간 전, 오늘, 어제 , 일주일 전으로  임시로 표시되도록 하였다. 
디자인팀한테 일주일전 몇시간전, 이 시간을 나타내는 부분을 어떻게 표시해야 할 지 문의한 상태이고 답변받는대로 수정할 예정이다. 지금은 알람 목록 조회와 동일하게 사용하고 있다.

### 
**2️⃣ 채팅 가입 성공했을 경우 채팅방 내부로 navigate**
추천채팅에서 채팅 가입 성공후 채팅방 내부로 이동하도록 구현하였다.
이 과정에서 chatRoomView가 ChatRoomItemModel 만을 타입으로 받고 있길래 ChatRoomProtocol을 받도록 수정하여 추천채팅의 정보가 채팅방 가입이 성공했을 경우 ChatRoomView로 넘어갈 수 있도록 수정하였다.



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
새로 클론 받아서 구현했습니다!! fastlane 없어서 안심하셔도 될거에여 ㅎㅎ.... 
구현은 빨리 했는데 이것저것.. 빌드 오류 해결한다고 이제 올려요!

<br/>

## 발견한 이슈
x

