### PR TITLE
🛠️ 채팅방 나간 후 사용자 판단 오류 해결

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatContent.swift
@@ -96,6 +96,13 @@ struct ChatContent: View {
                                     if index == chatsForDate.count - 1, chatsForDate[index].categoryType != .system {
                                         Spacer().frame(height: 10 * DynamicSizeFactor.factor())
                                     }
+                                } else if !members.contains(where: { $0.userId == chat.senderId }) {
+                                    // members에 없는 userId를 가진 경우 처리
+                                    ChatReceiveCell(chat: chat, sender: nil)
+
+                                    if index == chatsForDate.count - 1, chatsForDate[index].categoryType != .system {
+                                        Spacer().frame(height: 10 * DynamicSizeFactor.factor())
+                                    }
                                 }
                             }
                         }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ChatMessage: View {
     let chat: MessageItemModel
-    let sender: ChatMemberItemModel
+    let sender: ChatMemberItemModel?
     let isSender: Bool
     let maxWidth: CGFloat = 151 * DynamicSizeFactor.factor()
     
@@ -94,7 +94,7 @@ struct ChatMessage: View {
     private var shareChatMessage: some View {
         VStack(spacing: 12) {
             // 타이틀 영역
-            Text("\(sender.name)님의\n\(DateFormatterUtil.formatNormalDateString(spendingContent?.date ?? "")) 지출 내역")
+            Text("\(sender?.name ?? "알수없음")님의\n\(DateFormatterUtil.formatNormalDateString(spendingContent?.date ?? "")) 지출 내역")
                 .font(.B2SemiboldFont())
                 .platformTextColor(color: .white01)
                 .padding(.leading, 13 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatMessage.swift
@@ -94,7 +94,7 @@ struct ChatMessage: View {
     private var shareChatMessage: some View {
         VStack(spacing: 12) {
             // 타이틀 영역
-            Text("\(sender?.name ?? "알수없음")님의\n\(DateFormatterUtil.formatNormalDateString(spendingContent?.date ?? "")) 지출 내역")
+            Text("\(sender?.name ?? "알 수 없음")님의\n\(DateFormatterUtil.formatNormalDateString(spendingContent?.date ?? "")) 지출 내역")
                 .font(.B2SemiboldFont())
                 .platformTextColor(color: .white01)
                 .padding(.leading, 13 * DynamicSizeFactor.factor())

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct ChatReceiveCell: View, ImageLoadable {
     @State private var loadedImage: UIImage? = nil
     let chat: MessageItemModel
-    let sender: ChatMemberItemModel
+    let sender: ChatMemberItemModel?
 
     var body: some View {
         HStack(alignment: .top, spacing: 11 * DynamicSizeFactor.factor()) {
@@ -36,7 +36,7 @@ struct ChatReceiveCell: View, ImageLoadable {
 
             VStack(alignment: .leading, spacing: 5 * DynamicSizeFactor.factor()) {
                 // 사용자 이름
-                Text(sender.name)
+                Text(sender?.name ?? "알수없음")
                     .font(.B3MediumFont())
                     .platformTextColor(color: Color("Gray06"))
 
@@ -47,8 +47,8 @@ struct ChatReceiveCell: View, ImageLoadable {
         }
         .padding(.horizontal, 20)
         .onAppear {
-            if sender.profileImage != "" {
-                loadImage(from: sender.profileImage ?? "") { image in
+            if sender?.profileImage != "" {
+                loadImage(from: sender?.profileImage ?? "") { image in
                     self.loadedImage = image
                 }
             }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/Component/ChatReceiveCell.swift
@@ -36,7 +36,7 @@ struct ChatReceiveCell: View, ImageLoadable {
 
             VStack(alignment: .leading, spacing: 5 * DynamicSizeFactor.factor()) {
                 // 사용자 이름
-                Text(sender?.name ?? "알수없음")
+                Text(sender?.name ?? "알 수 없음")
                     .font(.B3MediumFont())
                     .platformTextColor(color: Color("Gray06"))
 

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -21,7 +21,7 @@ struct ChatRoomView: View {
 
     let chatRoomId: Int64?
     var chatRoom: ChatRoomProtocol?
-    private let currentUserId = getUserData()!.id
+    private let currentUserId = getUserData()?.id ?? 0
 
     var body: some View {
         ZStack {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -80,6 +80,9 @@ class DefaultChatRoomViewModel: ChatRoomViewModel {
             .sink { [weak self] notification in
                 // 메시지 받은 경우 처리
                 if let message = notification.object as? MessageItemModel, self?.roomData.value?.id == message.chatRoomId {
+                    if message.categoryType == .system {
+                        self?.getChatRoomDetail(chatRoomId: message.chatRoomId) { _ in }
+                    }
                     self?.handleNewMessage(message)
                     self?.sendLastMessage(chatRoomId: message.chatRoomId, lastReadMessageId: message.chatId)
                 }

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -114,7 +114,7 @@ private struct SideMenuContent: View {
     let members: [ChatMemberItemModel]
     let onUserSelect: (ChatMemberItemModel) -> Void
     
-    private let currentUserId = getUserData()!.id
+    private let currentUserId = getUserData()?.id ?? 0
     
     var body: some View {
         VStack(alignment: .leading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ShareToChatRoom/View/ShareToChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ShareToChatRoom/View/ShareToChatRoomView.swift
@@ -86,7 +86,7 @@ struct ShareToChatRoomView: View {
     
     private var searchChatContainer: some View {
         VStack {
-            CustomInputView(inputText: $chatRoomName, placeholder: "원하는 주제를 찾아보세요", onCommit: {
+            CustomInputView(inputText: $chatRoomName, placeholder: "", onCommit: {
                 viewModelWrapper.searchQuery = chatRoomName
             }, isSecureText: false, showSearchBtn: true)
                 .onChange(of: chatRoomName) { newValue in

--- a/pennyway-client-iOS/pennyway-client-iOS/Utils/UserDefaultsHelper.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Utils/UserDefaultsHelper.swift
@@ -15,6 +15,10 @@ func saveUserData(userData: UserDataDto) {
     }
 }
 
+func removeUserData() {
+    UserDefaults.standard.removeObject(forKey: "userData")
+}
+
 func getUserData() -> UserDataDto? {
     if let userDataJSON = UserDefaults.standard.data(forKey: "userData") {
         do {

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
@@ -58,7 +58,7 @@ struct MainTabView: View {
         .onChange(of: navigationState.shouldNavigateToChatRoom) { showNavigate in
             if showNavigate {
                 // 딥링크를 통해 채팅 탭으로 이동
-                selection = 2
+                viewModel.selection = 2
                 Log.debug("[MainTabView]: \(String(describing: navigationState.selectedChatRoomId))")
 
                 DispatchQueue.main.async {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -27,6 +27,7 @@ class AppViewModel: ObservableObject {
     func logout() {
         isLoggedIn = false
         checkLoginState = false
+        removeUserData()
     }
 
     func login() {
@@ -35,12 +36,17 @@ class AppViewModel: ObservableObject {
     }
 
     func checkLoginStateUseCase() {
-        loginUseCase.checkLoginState { [weak self] isLoggedIn in
-            self?.checkLoginState = isLoggedIn
-            self?.isLoggedIn = isLoggedIn
-            if isLoggedIn {
-                self?.registDeviceTokenApi()
-                Log.debug("accessToken: \(KeychainHelper.loadAccessToken())")
+        if getUserData() == nil {
+            KeychainHelper.deleteAccessToken()
+            TokenHandler.deleteAllRefreshTokens()     
+        } else {
+            loginUseCase.checkLoginState { [weak self] isLoggedIn in
+                self?.checkLoginState = isLoggedIn
+                self?.isLoggedIn = isLoggedIn
+                if isLoggedIn {
+                    self?.registDeviceTokenApi()
+                    Log.debug("accessToken: \(KeychainHelper.loadAccessToken())")
+                }
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -36,17 +36,12 @@ class AppViewModel: ObservableObject {
     }
 
     func checkLoginStateUseCase() {
-        if getUserData() == nil {
-            KeychainHelper.deleteAccessToken()
-            TokenHandler.deleteAllRefreshTokens()     
-        } else {
-            loginUseCase.checkLoginState { [weak self] isLoggedIn in
-                self?.checkLoginState = isLoggedIn
-                self?.isLoggedIn = isLoggedIn
-                if isLoggedIn {
-                    self?.registDeviceTokenApi()
-                    Log.debug("accessToken: \(KeychainHelper.loadAccessToken())")
-                }
+        loginUseCase.checkLoginState { [weak self] isLoggedIn in
+            self?.checkLoginState = isLoggedIn
+            self?.isLoggedIn = isLoggedIn
+            if isLoggedIn {
+                self?.registDeviceTokenApi()
+                Log.debug("accessToken: \(KeychainHelper.loadAccessToken())")
             }
         }
     }


### PR DESCRIPTION
## 작업 이유

- 채팅방 나간 후 사용자 판단 오류 해결


<br/>

## 작업 사항

### 1️⃣ 채팅방 나간 후 사용자 판단 오류 해결

채팅방에서 사용자가 나간 후에는 그 사용자의 프로필 이미지나 이름을 더 이상 업데이트할 수 없다.
그래서 채팅방을 나간 사용자는 이전 채팅 기록을 보여줄때 "알 수 없음"이라고 표시되고 기본 이미지를 보여주도록 처리하였다.

<img src = "https://github.com/user-attachments/assets/fd1f2593-3023-4ddc-8d3d-1e3aad67a834" width = "300" />

<br/>

### 2️⃣ 로그아웃하는 경우 userDefaults 데이터 제거

로그아웃하고 재로그인 하는 경우 메인 화면에서 이전 사용자의 이름이 잠깐 보였다가 다시 새로 로그인한 사용자의 이름으로 변경되는 문제가 있었다. 
그래서 로그아웃하는 경우 removeUserData() 메서드를 사용하여 userDefaults에 저장된 정보를 삭제하도록 하여 재로그인할때 이전 사용자의 이름이 보이지 않도록 처리하였다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

채팅방 나간 후 사용자 판단 오류 해결했고, 로그아웃하는 경우 userDefaults의 데이터도 제거하는 걸로 처리했는데 이상있으면 말씀해주세요!


<br/>

## 발견한 이슈
없음