### PR TITLE
📮 [Stomp] 사용자 화면 상태 서버 전달 구현

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -3583,6 +3583,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -3789,6 +3790,7 @@
 		};
 		4ACB61212CE4CC8A0018E78A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A3246572CF8943200DE023D /* Release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-Release.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-Release.xcscheme
@@ -54,8 +54,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-debug.xcscheme
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/xcshareddata/xcschemes/Pennyway-debug.xcscheme
@@ -34,8 +34,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
       <Testables>
@@ -54,8 +54,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -72,6 +72,12 @@
             ReferencedContainer = "container:pennyway-client-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "IDEPreferLogStreaming=YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Application/ViewStateManager.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Application/ViewStateManager.swift
@@ -21,15 +21,20 @@ enum CurrentViewType: String {
 
 class ViewStateManager: ObservableObject {
     private let chatStompService = DefaultChatStompService.shared
+    private var lastViewType: CurrentViewType = .activeNonChat
+    private var lastChatRoomId: Int64? = nil
 
     /// 현재 활성화된 뷰 타입을 저장하는 변수 (기본값: activeApp)
-    @Published var currentViewType: CurrentViewType = .activeNonChat
+    var currentViewType: CurrentViewType = .activeNonChat
+
     /// 현재 표시되고 있는 뷰를 저장하는 변수
-    @Published var currentView: AnyView?
+    var currentView: AnyView?
 
     /// 현재 뷰 설정 함수
-    /// - parameter view: 새로운 뷰를 받아와서 currentView에 설정함
-    /// - parameter selectedTab: 선택된 탭, nil일 수 있음
+    /// - Parameters:
+    ///   - view: 새로운 뷰를 받아와서 currentView에 설정
+    ///   - selectedTab: 선택된 탭 (기본값: nil)
+    ///   - chatRoomId: 선택된 채팅방 ID (기본값: nil)
     func setCurrentView(_ view: some View, selectedTab: Int? = nil, chatRoomId: Int64? = nil) {
         currentView = AnyView(view)
 
@@ -44,11 +49,13 @@ class ViewStateManager: ObservableObject {
         } else if view is ChatRoomView {
             currentViewType = .activeChatRoom
             Log.info("[ViewStateManager] View state: activeChatRoom")
-        } else {
+        }  else {
             currentViewType = .activeNonChat
             Log.info("[ViewStateManager] View state: activeNonChat")
         }
 
+        lastViewType = currentViewType
+        lastChatRoomId = chatRoomId
         chatStompService.sendViewState(status: currentViewType.rawValue, chatRoomId: chatRoomId)
     }
 
@@ -57,18 +64,16 @@ class ViewStateManager: ObservableObject {
     func setScenePhase(_ phase: ScenePhase) {
         switch phase {
         case .active:
-            currentViewType = .activeNonChat
-            Log.info("[ViewStateManager - setScenePhase] View state: activeNonChat")
-        case .inactive:
-            currentViewType = .inactive
-            Log.info("[ViewStateManager - setScenePhase] View state: inactive")
-        case .background:
+            currentViewType = lastViewType
+            Log.info("[ViewStateManager - setScenePhase] View state: \(currentViewType.rawValue)")
+        case .inactive, .background:
             currentViewType = .background
             Log.info("[ViewStateManager - setScenePhase] View state: background")
         @unknown default:
             currentViewType = .activeNonChat
         }
 
-        chatStompService.sendViewState(status: currentViewType.rawValue, chatRoomId: nil)
+        chatStompService.sendViewState(status: currentViewType.rawValue, chatRoomId: currentViewType == .activeChatRoom ? lastChatRoomId : nil)
+        
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Application/ViewStateManager.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Application/ViewStateManager.swift
@@ -9,17 +9,19 @@ import SwiftUI
 
 // MARK: - CurrentViewType
 
-enum CurrentViewType {
-    case activeNonChat // MainChatView와 ChatView를 제외한 모든 뷰
-    case activeChatRoomCell // MainChatView일 경우(추천 채팅 제외)
-    case activeChatRoom // ChatView일 경우
-    case inactive
-    case background
+enum CurrentViewType: String {
+    case activeNonChat = "ACTIVE_APP" // MainChatView와 ChatView를 제외한 모든 뷰
+    case activeChatRoomCell = "ACTIVE_CHAT_ROOM_LIST" // MainChatView일 경우(추천 채팅 제외)
+    case activeChatRoom = "ACTIVE_CHAT_ROOM" // ChatView일 경우
+    case inactive = "INACTIVE"
+    case background = "BACKGROUND"
 }
 
 // MARK: - ViewStateManager
 
 class ViewStateManager: ObservableObject {
+    private let chatStompService = DefaultChatStompService.shared
+
     /// 현재 활성화된 뷰 타입을 저장하는 변수 (기본값: activeApp)
     @Published var currentViewType: CurrentViewType = .activeNonChat
     /// 현재 표시되고 있는 뷰를 저장하는 변수
@@ -28,7 +30,7 @@ class ViewStateManager: ObservableObject {
     /// 현재 뷰 설정 함수
     /// - parameter view: 새로운 뷰를 받아와서 currentView에 설정함
     /// - parameter selectedTab: 선택된 탭, nil일 수 있음
-    func setCurrentView(_ view: some View, selectedTab: Int? = nil) {
+    func setCurrentView(_ view: some View, selectedTab: Int? = nil, chatRoomId: Int64? = nil) {
         currentView = AnyView(view)
 
         if view is ChatCellView {
@@ -46,6 +48,8 @@ class ViewStateManager: ObservableObject {
             currentViewType = .activeNonChat
             Log.info("[ViewStateManager] View state: activeNonChat")
         }
+
+        chatStompService.sendViewState(status: currentViewType.rawValue, chatRoomId: chatRoomId)
     }
 
     /// 앱의 화면 상태(ScenePhase)에 따른 처리
@@ -64,5 +68,7 @@ class ViewStateManager: ObservableObject {
         @unknown default:
             currentViewType = .activeNonChat
         }
+
+        chatStompService.sendViewState(status: currentViewType.rawValue, chatRoomId: nil)
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Application/ViewStateManager.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Application/ViewStateManager.swift
@@ -49,7 +49,10 @@ class ViewStateManager: ObservableObject {
         } else if view is ChatRoomView {
             currentViewType = .activeChatRoom
             Log.info("[ViewStateManager] View state: activeChatRoom")
-        }  else {
+        } else if view is LoginView {
+            currentViewType = .inactive
+            Log.info("[ViewStateManager] View state: inactive")
+        } else {
             currentViewType = .activeNonChat
             Log.info("[ViewStateManager] View state: activeNonChat")
         }
@@ -74,6 +77,5 @@ class ViewStateManager: ObservableObject {
         }
 
         chatStompService.sendViewState(status: currentViewType.rawValue, chatRoomId: currentViewType == .activeChatRoom ? lastChatRoomId : nil)
-        
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -10,7 +10,7 @@ import StompClientLib
 
 // MARK: - DefaultChatStompRepository
 
-class DefaultChatStompRepository: NSObject, ChatStompRepository {
+class DefaultChatStompRepository: ChatStompRepository {
     private let stompClient: StompClientLib
 
     init(stompClient: StompClientLib) {
@@ -68,6 +68,11 @@ class DefaultChatStompRepository: NSObject, ChatStompRepository {
         let chatRoomReceiptId = "chat-room-receipt-\(UUID().uuidString)"
         let destination = "/sub/chat.room.\(chatRoomId)"
         stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": chatRoomReceiptId])
+    }
+
+    /// 뷰 상태를 전달하는 메서드
+    func sendViewState(status: String, chatRoomId: Int64?) {
+        Log.debug("[DefaultChatStompRepository] view state: \(status) \(String(describing: chatRoomId))")
     }
 }
 
@@ -174,14 +179,14 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     func stompClientDidDisconnect(client _: StompClientLib!) {
         Log.debug("Socket disconnected")
 
-        connect { result in
-            switch result {
-            case .success:
-                Log.debug("[DefaultChatStompRepository] 재연결 시도 성공")
-            case let .failure(error):
-                Log.error("재연결 시도 실패: \(error)")
-            }
-        }
+//        connect { result in
+//            switch result {
+//            case .success:
+//                Log.debug("[DefaultChatStompRepository] 재연결 시도 성공")
+//            case let .failure(error):
+//                Log.error("재연결 시도 실패: \(error)")
+//            }
+//        }
     }
 
     func stompClient(client _: StompClientLib!, didReceiveMessageWithJSONBody body: AnyObject?, akaStringBody akaStringBody: String?, withHeader _: [String: String]?, withDestination _: String) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -47,7 +47,7 @@ class DefaultChatStompRepository: ChatStompRepository {
             let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                Log.debug("📤 [Send Message])")
+                Log.info("📤 [Send Message])")
             }
         } catch {
             Log.error("Failed to serialize message body: \(error)")
@@ -60,7 +60,7 @@ class DefaultChatStompRepository: ChatStompRepository {
         let headers = createSendHeaders()
 
         stompClient.sendMessage(message: "", toDestination: destination, withHeaders: headers, withReceipt: nil)
-        Log.debug("📤 [Send Last Message])")
+        Log.info("📤 [Send Last Message])")
     }
 
     /// 채팅방 ID 에 대한 구독을 설정하는 메서드
@@ -88,7 +88,7 @@ class DefaultChatStompRepository: ChatStompRepository {
             let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                Log.debug("📤 [Send User State] \(jsonString)")
+                Log.info("📤 [Send User State] \(jsonString)")
             }
         } catch {
             Log.error("Failed to serialize message body: \(error)")
@@ -191,26 +191,26 @@ extension DefaultChatStompRepository {
 
 extension DefaultChatStompRepository: StompClientLibDelegate {
     func stompClientDidConnect(client _: StompClientLib!) {
-        Log.debug("Socket connected")
+        Log.info("Socket connected")
         subscribeToErrors()
         getJoinedChatRooms()
     }
 
     func stompClientDidDisconnect(client _: StompClientLib!) {
-        Log.debug("Socket disconnected")
+        Log.info("Socket disconnected")
 
-//        connect { result in
-//            switch result {
-//            case .success:
-//                Log.debug("[DefaultChatStompRepository] 재연결 시도 성공")
-//            case let .failure(error):
-//                Log.error("재연결 시도 실패: \(error)")
-//            }
-//        }
+        connect { result in
+            switch result {
+            case .success:
+                Log.debug("[DefaultChatStompRepository] 재연결 시도 성공")
+            case let .failure(error):
+                Log.error("재연결 시도 실패: \(error)")
+            }
+        }
     }
 
     func stompClient(client _: StompClientLib!, didReceiveMessageWithJSONBody body: AnyObject?, akaStringBody akaStringBody: String?, withHeader _: [String: String]?, withDestination _: String) {
-        Log.debug("Did receive Message: \(body), \(akaStringBody)")
+        Log.info("Did receive Message: \(body), \(akaStringBody)")
 
         if let body = body as? [String: Any],
            let jsonData = try? JSONSerialization.data(withJSONObject: body, options: []),
@@ -231,7 +231,7 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     }
 
     func serverDidSendReceipt(client _: StompClientLib!, withReceiptId receiptId: String) {
-        Log.debug("Receipt received: \(receiptId)")
+        Log.info("Receipt received: \(receiptId)")
     }
 
     func serverDidSendError(client _: StompClientLib!, withErrorMessage description: String, detailedErrorMessage _: String?) {
@@ -239,6 +239,6 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     }
 
     func serverDidSendPing() {
-        Log.debug("Server ping received")
+        Log.info("Server ping received")
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -72,7 +72,27 @@ class DefaultChatStompRepository: ChatStompRepository {
 
     /// 뷰 상태를 전달하는 메서드
     func sendViewState(status: String, chatRoomId: Int64?) {
-        Log.debug("[DefaultChatStompRepository] view state: \(status) \(String(describing: chatRoomId))")
+        let destination = "/pub/status.me"
+        let headers = createSendHeaders()
+
+        var messageBody: [String: Any] = [
+            "status": status
+        ]
+
+        // chatRoomId가 nil값이 아닌 경우 body에 포함
+        if let chatRoomId = chatRoomId {
+            messageBody["chatRoomId"] = chatRoomId
+        }
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
+                Log.debug("📤 [Send User State] \(jsonString)")
+            }
+        } catch {
+            Log.error("Failed to serialize message body: \(error)")
+        }
     }
 }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/ChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/ChatStompRepository.swift
@@ -13,4 +13,5 @@ protocol ChatStompRepository {
     func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion: @escaping (Result<Void, Error>) -> Void)
     func sendLastMessage(chatRoomId: Int64, lastReadMessageId: Int64, completion: @escaping (Result<Void, Error>) -> Void)
     func subscribeToChatRoom(chatRoomId: Int64)
+    func sendViewState(status: String, chatRoomId: Int64?)
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Service/DefaultChatStompService.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Service/DefaultChatStompService.swift
@@ -46,4 +46,8 @@ class DefaultChatStompService {
     func subscribeToChatRoom(chatRoomId: Int64) {
         repository.subscribeToChatRoom(chatRoomId: chatRoomId)
     }
+    
+    func sendViewState(status: String, chatRoomId: Int64?) {
+        repository.sendViewState(status: status, chatRoomId: chatRoomId)
+    }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -77,11 +77,11 @@ struct ChatRoomView: View {
                 }
             }
             .onAppear {
-                viewStateManager.setCurrentView(self)
                 viewModelWrapper.chatRoomViewModel.roomData.value = chatRoom // 현재 채팅방 정보 저장
+                viewStateManager.setCurrentView(self, chatRoomId: viewModelWrapper.roomData?.id)
 
                 // 채팅방 상세 정보 조회
-                viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: Int64(chatRoom.id))
+                viewModelWrapper.chatRoomViewModel.getChatRoomDetail(chatRoomId: chatRoom.id)
                 viewModelWrapper.chatRoomViewModel.subscribeToNotifications()
             }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -68,7 +68,7 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
         NotificationCenter.default.publisher(for: .didReceiveMessage)
             .sink { [weak self] notification in
                 // 메시지 받은 경우 처리
-                if let message = notification.object as? MessageItemModel {
+                if let message = notification.object as? MessageItemModel, self?.roomData.value?.id == message.chatRoomId {
                     self?.handleNewMessage(message)
                     self?.sendLastMessage(chatRoomId: message.chatRoomId, lastReadMessageId: message.chatId)
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Log.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Log.swift
@@ -39,7 +39,7 @@ enum Log {
 
     private static func log(_ message: Any, level: Level) {
         let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: level.category)
-        let logMessage = "\(message)"
+        let logMessage = "\(level.category): \(message)" // 메시지에 카테고리 포함
 
         switch level {
         case .default:


### PR DESCRIPTION
## 작업 이유

- [Stomp] 사용자 화면 상태 서버 전달 구현


<br/>

## 작업 사항

### 1️⃣ [Stomp] 사용자 화면 상태 서버 전달 구현

- destination: ` /pub/status.me`
- body: {"status": "현재 뷰 상태", "chatRoomId": "선택 사항 (채팅방에 있는 경우에만 포함)"}

``` swift
enum CurrentViewType: String {
    case activeNonChat = "ACTIVE_APP" // MainChatView와 ChatView를 제외한 모든 뷰
    case activeChatRoomCell = "ACTIVE_CHAT_ROOM_LIST" // MainChatView일 경우(추천 채팅 제외)
    case activeChatRoom = "ACTIVE_CHAT_ROOM" // ChatRoomView일 경우
    case inactive = "INACTIVE"// 로그아웃 한 경우
    case background = "BACKGROUND"
}
```

사용자가 채팅방에 있는 경우(ChatRoomView)에만 chatRoomId를 포함하여 서버로 전달한다. 
그 외의 상태에서는 status만 전송된다.

<br/>

서버에 바뀐 뷰의 상태를 잘 전달하는 걸 확인하였다.

![image](https://github.com/user-attachments/assets/4017babf-6aa8-46e3-94c4-ca44c67c41c9)

![image1](https://github.com/user-attachments/assets/b1ef8706-671a-484d-ae14-be1bf73ccfae)


<br/>

### 2️⃣ scene 변경하는 경우 뷰 상태 변경 오류 해결


문제점:

배경 상태(Background) → 활성 상태(Active)로 전환될 때 onAppear가 호출되지 않는 문제가 있었다.
이로 인해, [채팅방 뷰 또는 채팅방 리스트 뷰 → 배경 상태 → 다시 채팅방 뷰 또는 채팅방 리스트 뷰]로 돌아왔을 때, activeChatRoomCell 또는 activeChatRoom 상태로 업데이트되지 않고, 잘못된 activeNonChat 상태로 유지되는 문제가 발생했다.

해결 방안:

그래서 ViewStateManager에 lastViewType과 lastChatRoomId 변수를 추가하여 배경 상태로 전환되기 직전의 마지막 뷰 상태를 저장하도록 구현했다.
앱이 다시 활성화될 때, 이 저장된 데이터를 사용해 정확한 뷰 상태(activeChatRoomCell 또는 activeChatRoom)로 복원되도록 수정했다.

<br/>

### 3️⃣ inactive 상태 처리

inactive 상태는 로그아웃 시 서버에 전달해야 하므로, LoginView가 표시되는 경우 inactive 상태로 서버에 전송하도록 구현했다.
ViewStateManager에서 LoginView가 활성화되면 뷰 상태를 inactive로 설정하고, 이를 서버로 전달하여 로그아웃 상태임을 알린다.



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

사용자 화면 상태 서버 전달 구현했습니다~
그리고 테스트하면서 오류 발견했던 2️⃣와 3️⃣도 같이 처리했습니다!

<br/>

## 발견한 이슈
없음