### PR TITLE
🛠️ chat 그룹 정렬 문제 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -51,7 +51,15 @@ struct ChatContent: View {
                         ReloadView(action: retryLoadPreviousChat)
                     }
 
-                    ForEach(groupedChatsByDate.keys.sorted(), id: \.self) { date in
+                    ForEach(groupedChatsByDate.keys.sorted(by: { lhs, rhs in
+                        guard
+                            let date1 = Date.chatDateFormatter().date(from: lhs),
+                            let date2 = Date.chatDateFormatter().date(from: rhs)
+                        else {
+                            return false
+                        }
+                        return date1 < date2
+                    }), id: \.self) { date in
                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                         Section(header: ChatHeader(data: date)) {
                             let chatsForDate = groupedChatsByDate[date] ?? []

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/SpendingManagementView/AddSpendingHistoryView/AddSpendingHistoryView/AddSpendingFormFieldsView.swift
@@ -55,7 +55,7 @@ struct MemoInputView: View {
                 RoundedRectangle(cornerRadius: 4)
                     .fill(Color("Gray01"))
                     .frame(height: 104 * DynamicSizeFactor.factor())
-                
+
                 TextEditor(text: $memoText)
                     .padding(.horizontal, 8 * DynamicSizeFactor.factor())
                     .padding(.vertical, 5 * DynamicSizeFactor.factor())
@@ -68,8 +68,8 @@ struct MemoInputView: View {
                         if memoText.count > maxCharacterCount {
                             memoText = String(memoText.prefix(maxCharacterCount))
                         }
-                }
-                .frame(height: 104 * DynamicSizeFactor.factor())
+                    }
+                    .frame(height: 104 * DynamicSizeFactor.factor())
 
                 if memoText.isEmpty {
                     Text(placeholder)


### PR DESCRIPTION
## 작업 이유

- chat 그룹 정렬 문제 해결


<br/>

## 작업 사항

### 1️⃣ chat 그룹 정렬 문제 해결

### 오류 발견

- 테스트 중 date에 따라서 그룹으로 묶은 채팅 정렬 오류를 발견했다.

<img src ="https://github.com/user-attachments/assets/6e9f7afa-0bbc-4641-a563-81ff8c43c3da" width = "300"/>


확인해보니 그룹안에 chat 데이터들은 오래된 순으로 정렬하고 있었는데 정작 그룹 date들은 정렬하고 있지 않던 문제였다.
이때까지 오류가 발생하지 않았던건 운이 좋았던거..?

그래서 다음과 같이 그룹 date들을 정렬해주니 해결되었다.

```swift
ForEach(groupedChatsByDate.keys.sorted(by: { lhs, rhs in
    guard
        let date1 = Date.chatDateFormatter().date(from: lhs),
        let date2 = Date.chatDateFormatter().date(from: rhs)
    else {
        return false
    }
    return date1 < date2
}), id: \.self) { date in
```

<img src ="https://github.com/user-attachments/assets/38c073f4-298f-40ba-b42b-cd9ec002cf84" width = "300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

chat 그룹 정렬 문제 해결했습니다~


<br/>

## 발견한 이슈
없음