### PR TITLE
🎨 채팅방 비밀번호 유효성 검사 로직 수정 및 ui 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/SecretRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/View/SecretRoomView.swift
@@ -7,6 +7,7 @@ struct SecretRoomView: View {
     @State private var password = ""
     @State private var isPasswordMatch = false // 비밀번호 일치 여부를 관리하는 변수
     @State private var isNavigateToChatRoom = false
+    @State private var isFirstAttempt = true
 
     @ObservedObject var viewModelWrapper: ChatViewModelWrapper
 
@@ -38,6 +39,12 @@ struct SecretRoomView: View {
                         password = String(password.prefix(6))
                     }
                     viewModelWrapper.joinChatRoomViewModel.validatePwForm(password: password)
+                    if !password.isEmpty {
+                        isPasswordMatch = false
+                    }
+                }
+                .onChange(of: isPasswordMatch) { _ in
+                    password = ""
                 }
 
             if isPasswordMatch {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/ViewModel/JoinChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoomDetail/ViewModel/JoinChatRoomViewModel.swift
@@ -57,6 +57,7 @@ class DefaultJoinChatRoomViewModel: JoinChatRoomViewModel {
                     switch joinChatRoomError {
                     case .invalidPassword:
                         self.isPasswordInvalid = true 
+                        self.isFormValid = false
                         completion(false)
                     case .other:
                         self.isPasswordInvalid = false

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -54,6 +54,8 @@ struct ChatRoomContent: View {
                                 }
                                 
                             })
+                            .buttonStyle(PlainButtonStyle())
+                            .buttonStyle(BasicButtonStyleUtil())
                         }
                     }
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -24,6 +24,8 @@ struct ChatRoomContent: View {
                                     isPopUp = true
                                     selectedChatRoom = chatRoom
                                 })
+                                .buttonStyle(PlainButtonStyle())
+                                .buttonStyle(BasicButtonStyleUtil())
                             }
                             .transition(.move(edge: .trailing).combined(with: .opacity))
                         }
@@ -95,6 +97,8 @@ struct ChatRoomCell: View, ImageLoadable {
                         .background(Color("Red03"))
                         
                     })
+                    .transition(.opacity)
+                    .opacity(isShowingDeleteButton ? 1 : 0) // 버튼이 보이는 경우에만 완전 표시
                 }
             }
             // 채팅방 셀
@@ -186,7 +190,7 @@ struct ChatRoomCell: View, ImageLoadable {
                     .onChanged { value in
                         withAnimation {
                             if value.translation.width < 0, isMyChat { // 내 채팅방일 때만 스와이프 가능
-                                offset = max(value.translation.width, -90)
+                                offset = max(value.translation.width, -110)
                                 isShowingDeleteButton = true
                             } else {
                                 offset = 0
@@ -199,9 +203,11 @@ struct ChatRoomCell: View, ImageLoadable {
                             if value.translation.width < -80, isMyChat {
                                 // 스와이프가 80pt 이상이면 삭제 버튼 표시
                                 offset = -90 * DynamicSizeFactor.factor()
+                                isShowingDeleteButton = true
                             } else {
                                 // 그렇지 않으면 원래 위치로 복구
                                 offset = 0
+                                isShowingDeleteButton = false
                             }
                         }
                     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/MainChat/Component/ChatRoomContent.swift
@@ -134,7 +134,7 @@ struct ChatRoomCell: View, ImageLoadable {
                                 Spacer()
                                 // TODO: 채팅방에 마지막으로 접속한 날짜 -> 웹 소켓 연결 후 수정 필요
                                 VStack(alignment: .trailing) {
-                                    Text(DateFormatterUtil.formatRelativeDate(from: chatRoom.lastMassage?.createdAt ?? ""))
+                                    Text(DateFormatterUtil.formatUnReadChatDate(from: chatRoom.lastMassage?.createdAt ?? ""))
                                         .font(.B3MediumFont())
                                         .platformTextColor(color: Color("Gray04"))
                                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
@@ -74,4 +74,34 @@ enum DateFormatterUtil {
             return "오늘"
         }
     }
+
+    static func formatUnReadChatDate(from createdAt: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone.current
+
+        guard let date = formatter.date(from: createdAt) else {
+            return createdAt // 변환 실패 시 원본 반환
+        }
+
+        let calendar = Calendar.current
+        let now = Date()
+
+        if calendar.isDateInToday(date) {
+            let components = calendar.dateComponents([.hour, .minute], from: date, to: now)
+            if let minutes = components.minute, minutes < 60 {
+                return "\(minutes)분 전"
+            } else if let hours = components.hour, hours < 24 {
+                return "\(hours)시간 전"
+            }
+        }
+
+        if calendar.isDateInYesterday(date) {
+            return "어제"
+        }
+
+        formatter.dateFormat = "M월 d일"
+        return formatter.string(from: date)
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 미확인 채팅 도착 날짜 디자인팀 답변 반영
- 채팅방 비밀번호 유효성 검사 실패시 => 하단 버튼 비활성화, 비밀번호 입력 초기화
- 내 채팅 셀 꾹눌렀을 경우 나가기 버튼 희미하게 보이는 문제 해결

<br/>

## 작업 사항
### **1️⃣  미확인 채팅 도착 날짜 디자인팀 답변 반영**
디자인팀한테 답변 받은 양식은 아래와 같다.
`지금 - 1~59분 전 - 1~23시간 전 (분 표시x) - 어제 - 이후 부터는 날짜 표기 (ex.-월 -일)`

따라서 채팅리스트에서만 표현되는 미확인 채팅 도착 날짜 dateformatter를 구분하기 위해서 DateFormatterUtil에 `formatUnReadChatDate`를 추가 구현해주었다.

문자열로 받은 createdAt을 날짜로 변환하여 현재날짜와 얼마나 차이나는지를 계산해주고 다시 문자열 값으로 return 해주도록 구현하였다.
```swift
        let calendar = Calendar.current
        let now = Date()

        if calendar.isDateInToday(date) {
            let components = calendar.dateComponents([.hour, .minute], from: date, to: now)
            if let minutes = components.minute, minutes < 60 {
                return "\(minutes)분 전"
            } else if let hours = components.hour, hours < 24 {
                return "\(hours)시간 전"
            }
        }

        if calendar.isDateInYesterday(date) {
            return "어제"
        }

        formatter.dateFormat = "M월 d일"
        return formatter.string(from: date)
``` 
### **2️⃣ 채팅방 비밀번호 유효성 검사 실패시 => 하단 버튼 비활성화, 비밀번호 입력 초기화**

채팅방 가입 시 비밀방에서 유효성 검사가 실패하여 "비밀번호 입력이 틀렸습니다."라는 문구가 뜰 때 하단 버튼도 비활성화되며 입력한 password도 초기화되도록 수정하였다.

onChange를 통해 실패문구가 뜰 때 password를 초기화 시켰고, 뷰모델에서 채팅가입에 실패했을 경우 isFormValid = false값을 주어 하단 버튼 "채팅 가입하기" 를 비활성화 시켰다.


### **3️⃣ 내채팅 셀 꾹 눌렀을 시 나가기 버튼 희미하게 보이는 거 처리**
나가기 버튼이 포함된 뷰에 나가기 버튼의 표시 유무를 나타내는 isShowingDeleteButton을 opacity에 적용해주면서 해당 이슈는 해결되었다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
ui 수정이랑 채팅방 비밀번호 유효성 검사 실패시 => 하단 버튼 비활성화, 비밀번호 입력 초기화 하는 부분 구현하였습니다! 
근데 여전히 셀을 꾹눌렀을때 희미해지는..? 이벤트는 처리가 잘 안되네여 ㅠㅠ..

<br/>

## 발견한 이슈
x