### PR TITLE
🛠️ 메시지 전송시 x-message-id 헤더로 식별 가능하도록 개선

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
+++ b/pennyway-client-iOS/pennyway-client-iOS.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		4AA52F3F2C05C3AD00B21521 /* RoundedCornerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */; };
 		4AA969752C6D2B8F00CA889C /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA969742C6D2B8F00CA889C /* NotificationName.swift */; };
 		4AABDBBC2C9C8C2900E9436D /* PresignedUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AABDBBB2C9C8C2900E9436D /* PresignedUrl.swift */; };
+		4AAD2ED82D2D528F00E9EAF2 /* GenerateUuid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAD2ED72D2D528F00E9EAF2 /* GenerateUuid.swift */; };
 		4AB0B13A2C4E56C900A475F5 /* EntryPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */; };
 		4AB0B13C2C4F497400A475F5 /* MapCategoryIconUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */; };
 		4AB0B13E2C50256300A475F5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0B13D2C50256300A475F5 /* LoadingView.swift */; };
@@ -688,6 +689,7 @@
 		4AA52F3E2C05C3AD00B21521 /* RoundedCornerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornerUtil.swift; sourceTree = "<group>"; };
 		4AA969742C6D2B8F00CA889C /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		4AABDBBB2C9C8C2900E9436D /* PresignedUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresignedUrl.swift; sourceTree = "<group>"; };
+		4AAD2ED72D2D528F00E9EAF2 /* GenerateUuid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateUuid.swift; sourceTree = "<group>"; };
 		4AB0B1392C4E56C900A475F5 /* EntryPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryPoint.swift; sourceTree = "<group>"; };
 		4AB0B13B2C4F497400A475F5 /* MapCategoryIconUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCategoryIconUtil.swift; sourceTree = "<group>"; };
 		4AB0B13D2C50256300A475F5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -1404,6 +1406,7 @@
 				4A12FF182C9C4D4600DE10BC /* Observable.swift */,
 				4A863A132CB461BE00BA2F2F /* TextHeightPreference.swift */,
 				4ACB61122CE4C09D0018E78A /* ChatHistoryBinaryList.swift */,
+				4AAD2ED72D2D528F00E9EAF2 /* GenerateUuid.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3189,6 +3192,7 @@
 				D8B0A92C2C4EBDDC00716ECB /* PasswordChangeTypeNavigation.swift in Sources */,
 				4A641A152C0F98380041B053 /* TotalTargetAmountViewModel.swift in Sources */,
 				4A3701CD2C08F7F600F0AEBA /* SpendingAlamofire.swift in Sources */,
+				4AAD2ED82D2D528F00E9EAF2 /* GenerateUuid.swift in Sources */,
 				4AE8F3A82C32AB970014F0D4 /* GetTargetAmountForPreviousMonthResponseDto.swift in Sources */,
 				D83EF6F02CDDD3EA002A4965 /* CdnUrl.swift in Sources */,
 				4A60F64E2C595F6A00805F2C /* CompleteDeleteUserView.swift in Sources */,

--- a/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenHandler.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Api/Handler/TokenHandler.swift
@@ -2,6 +2,8 @@
 import Alamofire
 import Foundation
 
+// MARK: - TokenHandler
+
 class TokenHandler {
     static func extractAndStoreToken(from response: AFDataResponse<Data?>) {
         if let responseHeaders = response.response?.allHeaderFields as? [String: String],
@@ -37,5 +39,88 @@ class TokenHandler {
                 cookieStorage.deleteCookie(cookie)
             }
         }
+    }
+}
+
+// MARK: - JWTError
+
+enum JWTError: Error {
+    case encodingFailed
+    case invalidSecret
+}
+
+import CryptoKit
+import Foundation
+
+// MARK: - AccessTokenGenerator
+
+class AccessTokenGenerator {
+    private let secretKey: Data
+    private let expirationTimeMs: Int64
+
+    enum JWTError: Error {
+        case encodingFailed
+        case invalidSecretKey
+    }
+
+    init(secretKey: String, expirationTimeMs: Int64) {
+        // 평문 시크릿 키를 Base64로 인코딩한 후 다시 디코딩
+        let secretKeyBase64 = secretKey.data(using: .utf8)!.base64EncodedString()
+        self.secretKey = Data(base64Encoded: secretKeyBase64)!
+        self.expirationTimeMs = expirationTimeMs
+    }
+
+    private func createHeader() -> [String: Any] {
+        return [
+            "typ": "JWT",
+            "alg": "HS256",
+            "regDate": Int64(Date().timeIntervalSince1970 * 1000)
+        ]
+    }
+
+    func generateToken(userId: Int64, role: String) throws -> String {
+        let now = Date()
+        let expireDate = now.addingTimeInterval(TimeInterval(expirationTimeMs) / 1000.0)
+
+        // Claims 생성
+        let claims: [String: Any] = [
+            "userId": String(userId), // 서버와 동일하게 문자열로 변환
+            "role": role,
+            "exp": Int64(expireDate.timeIntervalSince1970)
+        ]
+
+        // Header를 Base64URL로 인코딩
+        let header = createHeader()
+        guard let headerData = try? JSONSerialization.data(withJSONObject: header) else {
+            throw JWTError.encodingFailed
+        }
+        let headerBase64 = headerData.base64UrlEncodedString()
+
+        // Payload를 Base64URL로 인코딩
+        guard let payloadData = try? JSONSerialization.data(withJSONObject: claims) else {
+            throw JWTError.encodingFailed
+        }
+        let payloadBase64 = payloadData.base64UrlEncodedString()
+
+        // Signature 생성
+        let signingInput = "\(headerBase64).\(payloadBase64)".data(using: .utf8)!
+        let signature = HMAC<SHA256>.authenticationCode(
+            for: signingInput,
+            using: SymmetricKey(data: secretKey)
+        )
+        let signatureBase64 = Data(signature).base64UrlEncodedString()
+
+        // 최종 토큰 생성
+        return "\(headerBase64).\(payloadBase64).\(signatureBase64)"
+    }
+}
+
+/// Base64URL 인코딩을 위한 확장
+extension Data {
+    func base64UrlEncodedString() -> String {
+        return base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
@@ -33,6 +33,19 @@ struct pennyway_client_iOSApp: App {
                 }
             }
             .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
+            .onAppear {
+                // 사용 예시
+                let secretKey = "exampleSecretKeyForSpringBootProjectAtSubRepository"
+                let expirationTimeMs: Int64 = 5 * 60 * 1000 // 5분
+
+                let generator = AccessTokenGenerator(secretKey: secretKey, expirationTimeMs: expirationTimeMs)
+                do {
+                    let token = try generator.generateToken(userId: 1, role: "ROLE_USER")
+                    print("📍📍📍 Generated Token:", token)
+                } catch {
+                    print("Error:", error)
+                }
+            }
             .onOpenURL { url in
                 GIDSignIn.sharedInstance.handle(url)
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/pennyway_client_iOSApp.swift
@@ -33,19 +33,6 @@ struct pennyway_client_iOSApp: App {
                 }
             }
             .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
-            .onAppear {
-                // 사용 예시
-                let secretKey = "exampleSecretKeyForSpringBootProjectAtSubRepository"
-                let expirationTimeMs: Int64 = 5 * 60 * 1000 // 5분
-
-                let generator = AccessTokenGenerator(secretKey: secretKey, expirationTimeMs: expirationTimeMs)
-                do {
-                    let token = try generator.generateToken(userId: 1, role: "ROLE_USER")
-                    print("📍📍📍 Generated Token:", token)
-                } catch {
-                    print("Error:", error)
-                }
-            }
             .onOpenURL { url in
                 GIDSignIn.sharedInstance.handle(url)
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -12,7 +12,7 @@ import StompClientLib
 
 class DefaultChatStompRepository: ChatStompRepository {
     private let stompClient: StompClientLib
-    private var messageUUIDs: [String: [String: String]] = [:]
+    private var messageDatas: [String: [String: String]] = [:]
 
     init(stompClient: StompClientLib) {
         self.stompClient = stompClient
@@ -38,7 +38,7 @@ class DefaultChatStompRepository: ChatStompRepository {
     /// 메시지를 특정 목적지로 보내는 메서드
     func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion _: @escaping (Result<Void, Error>) -> Void) {
         let destination = "/pub/chat.message.\(chatRoomId)"
-        let uuid = generateSequentialUUID().uuidString
+        let uuid = GenerateUuid.generateSequentialUuid().uuidString
         let headers = createSendMessageIdHeaders(uuid: uuid)
 
         let messageBody: [String: String] = [
@@ -50,9 +50,9 @@ class DefaultChatStompRepository: ChatStompRepository {
             let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                messageUUIDs[uuid] = ["message": message, "chatRoomId": String(chatRoomId), "contentType": contentType]
-                Log.info("📤 [Send Message] total - \(String(describing: messageUUIDs))")
-                Log.info("📤 [Send Message] - \(String(describing: messageUUIDs[uuid]))")
+                messageDatas[uuid] = ["message": message, "chatRoomId": String(chatRoomId), "contentType": contentType]
+                Log.info("📤 [Send Message] total - \(String(describing: messageDatas))")
+                Log.info("📤 [Send Message] - \(String(describing: messageDatas[uuid]))")
                 printSortedMessageUUIDs()
             }
         } catch {
@@ -102,13 +102,13 @@ class DefaultChatStompRepository: ChatStompRepository {
     }
 
     func printSortedMessageUUIDs() {
-        let sortedMessageUUIDs = messageUUIDs.keys.sorted().map { uuid -> (String, [String: String]) in
-            (uuid, messageUUIDs[uuid]!)
+        let sortedMessageUUIDs = messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
+            (uuid, messageDatas[uuid]!)
         }
 
         // 출력: 정렬된 UUID와 해당 데이터
         for (uuid, data) in sortedMessageUUIDs {
-            print("UUID: \(uuid), Data: \(data)")
+            Log.debug("UUID: \(uuid), Data: \(data)")
         }
     }
 }
@@ -120,6 +120,12 @@ extension DefaultChatStompRepository {
     private func subscribeToErrors() {
         let errorReceiptId = "error-receipt-\(UUID().uuidString)"
         stompClient.subscribeWithHeader(destination: "/user/queue/errors", withHeader: ["receipt": errorReceiptId])
+    }
+
+    /// 메시지 전송 성공 처리에 대한 구독을 설정하는 메서드
+    private func subscribeToSuccess() {
+        let errorReceiptId = "success-receipt-\(UUID().uuidString)"
+        stompClient.subscribeWithHeader(destination: "/user/queue/success", withHeader: ["receipt": errorReceiptId])
     }
 
     /// 채팅방 ID 리스트에 대한 구독을 설정하는 메서드
@@ -214,7 +220,7 @@ extension DefaultChatStompRepository {
 
     /// 메시지 UUID 관리에서 제거
     private func removeMessageUUID(uuid: String) {
-        if messageUUIDs.removeValue(forKey: uuid) != nil {
+        if messageDatas.removeValue(forKey: uuid) != nil {
             Log.debug("Message UUID removed: \(uuid)")
         } else {
             Log.warning("Attempted to remove non-existing UUID: \(uuid)")
@@ -228,6 +234,7 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     func stompClientDidConnect(client _: StompClientLib!) {
         Log.info("Socket connected")
         subscribeToErrors()
+        subscribeToSuccess()
         getJoinedChatRooms()
     }
 
@@ -246,6 +253,18 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
 
     func stompClient(client _: StompClientLib!, didReceiveMessageWithJSONBody body: AnyObject?, akaStringBody akaStringBody: String?, withHeader header: [String: String]?, withDestination _: String) {
         Log.info("Did receive Message: body - \(body), \(akaStringBody), \n header - \(header)")
+
+        // `destination` 확인
+        if let destination = header?["destination"], destination == "/user/queue/success" {
+            Log.info("Message ignored: destination is \(destination)")
+            if let id = header?["x-message-id"] {
+                messageDatas.removeValue(forKey: id)
+
+                Log.info("📤📤📤 [Send Message] total - \(String(describing: messageDatas))")
+            }
+
+            return
+        }
 
         if let body = body as? [String: Any],
            let jsonData = try? JSONSerialization.data(withJSONObject: body, options: []),
@@ -276,28 +295,4 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     func serverDidSendPing() {
         Log.info("Server ping received")
     }
-}
-
-func generateSequentialUUID() -> UUID {
-    var uuidBytes = [UInt8](repeating: 0, count: 16)
-
-    // 현재 시간을 밀리초 단위로 가져오기
-    let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
-
-    // 상위 48비트: 타임스탬프 (6 바이트)
-    uuidBytes[0 ... 5] = withUnsafeBytes(of: timestamp.bigEndian) { Array($0) }[2 ... 7]
-
-    // 버전: UUIDv7의 경우 4비트 값 0111
-    uuidBytes[6] = (uuidBytes[6] & 0x0F) | 0x70
-
-    // Variant: 상위 2비트는 10
-    uuidBytes[8] = (uuidBytes[8] & 0x3F) | 0x80
-
-    // 나머지 6바이트: 랜덤 값
-    for i in 9 ..< 16 {
-        uuidBytes[i] = UInt8.random(in: 0 ... 255)
-    }
-
-    // UUID로 변환
-    return UUID(uuid: uuidBytes.withUnsafeBytes { $0.load(as: uuid_t.self) })
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -12,6 +12,7 @@ import StompClientLib
 
 class DefaultChatStompRepository: ChatStompRepository {
     private let stompClient: StompClientLib
+    private var messageUUIDs: [String: [String: String]] = [:]
 
     init(stompClient: StompClientLib) {
         self.stompClient = stompClient
@@ -37,7 +38,9 @@ class DefaultChatStompRepository: ChatStompRepository {
     /// 메시지를 특정 목적지로 보내는 메서드
     func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion _: @escaping (Result<Void, Error>) -> Void) {
         let destination = "/pub/chat.message.\(chatRoomId)"
-        let headers = createSendHeaders()
+        let uuid = generateSequentialUUID().uuidString
+        let headers = createSendMessageIdHeaders(uuid: uuid)
+
         let messageBody: [String: String] = [
             "content": message,
             "contentType": contentType
@@ -47,7 +50,10 @@ class DefaultChatStompRepository: ChatStompRepository {
             let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                Log.info("📤 [Send Message])")
+                messageUUIDs[uuid] = ["message": message, "chatRoomId": String(chatRoomId), "contentType": contentType]
+                Log.info("📤 [Send Message] total - \(String(describing: messageUUIDs))")
+                Log.info("📤 [Send Message] - \(String(describing: messageUUIDs[uuid]))")
+                printSortedMessageUUIDs()
             }
         } catch {
             Log.error("Failed to serialize message body: \(error)")
@@ -94,6 +100,17 @@ class DefaultChatStompRepository: ChatStompRepository {
             Log.error("Failed to serialize message body: \(error)")
         }
     }
+
+    func printSortedMessageUUIDs() {
+        let sortedMessageUUIDs = messageUUIDs.keys.sorted().map { uuid -> (String, [String: String]) in
+            (uuid, messageUUIDs[uuid]!)
+        }
+
+        // 출력: 정렬된 UUID와 해당 데이터
+        for (uuid, data) in sortedMessageUUIDs {
+            print("UUID: \(uuid), Data: \(data)")
+        }
+    }
 }
 
 // MARK: Private Methods
@@ -121,6 +138,14 @@ extension DefaultChatStompRepository {
         let request = NSURLRequest(url: URL(string: url)!)
 
         stompClient.openSocketWithURLRequest(request: request, delegate: self, connectionHeaders: headers)
+    }
+
+    private func createSendMessageIdHeaders(uuid: String) -> [String: String] {
+        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")",
+                       "content-type": "application/json",
+                       "x-message-id": uuid
+        ]
+        return headers
     }
 
     private func createSendHeaders() -> [String: String] {
@@ -186,6 +211,15 @@ extension DefaultChatStompRepository {
             }
         }
     }
+
+    /// 메시지 UUID 관리에서 제거
+    private func removeMessageUUID(uuid: String) {
+        if messageUUIDs.removeValue(forKey: uuid) != nil {
+            Log.debug("Message UUID removed: \(uuid)")
+        } else {
+            Log.warning("Attempted to remove non-existing UUID: \(uuid)")
+        }
+    }
 }
 
 // MARK: StompClientLibDelegate
@@ -210,8 +244,8 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
         }
     }
 
-    func stompClient(client _: StompClientLib!, didReceiveMessageWithJSONBody body: AnyObject?, akaStringBody akaStringBody: String?, withHeader _: [String: String]?, withDestination _: String) {
-        Log.info("Did receive Message: \(body), \(akaStringBody)")
+    func stompClient(client _: StompClientLib!, didReceiveMessageWithJSONBody body: AnyObject?, akaStringBody akaStringBody: String?, withHeader header: [String: String]?, withDestination _: String) {
+        Log.info("Did receive Message: body - \(body), \(akaStringBody), \n header - \(header)")
 
         if let body = body as? [String: Any],
            let jsonData = try? JSONSerialization.data(withJSONObject: body, options: []),
@@ -242,4 +276,28 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
     func serverDidSendPing() {
         Log.info("Server ping received")
     }
+}
+
+func generateSequentialUUID() -> UUID {
+    var uuidBytes = [UInt8](repeating: 0, count: 16)
+
+    // 현재 시간을 밀리초 단위로 가져오기
+    let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+
+    // 상위 48비트: 타임스탬프 (6 바이트)
+    uuidBytes[0 ... 5] = withUnsafeBytes(of: timestamp.bigEndian) { Array($0) }[2 ... 7]
+
+    // 버전: UUIDv7의 경우 4비트 값 0111
+    uuidBytes[6] = (uuidBytes[6] & 0x0F) | 0x70
+
+    // Variant: 상위 2비트는 10
+    uuidBytes[8] = (uuidBytes[8] & 0x3F) | 0x80
+
+    // 나머지 6바이트: 랜덤 값
+    for i in 9 ..< 16 {
+        uuidBytes[i] = UInt8.random(in: 0 ... 255)
+    }
+
+    // UUID로 변환
+    return UUID(uuid: uuidBytes.withUnsafeBytes { $0.load(as: uuid_t.self) })
 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -218,7 +218,7 @@ extension DefaultChatStompRepository {
     }
 
     /// refresh token을 서버에 전송하는  메서드
-    private func sendRefreshToken(completion: @escaping (Result<Void, Error>) -> Void) {
+    private func sendRefreshToken() {
         let destination = "/pub/auth.refresh"
         let receiptId = "refresh-receipt-\(UUID().uuidString)"
         let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")",
@@ -228,36 +228,31 @@ extension DefaultChatStompRepository {
         stompClient.sendMessage(message: "", toDestination: destination, withHeaders: headers, withReceipt: nil)
 
         Log.info("📤 [Send RefreshToken])")
-
-        completion(.success(()))
     }
 
     /// 보내지지 않은 메시지 보내는 메서드
     private func retryUnsentMessages() {
-        sendRefreshToken { _ in
-            Log.info("💀💀💀 [Retry Messages] 호출")
-            let sortedMessages = self.messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
-                (uuid, self.messageDatas[uuid]!)
+        let sortedMessages = messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
+            (uuid, self.messageDatas[uuid]!)
+        }
+
+        for (uuid, data) in sortedMessages {
+            guard let message = data["message"],
+                  let chatRoomIdString = data["chatRoomId"],
+                  let chatRoomId = Int64(chatRoomIdString),
+                  let contentType = data["contentType"]
+            else {
+                Log.error("📤 [Retry Messages] Invalid message data: \(data)")
+                continue
             }
 
-            for (uuid, data) in sortedMessages {
-                guard let message = data["message"],
-                      let chatRoomIdString = data["chatRoomId"],
-                      let chatRoomId = Int64(chatRoomIdString),
-                      let contentType = data["contentType"]
-                else {
-                    Log.error("📤 [Retry Messages] Invalid message data: \(data)")
-                    continue
-                }
-
-                self.sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, retry: true, uuid: uuid) { [weak self] result in
-                    switch result {
-                    case .success:
-                        self?.messageDatas.removeValue(forKey: uuid)
-                        Log.info("📤 [Retry Messages] Successfully sent message with UUID: \(uuid)")
-                    case let .failure(error):
-                        Log.error("📤 [Retry Messages] Failed to resend message with UUID: \(uuid), Error: \(error)")
-                    }
+            sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, retry: true, uuid: uuid) { [weak self] result in
+                switch result {
+                case .success:
+                    self?.messageDatas.removeValue(forKey: uuid)
+                    Log.info("📤 [Retry Messages] Successfully sent message with UUID: \(uuid)")
+                case let .failure(error):
+                    Log.error("📤 [Retry Messages] Failed to resend message with UUID: \(uuid), Error: \(error)")
                 }
             }
         }
@@ -302,7 +297,7 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
                 switch result {
                 case .success:
                     Log.debug("Token refreshed, retrying request sucess")
-                    self.retryUnsentMessages()
+                    self.sendRefreshToken()
 
                 case .failure:
                     Log.debug("Token refreshed, retrying request fail")
@@ -328,8 +323,13 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
         }
     }
 
-    func serverDidSendReceipt(client _: StompClientLib!, withReceiptId receiptId: String) {
-        Log.info("Receipt received: \(receiptId)")
+    func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String) {
+        Log.info("Receipt received: \(receiptId) \(String(describing: client))")
+
+        // receiptId가 "refresh-receipt-"로 시작하는 경우 처리
+        if receiptId.hasPrefix("refresh-receipt-") {
+            retryUnsentMessages()
+        }
     }
 
     func serverDidSendError(client _: StompClientLib!, withErrorMessage description: String, detailedErrorMessage detailedErrorMessage: String?) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -36,10 +36,10 @@ class DefaultChatStompRepository: ChatStompRepository {
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
-    func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion _: @escaping (Result<Void, Error>) -> Void) {
+    func sendMessage(message: String, chatRoomId: Int64, contentType: String, retry: Bool? = false, uuid: String? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
         let destination = "/pub/chat.message.\(chatRoomId)"
-        let uuid = GenerateUuid.generateSequentialUuid().uuidString
-        let headers = createSendMessageIdHeaders(uuid: uuid)
+        let messageUuid = uuid ?? GenerateUuid.generateSequentialUuid().uuidString
+        let headers = createSendMessageIdHeaders(uuid: messageUuid)
 
         let messageBody: [String: String] = [
             "content": message,
@@ -50,13 +50,14 @@ class DefaultChatStompRepository: ChatStompRepository {
             let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: [])
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 stompClient.sendMessage(message: jsonString, toDestination: destination, withHeaders: headers, withReceipt: nil)
-                messageDatas[uuid] = ["message": message, "chatRoomId": String(chatRoomId), "contentType": contentType]
+                messageDatas[messageUuid] = ["message": message, "chatRoomId": String(chatRoomId), "contentType": contentType]
                 Log.info("📤 [Send Message] total - \(String(describing: messageDatas))")
-                Log.info("📤 [Send Message] - \(String(describing: messageDatas[uuid]))")
-                printSortedMessageUUIDs()
+                Log.info("📤 [Send Message] - \(String(describing: messageDatas[messageUuid]))")
+                completion(.success(()))
             }
         } catch {
             Log.error("Failed to serialize message body: \(error)")
+            completion(.failure(error))
         }
     }
 
@@ -67,6 +68,19 @@ class DefaultChatStompRepository: ChatStompRepository {
 
         stompClient.sendMessage(message: "", toDestination: destination, withHeaders: headers, withReceipt: nil)
         Log.info("📤 [Send Last Message])")
+    }
+
+    /// refresh token을 전송하는  메서드
+    func sendRefreshToken(completion: @escaping (Result<Void, Error>) -> Void) {
+        let destination = "/pub/auth.refresh"
+        let headers = createSendHeaders()
+
+        stompClient.sendMessage(message: "", toDestination: destination, withHeaders: headers, withReceipt: nil)
+
+        Log.info("📤 [Send RefreshToken])")
+
+        // 여기에 completion 호출 추가
+        completion(.success(()))
     }
 
     /// 채팅방 ID 에 대한 구독을 설정하는 메서드
@@ -101,14 +115,34 @@ class DefaultChatStompRepository: ChatStompRepository {
         }
     }
 
-    func printSortedMessageUUIDs() {
-        let sortedMessageUUIDs = messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
-            (uuid, messageDatas[uuid]!)
-        }
-
-        // 출력: 정렬된 UUID와 해당 데이터
-        for (uuid, data) in sortedMessageUUIDs {
-            Log.debug("UUID: \(uuid), Data: \(data)")
+    /// 보내지지 않은 메시지 보내는 메서드
+    func retryUnsentMessages() {
+        sendRefreshToken { _ in
+            Log.debug("💀💀💀 retry 실행")
+            let sortedMessages = self.messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
+                (uuid, self.messageDatas[uuid]!)
+            }
+            
+            for (uuid, data) in sortedMessages {
+                guard let message = data["message"],
+                      let chatRoomIdString = data["chatRoomId"],
+                      let chatRoomId = Int64(chatRoomIdString),
+                      let contentType = data["contentType"]
+                else {
+                    Log.error("📤 [Retry Messages] Invalid message data: \(data)")
+                    continue
+                }
+                
+                self.sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, retry: true, uuid: uuid) { [weak self] result in
+                    switch result {
+                    case .success:
+                        self?.messageDatas.removeValue(forKey: uuid)
+                        Log.info("📤 [Retry Messages] Successfully sent message with UUID: \(uuid)")
+                    case let .failure(error):
+                        Log.error("📤 [Retry Messages] Failed to resend message with UUID: \(uuid), Error: \(error)")
+                    }
+                }
+            }
         }
     }
 }
@@ -256,8 +290,21 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
         // `destination` 확인
         if let destination = header?["destination"], destination == "/user/queue/success" {
             handleRemovedMessage(header: header)
-
             return
+        }
+
+        if let body = body as? [String: Any], let code = body["code"] as? String, code == "4011" {
+            Log.info("📤 [Retry Messages] Error code \(code) detected. Retrying unsent messages.")
+            TokenRefreshHandler.shared.refreshSync { result, _ in
+                switch result {
+                case .success:
+                    Log.debug("Token refreshed, retrying request sucess")
+                    self.retryUnsentMessages()
+
+                case .failure:
+                    Log.debug("Token refreshed, retrying request fail")
+                }
+            }
         }
 
         if let body = body as? [String: Any],

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -218,12 +218,11 @@ extension DefaultChatStompRepository {
         }
     }
 
-    /// 메시지 UUID 관리에서 제거
-    private func removeMessageUUID(uuid: String) {
-        if messageDatas.removeValue(forKey: uuid) != nil {
-            Log.debug("Message UUID removed: \(uuid)")
-        } else {
-            Log.warning("Attempted to remove non-existing UUID: \(uuid)")
+    /// `/user/queue/success`에서 받은 메시지 처리
+    private func handleRemovedMessage(header: [String: String]?) {
+        if let id = header?["x-message-id"] {
+            messageDatas.removeValue(forKey: id)
+            Log.info("📤 [Send Message] Removed ID \(id). Remaining messages: \(messageDatas)")
         }
     }
 }
@@ -256,12 +255,7 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
 
         // `destination` 확인
         if let destination = header?["destination"], destination == "/user/queue/success" {
-            Log.info("Message ignored: destination is \(destination)")
-            if let id = header?["x-message-id"] {
-                messageDatas.removeValue(forKey: id)
-
-                Log.info("📤📤📤 [Send Message] total - \(String(describing: messageDatas))")
-            }
+            handleRemovedMessage(header: header)
 
             return
         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultChatStompRepository.swift
@@ -36,7 +36,7 @@ class DefaultChatStompRepository: ChatStompRepository {
     }
 
     /// 메시지를 특정 목적지로 보내는 메서드
-    func sendMessage(message: String, chatRoomId: Int64, contentType: String, retry: Bool? = false, uuid: String? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
+    func sendMessage(message: String, chatRoomId: Int64, contentType: String, retry _: Bool? = false, uuid: String? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
         let destination = "/pub/chat.message.\(chatRoomId)"
         let messageUuid = uuid ?? GenerateUuid.generateSequentialUuid().uuidString
         let headers = createSendMessageIdHeaders(uuid: messageUuid)
@@ -70,19 +70,6 @@ class DefaultChatStompRepository: ChatStompRepository {
         Log.info("📤 [Send Last Message])")
     }
 
-    /// refresh token을 전송하는  메서드
-    func sendRefreshToken(completion: @escaping (Result<Void, Error>) -> Void) {
-        let destination = "/pub/auth.refresh"
-        let headers = createSendHeaders()
-
-        stompClient.sendMessage(message: "", toDestination: destination, withHeaders: headers, withReceipt: nil)
-
-        Log.info("📤 [Send RefreshToken])")
-
-        // 여기에 completion 호출 추가
-        completion(.success(()))
-    }
-
     /// 채팅방 ID 에 대한 구독을 설정하는 메서드
     func subscribeToChatRoom(chatRoomId: Int64) {
         let chatRoomReceiptId = "chat-room-receipt-\(UUID().uuidString)"
@@ -114,37 +101,6 @@ class DefaultChatStompRepository: ChatStompRepository {
             Log.error("Failed to serialize message body: \(error)")
         }
     }
-
-    /// 보내지지 않은 메시지 보내는 메서드
-    func retryUnsentMessages() {
-        sendRefreshToken { _ in
-            Log.debug("💀💀💀 retry 실행")
-            let sortedMessages = self.messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
-                (uuid, self.messageDatas[uuid]!)
-            }
-            
-            for (uuid, data) in sortedMessages {
-                guard let message = data["message"],
-                      let chatRoomIdString = data["chatRoomId"],
-                      let chatRoomId = Int64(chatRoomIdString),
-                      let contentType = data["contentType"]
-                else {
-                    Log.error("📤 [Retry Messages] Invalid message data: \(data)")
-                    continue
-                }
-                
-                self.sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, retry: true, uuid: uuid) { [weak self] result in
-                    switch result {
-                    case .success:
-                        self?.messageDatas.removeValue(forKey: uuid)
-                        Log.info("📤 [Retry Messages] Successfully sent message with UUID: \(uuid)")
-                    case let .failure(error):
-                        Log.error("📤 [Retry Messages] Failed to resend message with UUID: \(uuid), Error: \(error)")
-                    }
-                }
-            }
-        }
-    }
 }
 
 // MARK: Private Methods
@@ -173,6 +129,7 @@ extension DefaultChatStompRepository {
 
     /// 실제로 소켓 연결을 수행하는 메서드
     private func connectToSocket(url: String) {
+        Log.debug("[connectToSocket] - 소켓 연결 수행")
         let headers = createConnectionHeaders()
 
         let request = NSURLRequest(url: URL(string: url)!)
@@ -259,6 +216,52 @@ extension DefaultChatStompRepository {
             Log.info("📤 [Send Message] Removed ID \(id). Remaining messages: \(messageDatas)")
         }
     }
+
+    /// refresh token을 서버에 전송하는  메서드
+    private func sendRefreshToken(completion: @escaping (Result<Void, Error>) -> Void) {
+        let destination = "/pub/auth.refresh"
+        let receiptId = "refresh-receipt-\(UUID().uuidString)"
+        let headers = ["Authorization": "Bearer \(KeychainHelper.loadAccessToken() ?? "")",
+                       "content-type": "application/json",
+                       "receipt": receiptId]
+
+        stompClient.sendMessage(message: "", toDestination: destination, withHeaders: headers, withReceipt: nil)
+
+        Log.info("📤 [Send RefreshToken])")
+
+        completion(.success(()))
+    }
+
+    /// 보내지지 않은 메시지 보내는 메서드
+    private func retryUnsentMessages() {
+        sendRefreshToken { _ in
+            Log.info("💀💀💀 [Retry Messages] 호출")
+            let sortedMessages = self.messageDatas.keys.sorted().map { uuid -> (String, [String: String]) in
+                (uuid, self.messageDatas[uuid]!)
+            }
+
+            for (uuid, data) in sortedMessages {
+                guard let message = data["message"],
+                      let chatRoomIdString = data["chatRoomId"],
+                      let chatRoomId = Int64(chatRoomIdString),
+                      let contentType = data["contentType"]
+                else {
+                    Log.error("📤 [Retry Messages] Invalid message data: \(data)")
+                    continue
+                }
+
+                self.sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, retry: true, uuid: uuid) { [weak self] result in
+                    switch result {
+                    case .success:
+                        self?.messageDatas.removeValue(forKey: uuid)
+                        Log.info("📤 [Retry Messages] Successfully sent message with UUID: \(uuid)")
+                    case let .failure(error):
+                        Log.error("📤 [Retry Messages] Failed to resend message with UUID: \(uuid), Error: \(error)")
+                    }
+                }
+            }
+        }
+    }
 }
 
 // MARK: StompClientLibDelegate
@@ -329,8 +332,8 @@ extension DefaultChatStompRepository: StompClientLibDelegate {
         Log.info("Receipt received: \(receiptId)")
     }
 
-    func serverDidSendError(client _: StompClientLib!, withErrorMessage description: String, detailedErrorMessage _: String?) {
-        Log.error("Error: \(description)")
+    func serverDidSendError(client _: StompClientLib!, withErrorMessage description: String, detailedErrorMessage detailedErrorMessage: String?) {
+        Log.error("Error: \(description) \n detail: \(detailedErrorMessage)")
     }
 
     func serverDidSendPing() {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/ChatStompRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Interfaces/Chat/ChatStompRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol ChatStompRepository {
     func connect(completion: @escaping (Result<Void, Error>) -> Void)
     func disconnect()
-    func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion: @escaping (Result<Void, Error>) -> Void)
+    func sendMessage(message: String, chatRoomId: Int64, contentType: String, retry: Bool?, uuid: String?, completion: @escaping (Result<Void, Error>) -> Void)
     func sendLastMessage(chatRoomId: Int64, lastReadMessageId: Int64, completion: @escaping (Result<Void, Error>) -> Void)
     func subscribeToChatRoom(chatRoomId: Int64)
     func sendViewState(status: String, chatRoomId: Int64?)

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Service/DefaultChatStompService.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Domain/Service/DefaultChatStompService.swift
@@ -36,7 +36,7 @@ class DefaultChatStompService {
     }
     
     func sendMessage(message: String, chatRoomId: Int64, contentType: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        repository.sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, completion: completion)
+        repository.sendMessage(message: message, chatRoomId: chatRoomId, contentType: contentType, retry: nil, uuid: nil, completion: completion)
     }
     
     func sendLastMessage(chatRoomId: Int64, lastReadMessageId: Int64, completion: @escaping (Result<Void, Error>) -> Void) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/GenerateUuid.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Utils/GenerateUuid.swift
@@ -1,0 +1,34 @@
+//
+//  GenerateUuid.swift
+//  pennyway-client-iOS
+//
+//  Created by 최희진 on 1/7/25.
+//
+
+import Foundation
+
+class GenerateUuid {
+    static func generateSequentialUuid() -> UUID {
+        var uuidBytes = [UInt8](repeating: 0, count: 16)
+
+        // 현재 시간을 밀리초 단위로 가져오기
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+
+        // 상위 48비트: 타임스탬프 (6 바이트)
+        uuidBytes[0 ... 5] = withUnsafeBytes(of: timestamp.bigEndian) { Array($0) }[2 ... 7]
+
+        // 버전: UUIDv7의 경우 4비트 값 0111
+        uuidBytes[6] = (uuidBytes[6] & 0x0F) | 0x70
+
+        // Variant: 상위 2비트는 10
+        uuidBytes[8] = (uuidBytes[8] & 0x3F) | 0x80
+
+        // 나머지 6바이트: 랜덤 값
+        for i in 9 ..< 16 {
+            uuidBytes[i] = UInt8.random(in: 0 ... 255)
+        }
+
+        // UUID로 변환
+        return UUID(uuid: uuidBytes.withUnsafeBytes { $0.load(as: uuid_t.self) })
+    }
+}


### PR DESCRIPTION
## 작업 이유

- 메시지 전송시 x-message-id 헤더로 식별 가능하도록 개선


<br/>

## 작업 사항

## 문제

사용자가 메시지를 전송하는 도중 토큰 만료로 인해 메시지 전송이 실패하는 경우, 해당 메시지가 전달되지 않는 문제가 있었다. 이를 해결하기 위해, 실패한 메시지를 저장한 뒤, 토큰 갱신(refresh) 후 재전송하는 로직을 구현했다.

## 구현

메시지 전송 오류로 인해 다시 refresh한 후 재전송하는 로직을 다이어그램으로 표현했다.

![스크린샷 2025-01-15 오후 6 45 00](https://github.com/user-attachments/assets/d70b0a12-81dc-4cca-bc05-2837cb3d6d95)

GenerateUuid 클래스를 만들어서 uuid를 시간순으로 만들 수 있도록 구현하였고, 
메시지를 전송할 때 GenerateUuid에서 만든 uuid(x-message-id) 헤더를 추가하여 각 메시지가 고유한 ID를 가지도록 설정했다.

```swift
func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String) {
    // receiptId가 "refresh-receipt-"로 시작하는 경우 처리
    if receiptId.hasPrefix("refresh-receipt-") {
        retryUnsentMessages()//보내지지 않은 메시지 전송
    }
}
```

현재는 다음과 같이 receiptId가 `refresh-receipt-`로 시작하는 경우 재전송 로직을 실행하도록 처리하였는데 추후에 serverDidSendReceipt()의 client 매개변수 header값을 열어서 성공한 경우에만 재전송 로직을 실행하도록 수정하려고 한다.



<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

메시지 전송시 x-message-id 헤더를 추가하여 각 메시지를 식별할 수 있도록 하였고, 전송 오류가 생겼을 때도 메시지 재전송이 이뤄지도록 처리했습니다! 
궁금한 점이나 이상있으면 말씀해주세요!


<br/>

## 발견한 이슈
없음