### PR TITLE
🎨 채팅방 설정 뷰 변경된 ui 반영

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 		4AE8F3AF2C3307940014F0D4 /* CustomDropDownMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3AE2C3307940014F0D4 /* CustomDropDownMenuView.swift */; };
 		4AE8F3B42C330A0B0014F0D4 /* TargetAmountSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3B32C330A0B0014F0D4 /* TargetAmountSettingView.swift */; };
 		4AE8F3B62C330F7A0014F0D4 /* TargetAmountSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8F3B52C330F7A0014F0D4 /* TargetAmountSettingViewModel.swift */; };
-		4AE9B32E2CB67E3E0044D3E1 /* ChatSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9B32D2CB67E3E0044D3E1 /* ChatSettingView.swift */; };
+		4AE9B32E2CB67E3E0044D3E1 /* ChatRoomSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9B32D2CB67E3E0044D3E1 /* ChatRoomSettingView.swift */; };
 		4AE9B3332CB689E50044D3E1 /* CustomRoundedBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9B3322CB689E50044D3E1 /* CustomRoundedBtn.swift */; };
 		4AE9B3402CB6E5770044D3E1 /* ChatSideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9B33F2CB6E5770044D3E1 /* ChatSideMenuView.swift */; };
 		4AE9B3422CB6E5A00044D3E1 /* SideMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9B3412CB6E5A00044D3E1 /* SideMenuCell.swift */; };
@@ -768,7 +768,7 @@
 		4AE8F3AE2C3307940014F0D4 /* CustomDropDownMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownMenuView.swift; sourceTree = "<group>"; };
 		4AE8F3B32C330A0B0014F0D4 /* TargetAmountSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAmountSettingView.swift; sourceTree = "<group>"; };
 		4AE8F3B52C330F7A0014F0D4 /* TargetAmountSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAmountSettingViewModel.swift; sourceTree = "<group>"; };
-		4AE9B32D2CB67E3E0044D3E1 /* ChatSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSettingView.swift; sourceTree = "<group>"; };
+		4AE9B32D2CB67E3E0044D3E1 /* ChatRoomSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomSettingView.swift; sourceTree = "<group>"; };
 		4AE9B3322CB689E50044D3E1 /* CustomRoundedBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRoundedBtn.swift; sourceTree = "<group>"; };
 		4AE9B33F2CB6E5770044D3E1 /* ChatSideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSideMenuView.swift; sourceTree = "<group>"; };
 		4AE9B3412CB6E5A00044D3E1 /* SideMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuCell.swift; sourceTree = "<group>"; };
@@ -2484,7 +2484,7 @@
 		4AE9B32C2CB67E330044D3E1 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				4AE9B32D2CB67E3E0044D3E1 /* ChatSettingView.swift */,
+				4AE9B32D2CB67E3E0044D3E1 /* ChatRoomSettingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3353,7 +3353,7 @@
 				4AB5AB472BB4A32F00D2C9EA /* AuthAlamofire.swift in Sources */,
 				4A5050332BC3DA7700EE5666 /* PhoneNumberFormatterUtil.swift in Sources */,
 				4A51D2AC2BB1855A0080083D /* CustomBottomButton.swift in Sources */,
-				4AE9B32E2CB67E3E0044D3E1 /* ChatSettingView.swift in Sources */,
+				4AE9B32E2CB67E3E0044D3E1 /* ChatRoomSettingView.swift in Sources */,
 				4A0BC6AA2BF5F5DB0036D900 /* StringAttributeExtensions.swift in Sources */,
 				4AC3205B2C11F31C00DDB4B6 /* GetTotalTargetAmountRequestDto.swift in Sources */,
 				4AC320442C11D5AC00DDB4B6 /* AddSpendingInputFormView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -43,6 +43,7 @@ struct ChatRoomView: View {
                         Button(action: {
                             UIApplication.shouldDismissKeyboard = true
                             isNavigateToMyChat = true
+                            viewModelWrapper.chatRoomViewModel.reset()
                         }, label: {
                             Image("icon_arrow_back")
                                 .resizable()
@@ -82,9 +83,6 @@ struct ChatRoomView: View {
                 // 채팅방 상세 정보 조회
                 viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: Int64(chatRoom.id))
                 viewModelWrapper.chatRoomViewModel.subscribeToNotifications()
-            }
-            .onDisappear {
-                viewModelWrapper.chatRoomViewModel.reset()
             }
 
             if isSideMenuPresented {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
@@ -1,5 +1,5 @@
 //
-//  ChatSettingView.swift
+//  ChatRoomSettingView.swift
 //  pennyway-client-iOS
 //
 //  Created by 최희진 on 10/9/24.
@@ -12,7 +12,6 @@ struct ChatRoomSettingView: View {
     @State private var isPublic: Bool = false // 토글 상태를 관리하는 변수
     @State private var chatRoomName: String = ""
     @State private var password: String = ""
-    @State private var isNavigateToEditView: Bool = false
     @State private var showCompleteToastPopup: Bool = false
     @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
@@ -14,6 +14,7 @@ struct ChatRoomSettingView: View {
     @State private var password: String = ""
     @State private var isNavigateToEditView: Bool = false
     @State private var showCompleteToastPopup: Bool = false
+    @EnvironmentObject var viewModelWrapper: ChatRoomViewModelWrapper
 
     var body: some View {
         ZStack {
@@ -109,18 +110,17 @@ struct ChatRoomSettingView: View {
                     .fill(Color("Gray01"))
                     .frame(height: 46 * DynamicSizeFactor.factor())
 
-                Button(action: {
-                    isNavigateToEditView = true
-                }) {
-                    HStack {
-                        TextField("", text: $chatRoomName)
-                            .font(.H4MediumFont())
-                            .platformTextColor(color: Color("Gray07"))
-                            .padding(.horizontal, 13 * DynamicSizeFactor.factor())
-                        Spacer()
-                    }
+                if chatRoomName.isEmpty {
+                    Text(viewModelWrapper.chatRoomViewModel.roomData.value?.title ?? "")
+                        .font(.H4MediumFont())
+                        .platformTextColor(color: Color("Gray07"))
+                        .padding(.leading, 13 * DynamicSizeFactor.factor())
                 }
-                .buttonStyle(PlainButtonStyle())
+
+                TextField("", text: $chatRoomName)
+                    .font(.H4MediumFont())
+                    .platformTextColor(color: Color("Gray07"))
+                    .padding(.horizontal, 13 * DynamicSizeFactor.factor())
             }
         }
         .padding(.horizontal, 20)
@@ -159,6 +159,11 @@ struct ChatRoomSettingView: View {
                         .platformTextColor(color: Color("Gray07"))
                         .padding(.horizontal, 13 * DynamicSizeFactor.factor())
                         .keyboardType(.numberPad)
+                        .onChange(of: password) { pw in
+                            if pw.count > 6 {
+                                password = String(pw.prefix(6))
+                            }
+                        }
                 }
             }
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-struct ChatSettingView: View {
+struct ChatRoomSettingView: View {
     @State private var isPublic: Bool = false // 토글 상태를 관리하는 변수
+    @State private var chatRoomName: String = ""
     @State private var password: String = ""
     @State private var isNavigateToEditView: Bool = false
 
@@ -16,7 +17,7 @@ struct ChatSettingView: View {
         ScrollView {
             VStack {
                 // 상단 여백 및 아이콘 이미지
-                Spacer().frame(height: 17 * DynamicSizeFactor.factor())
+                Spacer().frame(height: 30 * DynamicSizeFactor.factor())
 
                 Image("icon_illust_maintain_goal")
                     .resizable()
@@ -24,7 +25,7 @@ struct ChatSettingView: View {
                     .frame(width: 88 * DynamicSizeFactor.factor(), height: 88 * DynamicSizeFactor.factor())
                     .cornerRadius(12 * DynamicSizeFactor.factor())
 
-                Spacer().frame(height: 17 * DynamicSizeFactor.factor())
+                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
 
                 // 채팅방 커버 수정 버튼
                 CustomRoundedBtn(title: "채팅방 커버 변경", fontColor: Color("Mint03"), backgroundColor: Color("Mint01"), style: .large) {
@@ -49,11 +50,24 @@ struct ChatSettingView: View {
         .setTabBarVisibility(isHidden: true)
         .navigationBarBackButtonHidden(true)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 NavigationBackButton()
                     .padding(.leading, 5)
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                HStack {
+                    Button(action: {
+                        
+                    }, label: {
+                        Text("완료")
+                            .font(.H4MediumFont())
+                            .platformTextColor(color: .mint03)
+                            .padding(.trailing, 10)
+                    })
+                    .buttonStyle(PlainButtonStyle())
+                }
             }
         }
     }
@@ -74,16 +88,11 @@ struct ChatSettingView: View {
                     isNavigateToEditView = true
                 }) {
                     HStack {
-                        Text("채팅방 이름")
+                        TextField("", text: $chatRoomName)
                             .font(.H4MediumFont())
                             .platformTextColor(color: Color("Gray07"))
                             .padding(.horizontal, 13 * DynamicSizeFactor.factor())
                         Spacer()
-                        Image("icon_navigationbar_write_primary")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 20 * DynamicSizeFactor.factor(), height: 20 * DynamicSizeFactor.factor())
-                            .padding(.trailing, 13 * DynamicSizeFactor.factor())
                     }
                 }
                 .buttonStyle(PlainButtonStyle())
@@ -120,6 +129,7 @@ struct ChatSettingView: View {
                         .font(.H4MediumFont())
                         .platformTextColor(color: Color("Gray07"))
                         .padding(.horizontal, 13 * DynamicSizeFactor.factor())
+                        .keyboardType(.numberPad)
                 }
             }
         }
@@ -128,5 +138,5 @@ struct ChatSettingView: View {
 }
 
 #Preview {
-    ChatSettingView()
+    ChatRoomSettingView()
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
@@ -12,39 +12,60 @@ struct ChatRoomSettingView: View {
     @State private var chatRoomName: String = ""
     @State private var password: String = ""
     @State private var isNavigateToEditView: Bool = false
+    @State private var showCompleteToastPopup: Bool = false
 
     var body: some View {
-        ScrollView {
-            VStack {
-                // 상단 여백 및 아이콘 이미지
-                Spacer().frame(height: 30 * DynamicSizeFactor.factor())
+        ZStack {
+            ScrollView {
+                VStack {
+                    // 상단 여백 및 아이콘 이미지
+                    Spacer().frame(height: 30 * DynamicSizeFactor.factor())
 
-                Image("icon_illust_maintain_goal")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 88 * DynamicSizeFactor.factor(), height: 88 * DynamicSizeFactor.factor())
-                    .cornerRadius(12 * DynamicSizeFactor.factor())
+                    Image("icon_illust_maintain_goal")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 88 * DynamicSizeFactor.factor(), height: 88 * DynamicSizeFactor.factor())
+                        .cornerRadius(12 * DynamicSizeFactor.factor())
 
-                Spacer().frame(height: 16 * DynamicSizeFactor.factor())
+                    Spacer().frame(height: 16 * DynamicSizeFactor.factor())
 
-                // 채팅방 커버 수정 버튼
-                CustomRoundedBtn(title: "채팅방 커버 변경", fontColor: Color("Mint03"), backgroundColor: Color("Mint01"), style: .large) {
-                    // 버튼 액션
+                    // 채팅방 커버 수정 버튼
+                    CustomRoundedBtn(title: "채팅방 커버 변경", fontColor: Color("Mint03"), backgroundColor: Color("Mint01"), style: .large) {
+                        // 버튼 액션
+                    }
+
+                    Spacer().frame(height: 25 * DynamicSizeFactor.factor())
+
+                    // 채팅방 이름 입력
+                    ChatRoomNameSection
+
+                    Spacer().frame(height: 32 * DynamicSizeFactor.factor())
+
+                    // 공개 범위 설정
+                    PublicScopeSection
+
+                    Spacer()
                 }
-
-                Spacer().frame(height: 35 * DynamicSizeFactor.factor())
-
-                // 채팅방 이름 입력
-                ChatRoomNameSection
-
-                Spacer().frame(height: 35 * DynamicSizeFactor.factor())
-
-                // 공개 범위 설정
-                PublicScopeSection
-
-                Spacer()
             }
         }
+        .overlay(
+            Group {
+                if showCompleteToastPopup {
+                    CustomToastView(message: "변경 사항이 저장되었어요")
+                        .transition(.move(edge: .bottom))
+                        .animation(.easeInOut(duration: 0.2)) // 애니메이션 시간
+                        .padding(.bottom, 34 * DynamicSizeFactor.factor())
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                                if showCompleteToastPopup {
+                                    showCompleteToastPopup = false
+                                }
+                            }
+                        }
+                }
+            }, alignment: .bottom
+        )
+        .edgesIgnoringSafeArea(.bottom)
         .navigationBarColor(UIColor(named: "White01"), title: "채팅방 설정")
         .background(Color("White01"))
         .setTabBarVisibility(isHidden: true)
@@ -52,14 +73,14 @@ struct ChatRoomSettingView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 NavigationBackButton()
-                    .padding(.leading, 5)
+                    .padding(.trailing, 10)
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
             ToolbarItem(placement: .topBarTrailing) {
                 HStack {
                     Button(action: {
-                        
+                        showCompleteToastPopup = true
                     }, label: {
                         Text("완료")
                             .font(.H4MediumFont())
@@ -103,7 +124,7 @@ struct ChatRoomSettingView: View {
 
     /// 공개 범위 설정 섹션
     private var PublicScopeSection: some View {
-        VStack(alignment: .leading, spacing: 13 * DynamicSizeFactor.factor()) {
+        VStack(alignment: .leading, spacing: 8 * DynamicSizeFactor.factor()) {
             Text("공개 범위")
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Gray04"))
@@ -116,8 +137,10 @@ struct ChatRoomSettingView: View {
                 Spacer()
 
                 Toggle(isOn: $isPublic) {}
-                    .toggleStyle(CustomToggleStyle(hasAppeared: $isPublic))
+                    .toggleStyle(CustomToggleStyle(hasAppeared: .constant(true)))
             }
+
+            Spacer().frame(height: 3 * DynamicSizeFactor.factor())
 
             if !isPublic {
                 ZStack(alignment: .leading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ChatRoomSettingView: View {
+    @StateObject private var keyboardHandler = KeyboardManager()
     @State private var isPublic: Bool = false // 토글 상태를 관리하는 변수
     @State private var chatRoomName: String = ""
     @State private var password: String = ""
@@ -19,7 +20,7 @@ struct ChatRoomSettingView: View {
             ScrollView {
                 VStack {
                     // 상단 여백 및 아이콘 이미지
-                    Spacer().frame(height: 30 * DynamicSizeFactor.factor())
+                    Spacer().frame(height: 20 * DynamicSizeFactor.factor())
 
                     Image("icon_illust_maintain_goal")
                         .resizable()
@@ -46,7 +47,10 @@ struct ChatRoomSettingView: View {
 
                     Spacer()
                 }
+                .padding(.bottom, keyboardHandler.keyboardHeight > 0 ? 20 : nil)
             }
+            .padding(.bottom, keyboardHandler.keyboardHeight)
+            .animation(keyboardHandler.keyboardHeight > 0 ? .easeOut(duration: 0.3) : nil)
         }
         .overlay(
             Group {
@@ -124,13 +128,15 @@ struct ChatRoomSettingView: View {
 
     /// 공개 범위 설정 섹션
     private var PublicScopeSection: some View {
-        VStack(alignment: .leading, spacing: 8 * DynamicSizeFactor.factor()) {
+        VStack(alignment: .leading) {
             Text("공개 범위")
                 .font(.B1MediumFont())
                 .platformTextColor(color: Color("Gray04"))
 
+            Spacer().frame(height: 8 * DynamicSizeFactor.factor())
+
             HStack {
-                Text("채팅방 공개 설정")
+                Text("채팅방 비밀번호 설정")
                     .font(.ButtonH4SemiboldFont())
                     .platformTextColor(color: Color("Gray07"))
 
@@ -140,7 +146,7 @@ struct ChatRoomSettingView: View {
                     .toggleStyle(CustomToggleStyle(hasAppeared: .constant(true)))
             }
 
-            Spacer().frame(height: 3 * DynamicSizeFactor.factor())
+            Spacer().frame(height: 13 * DynamicSizeFactor.factor())
 
             if !isPublic {
                 ZStack(alignment: .leading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -102,7 +102,10 @@ private struct SideMenuContent: View {
         VStack {
             if !members.isEmpty {
                 if members[0].role.rawValue == Role.admin.rawValue { // 첫번째 사용자(나)가 방장인지 확인 후 ui
-                    SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone_no_padding", isAlarmCell: false, isAlarmOn: .constant(false))
+                    NavigationLink(destination: ChatRoomSettingView()) {
+                        SideMenuCell(title: "채팅방 설정", imageName: "icon_checkwithsomeone_no_padding", isAlarmCell: false, isAlarmOn: .constant(false))
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
             

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/Component/CustomRoundedBtn.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/Component/CustomRoundedBtn.swift
@@ -30,7 +30,7 @@ struct CustomRoundedBtn: View {
         var horizontalPadding: CGFloat {
             switch self {
             case .large:
-                return 10
+                return 8
             case .small:
                 return 4
             }
@@ -39,18 +39,9 @@ struct CustomRoundedBtn: View {
         var verticalPadding: CGFloat {
             switch self {
             case .large:
-                return 7
+                return 6
             case .small:
                 return 2
-            }
-        }
-
-        var cornerRadius: CGFloat {
-            switch self {
-            case .large:
-                return 14
-            case .small:
-                return 6
             }
         }
     }
@@ -65,7 +56,7 @@ struct CustomRoundedBtn: View {
                 .padding(.horizontal, style.horizontalPadding * DynamicSizeFactor.factor())
                 .padding(.vertical, style.verticalPadding * DynamicSizeFactor.factor())
                 .background(
-                    RoundedRectangle(cornerRadius: style.cornerRadius * DynamicSizeFactor.factor())
+                    RoundedRectangle(cornerRadius: 6 * DynamicSizeFactor.factor())
                         .fill(backgroundColor)
                 )
         }


### PR DESCRIPTION
## 작업 이유

- 채팅방 설정 뷰 변경된 ui 반영


<br/>

## 작업 사항

### 1️⃣ 채팅방 설정 뷰 변경된 ui 반영

ui 구현하고 변경된 부분은 다음과 같다.

- [x] 채팅방 사이드 메뉴 바에서 "채팅방 설정" 셀을 클릭한 경우에만 채팅방 설정 뷰로 화면 전환
- [x] 네비바 "완료" 버튼 구현
- [x] "완료" 버튼 클릭시 토스트바 나오기
- [x] 전체적인 ui 요소 간격 및 크기 수정
- [x] 비밀번호 설정시 6글자로 제한되도록
- [x] 현재 채팅방 이름 placeholder로 보여주고 입력시 사라지도록
- [x] 채팅방 비밀번호 입력시 키보드가 입력창 가리지 않도록  


<br/>

- 구현 영상

![Simulator Screen Recording - iPhone 15 Pro - 2024-11-26 at 02 26 36](https://github.com/user-attachments/assets/14178321-476b-45fb-9562-501ec4bd75f9)



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 설정 뷰 변경된 ui 반영했습니다~~
api 연동은 안 되어있어서 사진 반영하는 부분은 api 연동하면서 같이 구현할게요!

<br/>

## 발견한 이슈
없음