### PR TITLE
🎨 채팅방에서 뒤로가기 했을 경우 내채팅으로 이동 및 채팅 count가 100개이상인 경우 99+로 표시

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -14,6 +14,8 @@ struct ChatRoomView: View {
     @State private var isSideMenuPresented = false
     @EnvironmentObject var viewStateManager: ViewStateManager
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
+    @State private var isNavigateToMyChat = false
+    @ObservedObject var chatViewModelWrapper: ChatViewModelWrapper
 
     var chatRoom: ChatRoomProtocol
     private let currentUserId = getUserData()!.id
@@ -38,10 +40,18 @@ struct ChatRoomView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     HStack {
-                        NavigationBackButton()
-                            .padding(.leading, 5)
-                            .frame(width: 44, height: 44)
-                            .contentShape(Rectangle())
+                        Button(action: {
+                            isNavigateToMyChat = true
+                        }, label: {
+                            Image("icon_arrow_back")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 34, height: 34)
+                                .padding(5)
+                        })
+                        .padding(.leading, 5)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                     }.offset(x: -10)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
@@ -88,6 +98,9 @@ struct ChatRoomView: View {
                     .transition(.move(edge: .trailing))
                     .animation(.easeInOut(duration: 0.3))
             }
+
+            NavigationLink(destination: ChatCellView(viewModelWrapper: chatViewModelWrapper), isActive: $isNavigateToMyChat) {}
+                .hidden()
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/ChatRoomDetailView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/ChatRoomDetailView.swift
@@ -80,7 +80,7 @@ struct ChatRoomDetailView: View, ImageLoadable {
                         .hidden()
                 } else {
                     NavigationLink(
-                        destination: ChatRoomView(chatRoom: chatRoom!),
+                        destination: ChatRoomView(chatViewModelWrapper: viewModelWrapper, chatRoom: chatRoom!),
                         isActive: $isNavigateToChatRoom
                     ) {}
                         .hidden()

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/SecretRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/SecretRoomView.swift
@@ -68,7 +68,7 @@ struct SecretRoomView: View {
                 .padding(.bottom, 34 * DynamicSizeFactor.factor())
 
             NavigationLink(
-                destination: ChatRoomView(chatRoom: chatRoom!),
+                destination: ChatRoomView(chatViewModelWrapper: viewModelWrapper, chatRoom: chatRoom!),
                 isActive: $isNavigateToChatRoom
             ) {}
                 .hidden()

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -162,7 +162,7 @@ struct ChatRoomCell: View, ImageLoadable {
                     if isMyChat {
                         if chatRoom.unreadMessageCount > 0 {
                             ZStack {
-                                Text("\(chatRoom.unreadMessageCount)")
+                                Text(chatRoom.unreadMessageCount >= 100 ? "99+" : "\(chatRoom.unreadMessageCount)")
                                     .font(.B3MediumFont())
                                     .platformTextColor(color: Color("White01"))
                                     .padding(.vertical, 3 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -19,7 +19,7 @@ struct ChatRoomContent: View {
                 if isMyChat {
                     if let rooms = dummyChatRooms {
                         ForEach(rooms, id: \.id) { chatRoom in
-                            NavigationLink(destination: ChatRoomView(chatRoom: chatRoom)) {
+                            NavigationLink(destination: ChatRoomView(chatViewModelWrapper: viewModelWrapper, chatRoom: chatRoom)) {
                                 ChatRoomCell(chatRoom: chatRoom, isMyChat: true, onDelete: {
                                     isPopUp = true
                                     selectedChatRoom = chatRoom


### PR DESCRIPTION
## 작업 이유
- 채팅가입 성공시 채팅방에서 뒤로가기 했을 경우 내채팅으로 이동
- 채팅 갯수 100개이상인 경우 99+로 표시

<br/>

## 작업 사항
### **1️⃣ 채팅가입 성공시 채팅방에서 뒤로가기 했을 경우 내채팅으로 이동**

시연을 위해 우선 NavigationLink로 채팅방 내부에서 뒤로가기 버튼을 눌렀을시 ChatCellView로 이동하도록 구현하였다. 채팅방에 진입하는 조건은 1. 내채팅, 2. 채팅방 가입 에 해당하기 때문에 NavigationLink로 ChatCellView를 연결하는게 가능했던 것이지만 이슈등록후 추후 수정예정이다.

**동작과정**
![Simulator Screen Recording - iPhone 15 - 2024-11-20 at 21 21 00](https://github.com/user-attachments/assets/df006ec1-c01f-4cd0-b266-61e2b321bdbd)

### **2️⃣ 미확인 채팅 count가 100개이상인 경우 99+로 표시**
미확인 채팅 개수가 count되는 조건은 아래와 같다. 따라서 아래 조건에 맞추어 수정하였다.
```
1. 0개인 경우 표시x
2. 1~99개인 경우 숫자 그대로 표시
3. 100이상인 경우 99+로 표시
``` 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
구현완료 했고 1번은 이슈등록 해두겠습니다!

<br/>

## 발견한 이슈
x