### PR TITLE
🛠️ 채팅방 로딩 중 오류 및 공백 비허용

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -119,7 +119,7 @@ struct ChatBottomBar: View {
     private var SendButton: some View {
         VStack {
             Spacer()
-            if !message.isEmpty {
+            if !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 Button(action: {
                     viewModelWrapper.chatRoomViewModel.sendMessage(message: message, chatRoomId: viewModelWrapper.roomData?.id ?? 0, contentType: ContentType.text.rawValue)
                     message = ""
@@ -131,7 +131,7 @@ struct ChatBottomBar: View {
                         .padding(.bottom, 8)
                 }
                 .transition(.opacity)
-                .animation(.easeInOut, value: message.isEmpty)
+                .animation(.easeInOut, value: message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .buttonStyle(PlainButtonStyle())
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -100,8 +100,10 @@ private struct SideMenuContent: View {
     
     private var SideMenuCells: some View {
         VStack {
-            if members[0].role.rawValue == Role.admin.rawValue { // 첫번째 사용자(나)가 방장인지 확인 후 ui
-                SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone_no_padding", isAlarmCell: false, isAlarmOn: .constant(false))
+            if !members.isEmpty {
+                if members[0].role.rawValue == Role.admin.rawValue { // 첫번째 사용자(나)가 방장인지 확인 후 ui
+                    SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone_no_padding", isAlarmCell: false, isAlarmOn: .constant(false))
+                }
             }
             
             SideMenuCell(title: "알람 설정", imageName: "icon_notificationsetting_no_padding", isAlarmCell: true, isAlarmOn: $isAlarmOn)


### PR DESCRIPTION
## 작업 이유

- 채팅방 로딩 중 오류
- 공백 비허용


<br/>

## 작업 사항

## 1️⃣ 채팅방 로딩 중 오류

채팅방 상세 조회 api의 응답을 받아오기전 사이드 메뉴를 누르면 앱이 강제종료되는 문제가 있었다.

문제가 되던 코드의 members가 빈 값이면 보여주지 않도록 해서 members[0]일때의 오류가 없도록 하였다.

```swift
if !members.isEmpty {
    if members[0].role.rawValue == Role.admin.rawValue { // 첫번째 사용자(나)가 방장인지 확인 후 ui
        SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone_no_padding", isAlarmCell: false, isAlarmOn: .constant(false))
    }
}
```

- 해결

![Simulator Screen Recording - iPhone 15 Pro - 2024-11-21 at 15 18 41](https://github.com/user-attachments/assets/91850959-0b54-4d51-9915-e03509393845)


<br/>

## 2️⃣ 공백 비허용

채팅 입력할 때 공백만 있는 경우를 처리하지 않도록 하였다.
그래서 `!message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty` 를 사용해서 만약 공백이나 줄바꿈을 모두 제거하고도 텍스트가 있는지를 확인할 수 있다.

`!message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty`이 true이면 공백이나 줄바꿈을 모두 제거하고도 텍스트가 있다는 걸 의미하니 전송 버튼이 활성화된다.

- 해결

![Simulator Screen Recording - iPhone 15 Pro - 2024-11-21 at 22 21 31](https://github.com/user-attachments/assets/56ca91bf-45fa-4043-982d-54aac295cf8b)



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 로딩 중 오류 및 공백 비허용 구현했습니다~

<br/>

## 발견한 이슈
없음