### PR TITLE
🎨 채팅방 system 문구와 날짜 padding 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -23,7 +23,7 @@ struct ChatContent: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 14 * DynamicSizeFactor.factor()) {
+                LazyVStack(spacing: 10 * DynamicSizeFactor.factor()) {
                     GeometryReader { geometry in
                         Color.clear
                             .onAppear {
@@ -56,18 +56,26 @@ struct ChatContent: View {
                         Section(header: ChatHeader(data: date)) {
                             let chatsForDate = groupedChatsByDate[date] ?? []
 
-                            if chatsForDate[0].categoryType != CategoryType.system {// 첫번째 데이터가 system 아닌 경우 간격 적용
-                                Spacer().frame(height: 3)
+                            if chatsForDate[0].categoryType != CategoryType.system { // 첫번째 데이터가 system 아닌 경우 간격 적용
+                                Spacer().frame(height: 3 * DynamicSizeFactor.factor())
                             }
 
                             ForEach(Array(chatsForDate.enumerated()), id: \.element.id) { index, chat in
+                                let hasPreviousChat = index > 0
+                                let hasNextChat = index < chatsForDate.count - 1
+                                let previousChatType = hasPreviousChat ? chatsForDate[index - 1].categoryType : nil
+                                let nextChatType = hasNextChat ? chatsForDate[index + 1].categoryType : nil
+
                                 if chat.categoryType == CategoryType.system {
-                                    if index != 0 {// system이 첫번째 데이터인 경우 간격 적용
-                                        Spacer().frame(height: 3)
+                                    if hasPreviousChat, previousChatType != .system {
+                                        Spacer().frame(height: 3 * DynamicSizeFactor.factor())
                                     }
 
                                     ChatHeader(data: chat.content)
 
+                                    if !hasPreviousChat, hasNextChat, nextChatType != .system { // system 문구가 첫 데이터인 경우
+                                        Spacer().frame(height: 3 * DynamicSizeFactor.factor())
+                                    }
                                 } else if let sender = members.first(where: { $0.userId == chat.senderId }) {
                                     if chat.senderId == currentUserId {
                                         ChatSendCell(chat: chat, sender: sender)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -54,20 +54,25 @@ struct ChatContent: View {
                     ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                         Section(header: ChatHeader(data: date)) {
-                            Spacer().frame(height: 3)
+                            let chatsForDate = groupedChatsByDate[date] ?? []
 
-                            ForEach(groupedChatsByDate[date] ?? []) { chat in
-                                if let sender = members.first(where: { $0.userId == chat.senderId }) {
+                            if chatsForDate[0].categoryType != CategoryType.system {// 첫번째 데이터가 system 아닌 경우 간격 적용
+                                Spacer().frame(height: 3)
+                            }
+
+                            ForEach(Array(chatsForDate.enumerated()), id: \.element.id) { index, chat in
+                                if chat.categoryType == CategoryType.system {
+                                    if index != 0 {// system이 첫번째 데이터인 경우 간격 적용
+                                        Spacer().frame(height: 3)
+                                    }
+
+                                    ChatHeader(data: chat.content)
+
+                                } else if let sender = members.first(where: { $0.userId == chat.senderId }) {
                                     if chat.senderId == currentUserId {
                                         ChatSendCell(chat: chat, sender: sender)
                                     } else {
                                         ChatReceiveCell(chat: chat, sender: sender)
-                                    }
-                                } else {
-                                    Spacer().frame(height: 3)
-
-                                    if chat.categoryType == CategoryType.system {
-                                        ChatHeader(data: chat.content)
                                     }
                                 }
                             }


### PR DESCRIPTION
## 작업 이유

- 채팅방 system 문구와 날짜 padding 수정

<br/>

## 작업 사항

### 1️⃣ 채팅방 system 문구와 날짜 padding 수정

채팅방 system 문구와 날짜 사이의 간격을 조정하는 방식은 다음과 같다.

<날짜와 system 문구 관계>

- 날짜 다음 바로 system 문구가 오는 경우 => 간격 x
- 날짜 다음 바로 system 문구가 아닌 경우 => 간격 적용

<채팅 리스트 내부에서 system 문구 관계>

- 이전 채팅이 system이 아닌 경우  => 상단 간격 적용
- system 문구가 첫 채팅이면서 다음 채팅이 system이 아닌 경우 => 하단 간격 적용


<img src = "https://github.com/user-attachments/assets/c7ab913d-e845-4890-90fd-882f9cb9b8f9" height = "500"/>
<img src = "https://github.com/user-attachments/assets/8c6819f2-da84-406c-9675-b81d52e95fee" height = "500"/>
<img src = "https://github.com/user-attachments/assets/4ac15ddf-e662-4190-8a16-c7456b639aed" height = "500"/>



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 system 문구와 날짜 padding 수정 적용했습니다~~


<br/>

## 발견한 이슈
없음