### PR TITLE
🛠️ 채팅방 수정 설명 필드 데이터 누락 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultEditChatRoomRepository.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Data/Repository/Chat/DefaultEditChatRoomRepository.swift
@@ -50,8 +50,8 @@ class DefaultEditChatRoomRepository: EditChatRoomRepository {
 
         let editChatRoomRequestDto = EditChatRoomRequestDto(
             title: roomData.title,
-            description: roomData.description?.isEmpty == true ? nil : roomData.description!,
-            password: roomData.password?.isEmpty == true ? nil : roomData.password!,
+            description: roomData.description?.isEmpty == true ? nil : roomData.description,
+            password: roomData.password?.isEmpty == true ? nil : roomData.password,
             backgroundImageUrl: parserData.isEmpty ? nil : parserData
         )
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/View/ChatRoomSettingView.swift
@@ -94,7 +94,7 @@ struct ChatRoomSettingView: View, ImageLoadable {
                             validateForm()
 
                             if isFormValid {
-                                viewModelWrapper.editChatRoomViewModel.updateEditRoomData(title: chatRoomName, password: password, selectedUIImage: selectedUIImage)
+                                viewModelWrapper.editChatRoomViewModel.updateEditRoomData(title: chatRoomName, password: password, description: description, selectedUIImage: selectedUIImage)
                                 viewModelWrapper.editChatRoomViewModel.editChatRoom { success in
                                     if success {
                                         showCompleteToastPopup = true

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/ViewModel/EditChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSetting/ViewModel/EditChatRoomViewModel.swift
@@ -15,7 +15,7 @@ protocol EditChatRoomViewModelInput {
     func uploadImage(image: UIImage)
     func getChatAdminMode(chatRoomId: Int64, completion: @escaping (Result<AdminModeChatRoomItemModel, Error>) -> Void)
     func editChatRoom(completion: @escaping (Bool) -> Void)
-    func updateEditRoomData(title: String, password: String, selectedUIImage: UIImage?)
+    func updateEditRoomData(title: String, password: String, description: String, selectedUIImage: UIImage?)
     func handleChatRoomAlarm(chatRoomId: Int64, chatRoomAlarm: ChatRoomAlarmType, completion: @escaping (Bool) -> Void)
 }
 
@@ -51,9 +51,12 @@ class DefaultEditChatRoomViewModel: EditChatRoomViewModel {
         ))
     }
 
-    func updateEditRoomData(title: String, password: String, selectedUIImage: UIImage?) {
+    func updateEditRoomData(title: String, password: String, description: String, selectedUIImage: UIImage?) {
         if !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             editRoomData.value.title = title
+        }
+        if !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            editRoomData.value.description = description
         }
         if selectedUIImage == nil {
             editRoomData.value.backgroundImageUrlUpdate(backgroundImageUrl: nil)


### PR DESCRIPTION
## 작업 이유

- 채팅방 수정 설명 필드 데이터 누락 해결

<br/>

## 작업 사항

### 1️⃣ 채팅방 수정 설명 필드 데이터 누락 해결

채팅방 수정할 때 설명 필드 데이터를 반영하는 코드가 빠져있어서 추가하였다.
그리고 api 요청을 보낼때 강제 옵셔널 부분을 제외하여 만약의 오류가 발생하지 않도록 하였다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 수정 설명 필드 데이터 누락된 부분이 있어서 바로 반영하겠습니다~!

<br/>

## 발견한 이슈
없음