### PR TITLE
🎨 system 채팅 간격 수정

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -51,6 +51,8 @@ struct ChatContent: View {
                         ReloadView(action: retryLoadPreviousChat)
                     }
 
+                    Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+
                     ForEach(groupedChatsByDate.keys.sorted(by: { lhs, rhs in
                         guard
                             let date1 = Date.chatDateFormatter().date(from: lhs),
@@ -60,11 +62,10 @@ struct ChatContent: View {
                         }
                         return date1 < date2
                     }), id: \.self) { date in
-                        Spacer().frame(height: 10 * DynamicSizeFactor.factor())
-                        Section(header: ChatHeader(data: date)) {
-                            let chatsForDate = groupedChatsByDate[date] ?? []
+                        let chatsForDate = groupedChatsByDate[date] ?? []
 
-                            if chatsForDate[0].categoryType != CategoryType.system { // 첫번째 데이터가 system 아닌 경우 간격 적용
+                        Section(header: ChatHeader(data: date)) {
+                            if chatsForDate.first?.categoryType != CategoryType.system {
                                 Spacer().frame(height: 3 * DynamicSizeFactor.factor())
                             }
 
@@ -74,21 +75,26 @@ struct ChatContent: View {
                                 let previousChatType = hasPreviousChat ? chatsForDate[index - 1].categoryType : nil
                                 let nextChatType = hasNextChat ? chatsForDate[index + 1].categoryType : nil
 
-                                if chat.categoryType == CategoryType.system {
+                                if chat.categoryType == .system {
                                     if hasPreviousChat, previousChatType != .system {
                                         Spacer().frame(height: 3 * DynamicSizeFactor.factor())
                                     }
 
                                     ChatHeader(data: chat.content)
 
-                                    if !hasPreviousChat, hasNextChat, nextChatType != .system { // system 문구가 첫 데이터인 경우
+                                    if !hasPreviousChat, hasNextChat, nextChatType != .system {
                                         Spacer().frame(height: 3 * DynamicSizeFactor.factor())
                                     }
+
                                 } else if let sender = members.first(where: { $0.userId == chat.senderId }) {
                                     if chat.senderId == currentUserId {
                                         ChatSendCell(chat: chat, sender: sender)
                                     } else {
                                         ChatReceiveCell(chat: chat, sender: sender)
+                                    }
+
+                                    if index == chatsForDate.count - 1, chatsForDate[index].categoryType != .system {
+                                        Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                                     }
                                 }
                             }


### PR DESCRIPTION
## 작업 이유

- system 채팅 간격 수정


<br/>

## 작업 사항


### 1️⃣ 문제

다음과 같이 시스템 채팅이 나오다가 새로운 날짜의 채팅으로 섹션이 변경되는 경우 간격 오류가 발생하는 문제가 있었다.

<img width="356" alt="스크린샷 2025-01-07 오전 1 58 12" src="https://github.com/user-attachments/assets/8ede1bf6-cfdd-46c7-8b5e-e95a02ac60e4" />

<br/>

### 2️⃣ 해결

마지막 채팅이 시스템이면은 채팅 하단에 간격을 제거하고, 시스템이 아니면 채팅 하단에 간격을 줘서 해결하였다.

<img src = "https://github.com/user-attachments/assets/c40352d0-38c8-416a-91b8-48e527248782" width = "300"/>
<img src = "https://github.com/user-attachments/assets/01866ca6-7dde-48bc-87e4-48437597c795" width = "300"/>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

다른 화면에서도 잘 동작하는 거 확인했습니다!


<br/>

## 발견한 이슈
없음