### PR TITLE
🛠️ 소켓 연결 끊기던 오류 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -136,7 +136,8 @@ extension DefaultChatStompRepository {
         return [
             "Authorization": "Bearer \(accessToken)",
             "device-id": "\(deviceId)",
-            "device-name": "\(deviceName)"
+            "device-name": "\(deviceName)",
+            "heart-beat": "25000,25000"
         ]
     }
 


### PR DESCRIPTION
## 작업 이유

- 소켓 연결 끊기던 오류 해결

<br/>

## 작업 사항

### 1️⃣ 소켓 연결 끊기던 오류 해결

#241 에서 추가했던 heart-beat가 리팩토링 하는 도중 빠졌던 걸 몰랐었다,,, ㅎㅎ
그래서 stomp 라이브러리 openSocketWithURLRequest() 요청에 `"heart-beat": "25000,25000"` 헤더를 다시 추가하였다.

여기서 주의할 점!!!! 
=> 25000,25000 사이에 공백이 절대로 있으면 안된다,, 공백 넣어서 구현하다가 왜 안되는지 한참 이유를 찾아다녔다 ㅎ허허허허허허

이렇게 하면 30분 조금 넘게 테스트했을때 소켓 연결은 정상적으로 처리되고 있다.
> 다만, 아직 refresh 요청을 처리하고 있지 않아서 30분이 넘으면 사용자 오류가 발생하여 메시지 보내는 건 오류가 나지만, 받는건 정상적으로 잘 동작한다. 

즉, 소켓 연결은 끊기지 않았다!!!!!!


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

소켓 연결 끊기던 오류 해결했습니다~~


<br/>

## 발견한 이슈
없음