### PR TITLE
🎨 채팅방 나가기 팝업 간격 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -85,6 +85,9 @@
 		4A2C3A8B2CD3DCF0006B6804 /* GetJoinedChatRoomsRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C3A8A2CD3DCF0006B6804 /* GetJoinedChatRoomsRequestDto.swift */; };
 		4A2C3A8D2CD3F612006B6804 /* GetJoinedChatRoomsResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C3A8C2CD3F612006B6804 /* GetJoinedChatRoomsResponseDto.swift */; };
 		4A2C8B5C2CDC7F3C007816A9 /* SendChatUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C8B5B2CDC7F3C007816A9 /* SendChatUseCase.swift */; };
+		4A32465A2CF8943200DE023D /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A3246562CF8943200DE023D /* Debug.xcconfig */; };
+		4A32465B2CF8943200DE023D /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A3246572CF8943200DE023D /* Release.xcconfig */; };
+		4A32465C2CF8943200DE023D /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4A3246582CF8943200DE023D /* Secrets.xcconfig */; };
 		4A3560762BEB9C8200BA58F3 /* OAuthUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3560752BEB9C8200BA58F3 /* OAuthUserData.swift */; };
 		4A3560782BEBA1D000BA58F3 /* UserAuthAlamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3560772BEBA1CF00BA58F3 /* UserAuthAlamofire.swift */; };
 		4A35607A2BEBA25100BA58F3 /* UserAuthRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3560792BEBA25100BA58F3 /* UserAuthRouter.swift */; };
@@ -318,9 +321,6 @@
 		4AF69F642BFDF9E2001D49F8 /* BottomSheetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF69F632BFDF9E2001D49F8 /* BottomSheetExtension.swift */; };
 		4AFC7C9B2C581D9D003CFA8C /* TooManyRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */; };
 		4AFC7C9D2C581E1C003CFA8C /* TooManyRequestErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */; };
-		6A3D10ED2CF757C7004114A8 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 6A3D10EA2CF757C7004114A8 /* Debug.xcconfig */; };
-		6A3D10EE2CF757C7004114A8 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 6A3D10EB2CF757C7004114A8 /* Secrets.xcconfig */; };
-		6A3D10EF2CF757C7004114A8 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 6A3D10EC2CF757C7004114A8 /* Release.xcconfig */; };
 		7C0E38D4CE51A896B5A498EE /* Pods_pennyway_client_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3E298D8A2B0690BBB7DB144 /* Pods_pennyway_client_iOS.framework */; };
 		B501605F2C75B54100328AFD /* ProfileAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501605E2C75B54100328AFD /* ProfileAnalyticsEvents.swift */; };
 		B50160612C75EA8C00328AFD /* QuestionAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50160602C75EA8C00328AFD /* QuestionAnalyticsEvents.swift */; };
@@ -556,6 +556,9 @@
 		4A2C3A8A2CD3DCF0006B6804 /* GetJoinedChatRoomsRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetJoinedChatRoomsRequestDto.swift; sourceTree = "<group>"; };
 		4A2C3A8C2CD3F612006B6804 /* GetJoinedChatRoomsResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetJoinedChatRoomsResponseDto.swift; sourceTree = "<group>"; };
 		4A2C8B5B2CDC7F3C007816A9 /* SendChatUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatUseCase.swift; sourceTree = "<group>"; };
+		4A3246562CF8943200DE023D /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4A3246572CF8943200DE023D /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		4A3246582CF8943200DE023D /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		4A3560752BEB9C8200BA58F3 /* OAuthUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthUserData.swift; sourceTree = "<group>"; };
 		4A3560772BEBA1CF00BA58F3 /* UserAuthAlamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthAlamofire.swift; sourceTree = "<group>"; };
 		4A3560792BEBA25100BA58F3 /* UserAuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthRouter.swift; sourceTree = "<group>"; };
@@ -785,9 +788,6 @@
 		4AF69F632BFDF9E2001D49F8 /* BottomSheetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetExtension.swift; sourceTree = "<group>"; };
 		4AFC7C9A2C581D9D003CFA8C /* TooManyRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooManyRequestError.swift; sourceTree = "<group>"; };
 		4AFC7C9C2C581E1C003CFA8C /* TooManyRequestErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooManyRequestErrorCode.swift; sourceTree = "<group>"; };
-		6A3D10EA2CF757C7004114A8 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = "../../../../../Library/Mobile Documents/com~apple~CloudDocs/Debug.xcconfig"; sourceTree = "<group>"; };
-		6A3D10EB2CF757C7004114A8 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Secrets.xcconfig; path = "../../../../../Library/Mobile Documents/com~apple~CloudDocs/Secrets.xcconfig"; sourceTree = "<group>"; };
-		6A3D10EC2CF757C7004114A8 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = "../../../../../Library/Mobile Documents/com~apple~CloudDocs/Release.xcconfig"; sourceTree = "<group>"; };
 		6E197F320882D15FA5AB74B7 /* Pods-pennyway-client-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pennyway-client-iOS.debug.xcconfig"; path = "Target Support Files/Pods-pennyway-client-iOS/Pods-pennyway-client-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		A3E298D8A2B0690BBB7DB144 /* Pods_pennyway_client_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pennyway_client_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B501605E2C75B54100328AFD /* ProfileAnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAnalyticsEvents.swift; sourceTree = "<group>"; };
@@ -1513,6 +1513,16 @@
 			path = Profile;
 			sourceTree = "<group>";
 		};
+		4A3246592CF8943200DE023D /* Xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				4A3246562CF8943200DE023D /* Debug.xcconfig */,
+				4A3246572CF8943200DE023D /* Release.xcconfig */,
+				4A3246582CF8943200DE023D /* Secrets.xcconfig */,
+			);
+			path = Xcconfig;
+			sourceTree = "<group>";
+		};
 		4A35607C2BEBA2AA00BA58F3 /* UserAuth */ = {
 			isa = PBXGroup;
 			children = (
@@ -1942,7 +1952,7 @@
 			isa = PBXGroup;
 			children = (
 				D80DB7872CF5FFC30052F234 /* GoogleService-Info.plist */,
-				D80DB7802CF5FFAE0052F234 /* Xcconfig */,
+				4A3246592CF8943200DE023D /* Xcconfig */,
 				4A12FEE62C9C47D800DE10BC /* Clean */,
 				B599E4BA2C58AE72006051E9 /* Analytics */,
 				4AE8F3AB2C32AEC30014F0D4 /* App */,
@@ -2602,16 +2612,6 @@
 			path = Alamofire;
 			sourceTree = "<group>";
 		};
-		D80DB7802CF5FFAE0052F234 /* Xcconfig */ = {
-			isa = PBXGroup;
-			children = (
-				6A3D10EA2CF757C7004114A8 /* Debug.xcconfig */,
-				6A3D10EC2CF757C7004114A8 /* Release.xcconfig */,
-				6A3D10EB2CF757C7004114A8 /* Secrets.xcconfig */,
-			);
-			path = Xcconfig;
-			sourceTree = "<group>";
-		};
 		D8180BFE2BE507D200F837FB /* FindIdView */ = {
 			isa = PBXGroup;
 			children = (
@@ -2994,22 +2994,22 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A3D10EF2CF757C7004114A8 /* Release.xcconfig in Resources */,
 				D846A29B2CEDD16D000B9BBC /* .gitignore in Resources */,
 				4A762AF42B99A16D001C1188 /* Preview Assets.xcassets in Resources */,
-				6A3D10ED2CF757C7004114A8 /* Debug.xcconfig in Resources */,
+				4A32465A2CF8943200DE023D /* Debug.xcconfig in Resources */,
 				4A1179B12BA9572F00A9CF4C /* Pretendard-Medium.otf in Resources */,
 				4A1179AD2BA9572F00A9CF4C /* Pretendard-Regular.otf in Resources */,
 				4A1179AC2BA9572F00A9CF4C /* Pretendard-Thin.otf in Resources */,
 				4A1179AF2BA9572F00A9CF4C /* Pretendard-SemiBold.otf in Resources */,
 				4A1179B22BA9572F00A9CF4C /* Pretendard-Light.otf in Resources */,
+				4A32465C2CF8943200DE023D /* Secrets.xcconfig in Resources */,
 				D80DB7882CF5FFC30052F234 /* GoogleService-Info.plist in Resources */,
 				4A762AF12B99A16D001C1188 /* Assets.xcassets in Resources */,
 				4A1179AB2BA9572F00A9CF4C /* Pretendard-ExtraLight.otf in Resources */,
-				6A3D10EE2CF757C7004114A8 /* Secrets.xcconfig in Resources */,
 				4A1179AE2BA9572F00A9CF4C /* Pretendard-Black.otf in Resources */,
 				4A1179B02BA9572F00A9CF4C /* Pretendard-Bold.otf in Resources */,
 				4A1179AA2BA9572F00A9CF4C /* Pretendard-ExtraBold.otf in Resources */,
+				4A32465B2CF8943200DE023D /* Release.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3670,7 +3670,7 @@
 		};
 		4A762AF82B99A16D001C1188 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A3D10EA2CF757C7004114A8 /* Debug.xcconfig */;
+			baseConfigurationReference = 4A3246562CF8943200DE023D /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3718,7 +3718,7 @@
 		};
 		4A762AF92B99A16D001C1188 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A3D10EC2CF757C7004114A8 /* Release.xcconfig */;
+			baseConfigurationReference = 4A3246572CF8943200DE023D /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3765,7 +3765,6 @@
 		};
 		4ACB61202CE4CC8A0018E78A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A3D10EA2CF757C7004114A8 /* Debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -3790,7 +3789,6 @@
 		};
 		4ACB61212CE4CC8A0018E78A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A3D10EC2CF757C7004114A8 /* Release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -40,6 +40,7 @@ struct ChatSideMenuView: View {
                                 secondBtnLabel: "나가기",
                                 secondBtnColor: Color("Red03")
                 )
+                .edgesIgnoringSafeArea(.vertical)
             }
         }
         .edgesIgnoringSafeArea(.bottom)


### PR DESCRIPTION
## 작업 이유

- 채팅방 나가기 팝업 간격 수정


<br/>

## 작업 사항

### 1️⃣ 채팅방 나가기 팝업 간격 수정

사이드 메뉴 뷰가 네비바를 제외한 영역을 가지고 있어서 팝업 위치가 조금 내려왔던 문제가 있었다.
그래서 CustomPopUpView에 `.edgesIgnoringSafeArea(.vertical)`를 추가하니 해결되었다.

```swift
if showExitPopUp {
    CustomPopUpView(showingPopUp: $showExitPopUp,
                    titleLabel: "\(viewModelWrapper.roomData?.title ?? "")",
                    subTitleLabel: "채팅방을 나가시겠어요?",
                    firstBtnAction: { self.showExitPopUp = false },
                    firstBtnLabel: "취소",
                    secondBtnAction: {
                        self.showExitPopUp = false
                    },
                    secondBtnLabel: "나가기",
                    secondBtnColor: Color("Red03")
    )
    .edgesIgnoringSafeArea(.vertical)
}
```


<img src ="https://github.com/user-attachments/assets/3e9b045c-40af-47e7-96a1-b56fc40d9313" width = "350"/> 
<img src ="https://github.com/user-attachments/assets/9599f1fd-233b-47c2-aa08-3473da56f627" width = "350"/> 

> 왼쪽이 해결 전, 오른쪽이 해결 후의 동작이다.



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 나가기 팝업 간격 수정 완료했습니다!


<br/>

## 발견한 이슈
없음