### PR TITLE
🛠️ 재로그인 후 채팅 전송시 사용자 식별 오류

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -12,7 +12,6 @@ import StompClientLib
 
 class DefaultChatStompRepository: ChatStompRepository {
     private let stompClient: StompClientLib
-    private var subscriptionIds: [String] = [] // 구독 ID를 저장하는 배열
 
     init(stompClient: StompClientLib) {
         self.stompClient = stompClient
@@ -32,11 +31,6 @@ class DefaultChatStompRepository: ChatStompRepository {
 
     /// Stomp 소켓 연결을 해제하는 메서드
     func disconnect() {
-        // 모든 구독 해제
-        for subscriptionId in subscriptionIds {
-            stompClient.unsubscribe(destination: subscriptionId)
-        }
-        subscriptionIds.removeAll() // 저장된 구독 ID 초기화
 
         // 소켓 연결 해제
         stompClient.disconnect()
@@ -77,7 +71,6 @@ class DefaultChatStompRepository: ChatStompRepository {
         let chatRoomReceiptId = "chat-room-receipt-\(UUID().uuidString)"
         let destination = "/sub/chat.room.\(chatRoomId)"
         stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": chatRoomReceiptId])
-        subscriptionIds.append(destination)
     }
 
     /// 뷰 상태를 전달하는 메서드
@@ -114,7 +107,6 @@ extension DefaultChatStompRepository {
         let destination = "/user/queue/errors"
         let errorReceiptId = "error-receipt-\(UUID().uuidString)"
         stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": errorReceiptId])
-        subscriptionIds.append(destination)
     }
 
     /// 채팅방 ID 리스트에 대한 구독을 설정하는 메서드
@@ -123,7 +115,6 @@ extension DefaultChatStompRepository {
             let chatRoomReceiptId = "chat-room-receipt-\(UUID().uuidString)"
             let destination = "/sub/chat.room.\(chatRoomId)"
             stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": chatRoomReceiptId])
-            subscriptionIds.append(destination) // 구독 ID 저장
         }
     }
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -12,6 +12,7 @@ import StompClientLib
 
 class DefaultChatStompRepository: ChatStompRepository {
     private let stompClient: StompClientLib
+    private var subscriptionIds: [String] = [] // 구독 ID를 저장하는 배열
 
     init(stompClient: StompClientLib) {
         self.stompClient = stompClient
@@ -31,13 +32,21 @@ class DefaultChatStompRepository: ChatStompRepository {
 
     /// Stomp 소켓 연결을 해제하는 메서드
     func disconnect() {
+        // 모든 구독 해제
+        for subscriptionId in subscriptionIds {
+            stompClient.unsubscribe(destination: subscriptionId)
+        }
+        subscriptionIds.removeAll() // 저장된 구독 ID 초기화
+
+        // 소켓 연결 해제
         stompClient.disconnect()
+        Log.info("[Disconnect] 모든 구독이 해제되고 소켓 연결 해제")
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
     func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion _: @escaping (Result<Void, Error>) -> Void) {
         let destination = "/pub/chat.message.\(chatRoomId)"
-        let headers = createSendHeaders()
+        let headers = createSendMessageIdHeaders(uuid: "")
         let messageBody: [String: String] = [
             "content": message,
             "contentType": contentType
@@ -68,6 +77,7 @@ class DefaultChatStompRepository: ChatStompRepository {
         let chatRoomReceiptId = "chat-room-receipt-\(UUID().uuidString)"
         let destination = "/sub/chat.room.\(chatRoomId)"
         stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": chatRoomReceiptId])
+        subscriptionIds.append(destination)
     }
 
     /// 뷰 상태를 전달하는 메서드
@@ -101,8 +111,10 @@ class DefaultChatStompRepository: ChatStompRepository {
 extension DefaultChatStompRepository {
     /// 에러 처리위해 Stomp 구독을 설정하는 메서드
     private func subscribeToErrors() {
+        let destination = "/user/queue/errors"
         let errorReceiptId = "error-receipt-\(UUID().uuidString)"
-        stompClient.subscribeWithHeader(destination: "/user/queue/errors", withHeader: ["receipt": errorReceiptId])
+        stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": errorReceiptId])
+        subscriptionIds.append(destination)
     }
 
     /// 채팅방 ID 리스트에 대한 구독을 설정하는 메서드
@@ -111,6 +123,7 @@ extension DefaultChatStompRepository {
             let chatRoomReceiptId = "chat-room-receipt-\(UUID().uuidString)"
             let destination = "/sub/chat.room.\(chatRoomId)"
             stompClient.subscribeWithHeader(destination: destination, withHeader: ["receipt": chatRoomReceiptId])
+            subscriptionIds.append(destination) // 구독 ID 저장
         }
     }
 
@@ -121,6 +134,14 @@ extension DefaultChatStompRepository {
         let request = NSURLRequest(url: URL(string: url)!)
 
         stompClient.openSocketWithURLRequest(request: request, delegate: self, connectionHeaders: headers)
+    }
+
+    private func createSendMessageIdHeaders(uuid: String) -> [String: String] {
+        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")",
+                       "content-type": "application/json",
+                       "x-message-id": uuid
+        ]
+        return headers
     }
 
     private func createSendHeaders() -> [String: String] {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Profile/DefaultLogoutRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Profile/DefaultLogoutRepository.swift
@@ -11,7 +11,7 @@ final class DefaultLogoutRepository: LogoutRepository {
     func execute(completion: @escaping (Bool) -> Void) {
         AuthAlamofire.shared.logout { result in
             switch result {
-            case let .success(data):
+            case .success:
                 Log.debug("Success Logout")
                 KeychainHelper.deleteAccessToken()
                 TokenHandler.deleteAllRefreshTokens()
@@ -39,15 +39,6 @@ final class DefaultLogoutRepository: LogoutRepository {
                         let response = try JSONDecoder().decode(ErrorResponseDto.self, from: responseData)
                         Log.debug(response)
                         Log.debug("디바이스 토큰 삭제됨")
-                        self.execute { success in
-                            if success {
-                                Log.debug("로그아웃 성공")
-                                completion(true)
-                            } else {
-                                Log.error("로그아웃 실패.")
-                                completion(false)
-                            }
-                        }
 
                     } catch {
                         Log.fault("Error parsing response JSON: \(error)")

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Profile/LogoutUseCase.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Usecases/Profile/LogoutUseCase.swift
@@ -26,13 +26,22 @@ protocol LogoutUseCase {
 
 class DefaultLogoutUseCase: LogoutUseCase {
     private let repository: LogoutRepository
+    private let chatStompService = DefaultChatStompService.shared
 
     init(repository: LogoutRepository) {
         self.repository = repository
     }
 
     func execute(completion: @escaping (Bool) -> Void) {
-        repository.execute(completion: completion)
+        repository.execute { result in
+            switch result {
+            case true:
+                self.chatStompService.disconnect()
+                completion(true)
+            case false:
+                completion(false)
+            }
+        }
     }
 
     func deleteDeviceToken(fcmToken: String, completion: @escaping (Bool) -> Void) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/View/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/View/ProfileMenuBarListView.swift
@@ -104,18 +104,6 @@ struct ProfileMenuBarListView: View {
     }
 
     func handleLogout() {
-//        if let fcmToken = AppDelegate.currentFCMToken {
-//            userProfileViewModel.deleteDeviceTokenApi(fcmToken: fcmToken) { success in
-//                DispatchQueue.main.async {
-//                    if success {
-//                        self.showLogoutPopUp = false
-//                        self.authViewModel.logout()
-//                    } else {
-//                        Log.error("디바이스 토큰 삭제 실패")
-//                    }
-//                }
-//            }
-//        }
         if let fcmToken = AppDelegate.currentFCMToken {
             viewModelWrapper.logoutViewModel.deleteDeviceToken(fcmToken: fcmToken)
             showLogoutPopUp = false

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/View/ProfileMenuBarListView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/View/ProfileMenuBarListView.swift
@@ -106,6 +106,7 @@ struct ProfileMenuBarListView: View {
     func handleLogout() {
         if let fcmToken = AppDelegate.currentFCMToken {
             viewModelWrapper.logoutViewModel.deleteDeviceToken(fcmToken: fcmToken)
+            viewModelWrapper.logoutViewModel.logout()
             showLogoutPopUp = false
             authViewModel.logout()
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/ViewModel/LogoutViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/ViewModel/LogoutViewModel.swift
@@ -48,13 +48,10 @@ class DefaultLogoutViewModel: LogoutViewModel {
         logoutUseCase.deleteDeviceToken(fcmToken: fcmToken) { success in
             if success {
                 Log.debug("[LogoutViewModel]: 디바이스 토큰삭제 성공")
+                self.logout()
             } else {
                 Log.error("[LogoutViewModel]: 디바이스 토큰삭제 실패")
             }
         }
     }
 }
-
-// MARK: - INPUT. View event methods
-
-extension DefaultLogoutViewModel {}

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/ViewModel/LogoutViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/UserProfile/ViewModel/LogoutViewModel.swift
@@ -48,7 +48,6 @@ class DefaultLogoutViewModel: LogoutViewModel {
         logoutUseCase.deleteDeviceToken(fcmToken: fcmToken) { success in
             if success {
                 Log.debug("[LogoutViewModel]: 디바이스 토큰삭제 성공")
-                self.logout()
             } else {
                 Log.error("[LogoutViewModel]: 디바이스 토큰삭제 실패")
             }


### PR DESCRIPTION
## 작업 이유

- 재로그인 후 채팅 전송시 사용자 식별 오류

<br/>

## 작업 사항

## 문제

사용자 1로 로그인한 상태에서 로그아웃한 뒤, 사용자 2로 재로그인하면 여전히 사용자 1로 식별되어 채팅이 전송되는 문제가 발생했다.

<br/>


## 해결

문제를 확인한 결과, 로그아웃 시 소켓 연결이 해제되지 않아 이전 사용자의 소켓 정보가 유지되면서 발생한 것으로 파악되었다.

그래서 로그아웃 후 소켓 연결을 해제하도록 DefaultChatStompRepository의 disconnect 메서드를 호출해 모든 소켓 연결을 종료하도록 처리했다. 


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

재로그인 후 채팅 전송시 사용자 식별 오류 발생하는 거 해결했습니다!

코드 중에 DefaultChatStompRepository의 createSendMessageIdHeaders 함수, x-message-id는 지금 처리하고 있는 채팅 메시지 전송할 때 uuid값 헤더에 넣어보내는 로직 구현때문에 넣은 것으로 신경쓰지 않으셔도 됩니다!


<br/>

## 발견한 이슈
없음