### PR TITLE
🎨 채팅 보낸 후 키보드 유지되도록 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -71,6 +71,7 @@ struct ChatBottomBar: View {
         VStack {
             Spacer()
             Button(action: {
+                UIApplication.shouldDismissKeyboard = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     showFeature.toggle()
                 }
@@ -121,6 +122,7 @@ struct ChatBottomBar: View {
             Spacer()
             if !message.isEmpty {
                 Button(action: {
+                    UIApplication.shouldDismissKeyboard = false
                     viewModelWrapper.chatRoomViewModel.sendMessage(message: message, chatRoomId: viewModelWrapper.roomData?.id ?? 0, contentType: ContentType.text.rawValue)
                     message = ""
                 }) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -95,6 +95,9 @@ struct ChatContent: View {
                 // 처음 열릴 때 가장 아래로 스크롤
                 proxy.scrollTo("bottom", anchor: .bottom)
             }
+            .onTapGesture {
+                UIApplication.shouldDismissKeyboard = true // 빈 화면 터치 시 키보드 닫기
+            }
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -41,6 +41,7 @@ struct ChatRoomView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     HStack {
                         Button(action: {
+                            UIApplication.shouldDismissKeyboard = true
                             isNavigateToMyChat = true
                         }, label: {
                             Image("icon_arrow_back")
@@ -58,6 +59,7 @@ struct ChatRoomView: View {
                     HStack {
                         Button(action: {
                             withAnimation {
+                                UIApplication.shouldDismissKeyboard = true
                                 isSideMenuPresented.toggle()
                             }
                         }, label: {

--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/TapGestureRecognizer.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/TapGestureRecognizer.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension UIApplication {
-    static var shouldDismissKeyboard: Bool = true
+    static var shouldDismissKeyboard: Bool = true// 키보드 닫기 여부
 
     func addTapGestureRecognizer() {
         guard let window = windows.first else {
@@ -15,13 +15,15 @@ extension UIApplication {
         window.addGestureRecognizer(tapGesture)
     }
 
+    /// 화면 터치하는 경우 실행
     @objc private func handleTapGesture(_: UITapGestureRecognizer) {
         guard let window = windows.first else {
             return
         }
 
+        // shouldDismissKeyboard가 true이면 키보드 닫기
         if UIApplication.shouldDismissKeyboard {
-            window.endEditing(true) // 키보드 닫기
+            window.endEditing(true)
         }
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Extension/TapGestureRecognizer.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Extension/TapGestureRecognizer.swift
@@ -1,15 +1,28 @@
 import SwiftUI
 
 extension UIApplication {
+    static var shouldDismissKeyboard: Bool = true
+
     func addTapGestureRecognizer() {
         guard let window = windows.first else {
             return
         }
-        let tapGesture = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(_:)))
         tapGesture.requiresExclusiveTouchType = false
         tapGesture.cancelsTouchesInView = false
         tapGesture.delegate = self
         window.addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func handleTapGesture(_: UITapGestureRecognizer) {
+        guard let window = windows.first else {
+            return
+        }
+
+        if UIApplication.shouldDismissKeyboard {
+            window.endEditing(true) // 키보드 닫기
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 이유

- 채팅 보낸 후 키보드 유지되도록 구현

<br/>

## 작업 사항

### 1️⃣  채팅 보낸 후 키보드 유지되도록 구현

<br/>

- 문제

화면 터치하는 경우 키보드가 닫히도록하는 UIApplication.shared.addTapGestureRecognizer를 app 파일에서 onAppear로 구현하고 있어서 채팅 보내는 버튼도 화면으로 인식하여 채팅 한번 보내면 키보드가 계속 닫히는 문제가 있었다.


<br/>

- 해결

기존에 구현했던 TapGestureRecognizer 파일의 코드에 shouldDismissKeyboard 변수를 추가하였다.
그래서 화면을 클릭했을 때 handleTapGesture가 실행되고 shouldDismissKeyboard의 값에 따라 키보드 닫을지 말지 선택한다.


```swift
extension UIApplication {
    static var shouldDismissKeyboard: Bool = true// 키보드 닫기 여부
   ...
   @objc private func handleTapGesture(_: UITapGestureRecognizer) {
        guard let window = windows.first else {
            return
        }

        if UIApplication.shouldDismissKeyboard {
            window.endEditing(true) // 키보드 닫기
        }
    }
```


<br/>


- 적용

ChatBottomBar의 sendButton을 클릭한 경우에만 `UIApplication.shouldDismissKeyboard = false`로 설정하여 키보드가 사라지지 않도록 했다.
그리고 sendButton이 아닌 다른 화면을 클릭한 경우에는 `UIApplication.shouldDismissKeyboard = true`로 설정하여 채팅보내는 과정에서만 키보드가 사라지지않도록 구현했다.


<br/>


- 작동 확인

![Simulator Screen Recording - iPhone 15 Pro - 2024-11-21 at 14 43 21](https://github.com/user-attachments/assets/47b220e9-b506-4656-a16b-c77066ae334e)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅 보낸 후 키보드 유지되도록 구현했습니다~

<br/>

## 발견한 이슈
없음