### PR TITLE
🎨 목표금액 설정하기 두줄 오류 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/SpendingManagementMainView/SpendingCheckBoxView.swift
@@ -109,7 +109,7 @@ struct SpendingCheckBoxView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 24 * DynamicSizeFactor.factor(), height: 24 * DynamicSizeFactor.factor())
                         }
-                        .frame(width: 110 * DynamicSizeFactor.factor(), alignment: .trailing)
+                        .frame(height: 24 * DynamicSizeFactor.factor(), alignment: .trailing)
                     }
                 }
             }


### PR DESCRIPTION
## 작업 이유

- 목표금액 설정하기 두줄 오류 해결


<br/>

## 작업 사항

### 1️⃣ 목표금액 설정하기 두줄 오류 해결

지출관리 메인화면에서 "목표금액 설정하기" 버튼이 두줄로 나오는 오류가 있었다.

`.frame(height: 24 * DynamicSizeFactor.factor(), alignment: .trailing)`으로 height만 지정해주고 width에 특정 값을 지정하지 않아 text 너비에 따라 자동으로 변하도록 구현하였다.

```swift
HStack(spacing: 0) {
    Text("목표금액 설정하기")
      ...

    Image("icon_arrow_front_small_mint")
      ...
}
.frame(height: 24 * DynamicSizeFactor.factor(), alignment: .trailing)
```

- 구현

<img src = "https://github.com/user-attachments/assets/0790be9c-d745-400b-aac7-d37f240cab36" width ="350"/>



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

목표금액 설정하기 두줄 오류 해결했습니다~

<br/>

## 발견한 이슈
없음