### PR TITLE
🎨 방금 수신/발신한 채팅은 0분전이 아니라 지금으로 표시되도록 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/Formatter/DateFormatterUtil .swift
@@ -90,7 +90,9 @@ enum DateFormatterUtil {
 
         if calendar.isDateInToday(date) {
             let components = calendar.dateComponents([.hour, .minute], from: date, to: now)
-            if let minutes = components.minute, minutes < 60 {
+            if let minutes = components.minute, minutes == 0 {
+                return "지금"
+            } else if let minutes = components.minute, minutes < 60 {
                 return "\(minutes)분 전"
             } else if let hours = components.hour, hours < 24 {
                 return "\(hours)시간 전"


### PR DESCRIPTION
## 작업 이유
- 방금 수신/발신한 채팅은 0분전이 아니라 지금으로 표시되도록 수정

<br/>

## 작업 사항
### **1️⃣ 방금 수신/발신한 채팅은 0분전이 아니라 지금으로 표시되도록 수정**
기존 코드에서 방금 수신, 발신 한 채팅은 따로 분기처리를 해주지 않고 minutes < 60 인 경우 무조건 ( )분 전 으로 반환되도록 구현되어 있어서 방금 0~1분 사이에 수신, 발신 된 채팅에 대해서는 0분전이라고 표시되는 오류가 존재했다.

```swift
 if let minutes = components.minute, minutes == 0 {
     return "지금"
 } else if let minutes = components.minute, minutes < 60 {
     return "\(minutes)분 전"
 } else if let hours = components.hour, hours < 24 {
      return "\(hours)시간 전"
 }
``` 
따라서 현재 분을 계산해서 0분인 경우 -> 지금이라고 표시되는 로직을 추가해줌으로써 해결하였다.

**동작과정**
<img src = "https://github.com/user-attachments/assets/862ac25c-8fdf-4693-bc88-358f9451832c" width ="320" height ="600">



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
11월 3주차 피드백 수정 완료 했습니다!

<br/>

## 발견한 이슈
x