### PR TITLE
🎨 지출추가뷰에서 폰트 동일하게 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
@@ -55,15 +55,8 @@ struct MemoInputView: View {
                 RoundedRectangle(cornerRadius: 4)
                     .fill(Color("Gray01"))
                     .frame(height: 104 * DynamicSizeFactor.factor())
-
+                
                 TextEditor(text: $memoText)
-//                CustomTextFieldModifier(
-//                    text: $memoText,
-//                    isSecureText: false, keyboardType: .default
-//                )
-//                
-//                .offset(x: 3 * DynamicSizeFactor.factor(), y: -32 * DynamicSizeFactor.factor())
-//                .font(.H4MediumFont())
                     .padding(.horizontal, 8 * DynamicSizeFactor.factor())
                     .padding(.vertical, 5 * DynamicSizeFactor.factor())
                     .zIndex(0)
@@ -75,8 +68,8 @@ struct MemoInputView: View {
                         if memoText.count > maxCharacterCount {
                             memoText = String(memoText.prefix(maxCharacterCount))
                         }
-                    }
-                    .frame(height: 104 * DynamicSizeFactor.factor())
+                }
+                .frame(height: 104 * DynamicSizeFactor.factor())
 
                 if memoText.isEmpty {
                     Text(placeholder)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
@@ -57,7 +57,13 @@ struct MemoInputView: View {
                     .frame(height: 104 * DynamicSizeFactor.factor())
 
                 TextEditor(text: $memoText)
-                    .font(.H4MediumFont())
+//                CustomTextFieldModifier(
+//                    text: $memoText,
+//                    isSecureText: false, keyboardType: .default
+//                )
+//                
+//                .offset(x: 3 * DynamicSizeFactor.factor(), y: -32 * DynamicSizeFactor.factor())
+//                .font(.H4MediumFont())
                     .padding(.horizontal, 8 * DynamicSizeFactor.factor())
                     .padding(.vertical, 5 * DynamicSizeFactor.factor())
                     .zIndex(0)

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountContentView.swift
@@ -48,7 +48,7 @@ struct TotalTargetAmountContentView: View {
                     HStack(spacing: 6 * DynamicSizeFactor.factor()) {
                         Circle()
                             .frame(width: 6 * DynamicSizeFactor.factor(), height: 6 * DynamicSizeFactor.factor())
-                            .platformTextColor(color: Color("mint02"))
+                            .platformTextColor(color: Color("Mint02"))
 
                         Text("소비금액")
                             .platformTextColor(color: Color("Gray04"))

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/TargetAmountView/TotalTargetAmountView/TotalTargetAmountGraphView.swift
@@ -32,7 +32,7 @@ struct TotalTargetAmountGraphView: View {
 
                             // 사용 금액
                             Rectangle()
-                                .platformTextColor(color: Color("mint02"))
+                                .platformTextColor(color: Color("Mint02"))
                                 .frame(width: 26 * DynamicSizeFactor.factor(), height: spendingHeight)
 
                             // 초과 금액


### PR DESCRIPTION
## 작업 이유
- mint02 -> Mint02로 네이밍
- 지출추가뷰에서 폰트 동일하게 수정[피드백 반영]

<br/>

## 작업 사항
### **1️⃣ mint02 -> Mint02로 네이밍**
assets파일의 네이밍 수정하였다.

### **2️⃣ 지출추가뷰에서 폰트 동일하게 수정[피드백 반영]**
TextEditor자체에서 폰트가 설정되어 있는데 그 위에 font를 새로 덮어씌우니까 자체적으로 bold처리가 되서 소비처랑 메모 칸의 폰트가 다르게 설정되는 문제가 있었다.

따라서 TextEditor에서 font 설정하는 칸을 지워주니 해결되었다.

<img src ="https://github.com/user-attachments/assets/0f999a9f-a658-49d4-b1b7-5783835f7eb8" width ="320" height ="600">

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

피드백 반영했습니다~
<br/>

## 발견한 이슈
x