### PR TITLE
🎨 채팅 입력 하단 패딩값 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -198,7 +198,7 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     }
 
     func stompClientDidDisconnect(client _: StompClientLib!) {
-        Log.info("Socket disconnected")
+        Log.fault("Socket disconnected")
 
         connect { result in
             switch result {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatBottomBar.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct ChatBottomBar: View {
+    var keyboardHeight = 0.0
+
     @State private var message: String = ""
     @State private var showFeature: Bool = false
     @State private var currentTextEditorHeight: CGFloat = 14 * DynamicSizeFactor.factor()
     @State private var maxTextWidth: CGFloat = 0
 
     // TextEditor의 최소, 최대 높이 정의
-    private let minHeight: CGFloat = 15 * DynamicSizeFactor.factor() // 최소 높이
+    private let minHeight: CGFloat = 14 * DynamicSizeFactor.factor() // 최소 높이
     private let maxHeight: CGFloat = 14 * DynamicSizeFactor.factor() * 3 // 최대 높이 (3줄)
     private let maxLineCount: Int = 3 // 최대 줄 수
 
@@ -50,7 +52,7 @@ struct ChatBottomBar: View {
 
     var body: some View {
         VStack {
-            Spacer().frame(height: 11 * DynamicSizeFactor.factor())
+            Spacer().frame(height: 10 * DynamicSizeFactor.factor())
 
             HStack(spacing: 4) {
                 FeatureButton
@@ -155,7 +157,11 @@ struct ChatBottomBar: View {
                 }
                 Spacer().frame(height: 20 * DynamicSizeFactor.factor())
             } else {
-                Spacer().frame(height: 19 * DynamicSizeFactor.factor())
+                if keyboardHeight > 0 {
+                    Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+                } else {
+                    Spacer().frame(height: 22 * DynamicSizeFactor.factor())
+                }
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -28,7 +28,7 @@ struct ChatRoomView: View {
                         .frame(height: geometry.size.height - keyboardManager.keyboardHeight) // ChatContent의 높이를 키보드 높이만큼 조정
                 }
 
-                ChatBottomBar()
+                ChatBottomBar(keyboardHeight: keyboardManager.keyboardHeight)
                     .offset(y: -keyboardManager.keyboardHeight)
                     .animation(keyboardManager.keyboardHeight > 0 ? .easeOut(duration: 0.5) : nil, value: keyboardManager.keyboardHeight)
             }


### PR DESCRIPTION
## 작업 이유

- 채팅 입력 하단 패딩값 수정


<br/>

## 작업 사항

### 1️⃣ 채팅 입력 하단 패딩값 수정

디자인팀이 다음과 같이 수정해달라고 요청했던 부분을 처리하였다.

<img width="596" alt="스크린샷 2024-12-05 오후 9 52 56" src="https://github.com/user-attachments/assets/d56e0344-c29d-4d13-b11f-3a4be4489118">

- 키보드가 나타나지 않은 경우 하단 패딩 32
- 키보드가 나타난 경우 하단 패딩 10

으로 설정하여 키보드가 나타난 전/후의 패딩 값을 다르게 보여줄 수 있다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅 입력 하단 패딩값 수정했습니다~


<br/>

## 발견한 이슈
없음