### PR TITLE
📮🎨 채팅방 리스트 뷰에서 읽지 않은 메시지 내용, 카운팅

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/Chat/GetChatRoomResponseDto.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Domain/ChatDomain/Dto/Response/Chat/GetChatRoomResponseDto.swift
@@ -29,10 +29,10 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
     let isAdmin: Bool
     let participantCount: Int32
     let createdAt: String?
-    let lastMessage: LastMessageData?
+    let lastMessage: GetMessage?
     let unreadMessageCount: Int64
 
-    public init(id: Int64, title: String, description: String, backgroundImageUrl: String, isPrivate: Bool, isAdmin: Bool, participantCount: Int32, createdAt: String?, lastMessage: LastMessageData, unreadMessageCount: Int64) {
+    init(id: Int64, title: String, description: String, backgroundImageUrl: String, isPrivate: Bool, isAdmin: Bool, participantCount: Int32, createdAt: String?, lastMessage: GetMessage, unreadMessageCount: Int64) {
         self.id = id
         self.title = title
         self.description = description
@@ -54,12 +54,12 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
         let completeBackgroundImageUrl = createFullURL(with: cdnUrl, pathComponent: dto.backgroundImageUrl)
 
         // lastMessage가 nil일 경우 기본 LastMessage 생성
-        let defaultLastMessage = LastMessage(
+        let defaultLastMessage = Message(
             chatRoomId: 0,
             chatId: 0,
             content: "",
-            contentType: "",
-            categoryType: "",
+            contentType: ContentType.text,
+            categoryType: CategoryType.normal,
             createdAt: "",
             senderId: 0
         )
@@ -73,7 +73,7 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
             isAdmin: dto.isAdmin,
             participantCount: dto.participantCount,
             createdAt: dto.createdAt ?? "",
-            lastMassage: dto.lastMessage != nil ? LastMessage(
+            lastMassage: dto.lastMessage != nil ? Message(
                 chatRoomId: dto.lastMessage!.chatRoomId,
                 chatId: dto.lastMessage!.chatId,
                 content: dto.lastMessage!.content,
@@ -84,16 +84,4 @@ public struct ChatRoomDetail: Codable, MakeFullImageURL {
             ) : defaultLastMessage,
             unreadMessageCount: dto.unreadMessageCount)
     }
-}
-
-// MARK: - LastMessageData
-
-public struct LastMessageData: Codable {
-    let chatRoomId: Int64
-    let chatId: Int64
-    let content: String
-    let contentType: String
-    let categoryType: String
-    let createdAt: String
-    let senderId: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatRoom.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Models/Chat/ChatRoom.swift
@@ -18,18 +18,6 @@ struct ChatRoom: Equatable, Identifiable {
     let isAdmin: Bool
     let participantCount: Int32
     let createdAt: String
-    let lastMassage: LastMessage?
+    let lastMassage: Message?
     let unreadMessageCount: Int64
-}
-
-// MARK: - LastMessage
-
-struct LastMessage: Equatable {
-    let chatRoomId: Int64
-    let chatId: Int64
-    let content: String
-    let contentType: String
-    let categoryType: String
-    let createdAt: String
-    let senderId: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/GetChatRoomUseCase.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Chat/GetChatRoomUseCase.swift
@@ -38,7 +38,15 @@ class DefaultGetChatRoomUseCase: GetChatRoomUseCase {
                         isPrivate: chatRoom.isPrivate,
                         isAdmin: chatRoom.isAdmin,
                         participantCount: chatRoom.participantCount,
-                        lastMassage: chatRoom.lastMassage,
+                        lastMassage: MessageItemModel(
+                            chatRoomId: chatRoom.lastMassage?.chatRoomId ?? 0,
+                            chatId: chatRoom.lastMassage?.chatId ?? 0,
+                            content: chatRoom.lastMassage?.content ?? "",
+                            contentType: chatRoom.lastMassage?.contentType ?? .text,
+                            categoryType: chatRoom.lastMassage?.categoryType ?? .normal,
+                            createdAt: chatRoom.lastMassage?.createdAt ?? "",
+                            senderId: chatRoom.lastMassage?.senderId ?? 0 
+                        ),
                         unreadMessageCount: chatRoom.unreadMessageCount
                     )
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -63,7 +63,7 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
         cancellables.removeAll() // 모든 구독 해제
     }
 
-    // NotificationCenter에서 메시지 알림 구독
+    /// NotificationCenter에서 메시지 알림 구독
     func subscribeToNotifications() {
         NotificationCenter.default.publisher(for: .didReceiveMessage)
             .sink { [weak self] notification in

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -141,7 +141,7 @@ struct ChatRoomCell: View, ImageLoadable {
                             
                         // 내 채팅인 경우 categoryType이 NORMAL인 경우만 뷰에 표시되도록 함
                         if isMyChat {
-                            Text(chatRoom.lastMassage?.categoryType == "NORMAL" ? chatRoom.lastMassage?.content ?? "" : "")
+                            Text(chatRoom.lastMassage?.categoryType == CategoryType.normal ? chatRoom.lastMassage?.content ?? "" : "")
                                 .font(.B3MediumFont())
                                 .platformTextColor(color: Color("Gray07"))
                         } else {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
@@ -109,6 +109,7 @@ struct ChatCellView: View {
             .onDisappear {
                 viewModelWrapper.searchChatData = []
                 viewModelWrapper.getChatRoomViewModel.initSearch()
+                viewModelWrapper.getChatRoomViewModel.unsubscribeFromNotifications()
                 viewModelWrapper.searchQuery = ""
                 chatRoomName = ""
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/View/ChatCellView.swift
@@ -116,6 +116,7 @@ struct ChatCellView: View {
                 // 뷰에 진입하자마자 내채팅 조회 api 호출
                 viewModelWrapper.getChatRoomViewModel.getChatRoom()
                 viewStateManager.setCurrentView(self, selectedTab: selectedTab)
+                viewModelWrapper.getChatRoomViewModel.subscribeToNotifications()
                 
                 // 검색어 초기화하여 전체 목록 표시
                 viewModelWrapper.searchChatData = []

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/ChatRoomItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/ChatRoomItemModel.swift
@@ -17,6 +17,6 @@ struct ChatRoomItemModel: Equatable, Identifiable, ChatRoomProtocol {
     var isPrivate: Bool
     var isAdmin: Bool
     var participantCount: Int32
-    var lastMassage: LastMessage?
+    var lastMassage: MessageItemModel?
     var unreadMessageCount: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/GetChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/GetChatRoomViewModel.swift
@@ -15,6 +15,7 @@ protocol GetChatRoomViewModelInput {
     func searchChatRoom(target: String)
     func initSearch()
     func subscribeToNotifications()
+    func unsubscribeFromNotifications()
 }
 
 // MARK: - GetChatRoomViewModelOutput
@@ -51,12 +52,33 @@ class DefaultGetChatRoomViewModel: GetChatRoomViewModel {
         hasNext = true
     }
 
+    func unsubscribeFromNotifications() {
+        cancellables.removeAll() // 모든 구독 해제
+    }
+
     init(getChatRoomUseCase: GetChatRoomUseCase, searchChatRoomUseCase: SearchChatRoomUseCase) {
         self.getChatRoomUseCase = getChatRoomUseCase
         self.searchChatRoomUseCase = searchChatRoomUseCase
 
         roomData = Observable([])
         searchRoomData = Observable([])
+    }
+
+    /// NotificationCenter에서 메시지 알림 구독
+    func subscribeToNotifications() {
+        NotificationCenter.default.publisher(for: .didReceiveMessage)
+            .sink { [weak self] notification in
+                // 메시지 받은 경우 처리
+                if let message = notification.object as? MessageItemModel {
+                    if let index = self?.roomData.value.firstIndex(where: { $0.id == message.chatRoomId }) {
+
+                        // 해당 roomData의 lastMassage를 업데이트
+                        self?.roomData.value[index].lastMassage = message
+                        self?.roomData.value[index].unreadMessageCount += 1
+                    }
+                }
+            }
+            .store(in: &cancellables) // 구독 관리
     }
 
     /// 내 채팅방 조회 요청

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/GetChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/GetChatRoomViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 아우신얀 on 10/9/24.
 //
 
-import Foundation
+import Combine
 import UIKit
 
 // MARK: - GetChatRoomViewModelInput
@@ -14,6 +14,7 @@ protocol GetChatRoomViewModelInput {
     func getChatRoom()
     func searchChatRoom(target: String)
     func initSearch()
+    func subscribeToNotifications()
 }
 
 // MARK: - GetChatRoomViewModelOutput
@@ -40,6 +41,7 @@ class DefaultGetChatRoomViewModel: GetChatRoomViewModel {
     private var currentPageNumber: Int = 0
     var hasNext: Bool = true // 다음 페이지가 있는지 여부
     var isFetching: Bool = false // API 호출 중인지 여부를 나타내는 플래그
+    private var cancellables = Set<AnyCancellable>()
 
     /// 검색 초기화
     func initSearch() {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/SearchChatRoomItemModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/ViewModel/SearchChatRoomItemModel.swift
@@ -16,6 +16,6 @@ struct SearchChatRoomItemModel: Equatable, Identifiable, ChatRoomProtocol {
     var isPrivate: Bool
     var backgroundImageUrl: String
     var participantCount: Int32
-    var lastMassage: LastMessage?
+    var lastMassage: MessageItemModel?
     var unreadMessageCount: Int64
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Protocol/ChatRoomProtocol.swift
@@ -13,6 +13,6 @@ protocol ChatRoomProtocol {
     var isPrivate: Bool { get }
     var participantCount: Int32 { get }
     var backgroundImageUrl: String { get }
-    var lastMassage: LastMessage? { get }
+    var lastMassage: MessageItemModel? { get }
     var unreadMessageCount: Int64 { get }
 }


### PR DESCRIPTION
## 작업 이유

- 채팅방 리스트 뷰에서 읽지 않은 메시지 내용, 카운팅


<br/>

## 작업 사항

## 1️⃣ 채팅방 리스트 뷰에서 읽지 않은 메시지 내용, 카운팅

DefaultGetChatRoomViewModel에서 NotificationCenter 메시지 알림 구독을 처리하고 만약 ChatCellView에 있을때 메시지를 받아오면 DefaultGetChatRoomViewModel의 roomData를 변경하도록 하였다.

```swift
NotificationCenter.default.publisher(for: .didReceiveMessage)
      .sink { [weak self] notification in
          // 메시지 받은 경우 처리
          if let message = notification.object as? MessageItemModel {
              if let index = self?.roomData.value.firstIndex(where: { $0.id == message.chatRoomId }) {

                  // 해당 roomData의 lastMassage와 unreadMessageCount를 업데이트
                  self?.roomData.value[index].lastMassage = message
                  self?.roomData.value[index].unreadMessageCount += 1
              }
          }
      }
      .store(in: &cancellables) // 구독 관리
```

roomData의 lastMassage를 받은 메시지로 변경하고, roomData의 unreadMessageCount를 1증가하도록 하였다.

<br/>


- 작동 확인

![Simulator Screen Recording - iPhone 15 Pro - 2024-11-19 at 18 03 41](https://github.com/user-attachments/assets/92ed7301-c4c9-4b52-bcf1-be78e6c105e6)

메시지를 받으면 해당 채팅방의 lastMassage를 변경하고 unreadMessageCount를 1 증가한다.
그리고 채팅방에 들어간 후 다시 나오면 unreadMessageCount가 초기화되어있다.


## 2️⃣ Message 모델 변경

Message 타입에 contentType과 categoryType이 enum 타입이기 때문에 LastMessage로 적용된 부분을 이전에 구현했던 Message타입으로 모두 변경하였다.

- LastMessage -> Message로 변경
- ChatRoomItemModel, SearchChatRoomItemMode의 LastMessage -> MessageItemModel로 변경
- GetChatRoomResponseDto의 ChatRoomDetail의 LastMessageData -> GetMessage로 변경


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 리스트 뷰에서 읽지 않은 메시지 내용, 카운팅 구현했습니다~~
그리고 디코에 말씀드린 신얀님이 LastMessage로 구현하셨던 부분 모두 Message로 수정했습니다~

<br/>

## 발견한 이슈
없음