### PR TITLE
💻 사용자 추적 금지 요청 팝업 적용

### DIFF
--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -1,3 +1,5 @@
+import AdSupport
+import AppTrackingTransparency
 import Firebase
 import FirebaseCore
 import FirebaseMessaging
@@ -14,45 +16,69 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         NetworkMonitor.shared.startMonitoring()
 
-        // 파이어베이스 설정
-        let firebaseAnalyticsService = FirebaseAnalyticsService()
+        deepLinkCoordinator = DeepLinkCoordinator()
+        FirebaseApp.configure()
 
+        setupNotification(application)
+        requestTrackingPermissionAndInitializeAnalytics(application, launchOptions)
+
+        application.registerForRemoteNotifications()
+        Messaging.messaging().delegate = self
+
+        return true
+    }
+
+    /// 🔔 **알림 설정**
+    private func setupNotification(_ application: UIApplication) {
+        UNUserNotificationCenter.current().delegate = self
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
+            if granted {
+                Log.info("알림 허용됨")
+            } else {
+                Log.info("알림 거부됨")
+            }
+
+            if let error = error {
+                Log.error("Error requesting notification authorization: \(error.localizedDescription)")
+            }
+
+            // 알림 요청 후 1초 뒤 앱 추적 권한 요청 실행
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.requestTrackingPermissionAndInitializeAnalytics(application, nil)
+            }
+        }
+    }
+
+    /// 📊 **앱 추적 권한 요청 및 Firebase Analytics 초기화**
+    private func requestTrackingPermissionAndInitializeAnalytics(_ application: UIApplication, _ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+        let status = ATTrackingManager.trackingAuthorizationStatus
+
+        if status == .authorized {
+            initializeAnalytics(application, launchOptions) // 추적 허용된 경우 실행
+        } else if status == .notDetermined {
+            // 권한 요청 후 승인된 경우 실행
+            ATTrackingManager.requestTrackingAuthorization { newStatus in
+                if newStatus == .authorized {
+                    DispatchQueue.main.async {
+                        self.initializeAnalytics(application, launchOptions)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Firebase Analytics 초기화
+    private func initializeAnalytics(_ application: UIApplication, _ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+        let firebaseAnalyticsService = FirebaseAnalyticsService()
         AnalyticsManager.shared.addService(firebaseAnalyticsService)
 
         if let launchOptions = launchOptions {
             AnalyticsManager.shared.initialize(application: application, didFinishLaunchingWithOptions: launchOptions)
         }
 
-        deepLinkCoordinator = DeepLinkCoordinator() // 초기화
-        FirebaseApp.configure()
-
-        // 알림 허용 여부
-        UNUserNotificationCenter.current().delegate = self
-
-        let authOption: UNAuthorizationOptions = [.alert, .badge, .sound]
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: authOption,
-            completionHandler: { granted, error in
-                if granted { // 알림 허용
-                    Log.info("알림 허용")
-                } else { // 알림 거부
-                    Log.info("알림 거부")
-                }
-
-                if let error = error {
-                    Log.error("Error requesting notification authorization: \(error.localizedDescription)")
-                }
-            }
-        )
-
-        application.registerForRemoteNotifications()
-
-        // Setting Up Cloud Messaging...
-        // 메세징 델리겟
-        Messaging.messaging().delegate = self
-
-        UNUserNotificationCenter.current().delegate = self
-        return true
+        Log.info("📊 Firebase Analytics Initialized")
     }
 
     /// fcm 토큰이 등록 되었을 때

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         FirebaseApp.configure()
 
         setupNotification(application)
-        requestTrackingPermissionAndInitializeAnalytics(application, launchOptions)
+        AnalyticsManager.shared.initialize(application: application, didFinishLaunchingWithOptions: launchOptions)
 
         application.registerForRemoteNotifications()
         Messaging.messaging().delegate = self
@@ -29,7 +29,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     /// 🔔 **알림 설정**
-    private func setupNotification(_ application: UIApplication) {
+    private func setupNotification(_: UIApplication) {
         UNUserNotificationCenter.current().delegate = self
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
 
@@ -43,44 +43,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             if let error = error {
                 Log.error("Error requesting notification authorization: \(error.localizedDescription)")
             }
-
-            // 알림 요청 후 1초 뒤 앱 추적 권한 요청 실행
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                self.requestTrackingPermissionAndInitializeAnalytics(application, nil)
-            }
         }
     }
-
-    /// 📊 **앱 추적 권한 요청 및 Firebase Analytics 초기화**
-    private func requestTrackingPermissionAndInitializeAnalytics(_ application: UIApplication, _ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        let status = ATTrackingManager.trackingAuthorizationStatus
-
-        if status == .authorized {
-            initializeAnalytics(application, launchOptions) // 추적 허용된 경우 실행
-        } else if status == .notDetermined {
-            // 권한 요청 후 승인된 경우 실행
-            ATTrackingManager.requestTrackingAuthorization { newStatus in
-                if newStatus == .authorized {
-                    DispatchQueue.main.async {
-                        self.initializeAnalytics(application, launchOptions)
-                    }
-                }
-            }
-        }
-    }
-
-    /// Firebase Analytics 초기화
-    private func initializeAnalytics(_ application: UIApplication, _ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        let firebaseAnalyticsService = FirebaseAnalyticsService()
-        AnalyticsManager.shared.addService(firebaseAnalyticsService)
-
-        if let launchOptions = launchOptions {
-            AnalyticsManager.shared.initialize(application: application, didFinishLaunchingWithOptions: launchOptions)
-        }
-
-        Log.info("📊 Firebase Analytics Initialized")
-    }
-
+    
     /// fcm 토큰이 등록 되었을 때
     func application(_: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken

--- a/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/App/AppDelegate.swift
@@ -1,5 +1,3 @@
-import AdSupport
-import AppTrackingTransparency
 import Firebase
 import FirebaseCore
 import FirebaseMessaging

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatRoom/View/ChatRoomView.swift
@@ -21,7 +21,7 @@ struct ChatRoomView: View {
 
     let chatRoomId: Int64?
     var chatRoom: ChatRoomProtocol?
-    private let currentUserId = getUserData()!.id
+    private let currentUserId = getUserData()?.id ?? 0
 
     var body: some View {
         ZStack {

--- a/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/Clean/Presentation/Scene/ChatSideMenu/View/ChatSideMenuView.swift
@@ -114,7 +114,7 @@ private struct SideMenuContent: View {
     let members: [ChatMemberItemModel]
     let onUserSelect: (ChatMemberItemModel) -> Void
     
-    private let currentUserId = getUserData()!.id
+    private let currentUserId = getUserData()?.id ?? 0
     
     var body: some View {
         VStack(alignment: .leading) {

--- a/pennyway-client-iOS/pennyway-client-iOS/Info.plist
+++ b/pennyway-client-iOS/pennyway-client-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>더 나은 맞춤 서비스와 콘텐츠 제공을 위해 사용되며, 서비스 이외의 목적으로는 사용되지 않습니다.</string>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>

--- a/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/View/TabView/MainTabView.swift
@@ -58,7 +58,7 @@ struct MainTabView: View {
         .onChange(of: navigationState.shouldNavigateToChatRoom) { showNavigate in
             if showNavigate {
                 // 딥링크를 통해 채팅 탭으로 이동
-                selection = 2
+                viewModel.selection = 2
                 Log.debug("[MainTabView]: \(String(describing: navigationState.selectedChatRoomId))")
 
                 DispatchQueue.main.async {

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -8,6 +8,7 @@ class AppViewModel: ObservableObject {
     @Published var isLoggedIn: Bool = false
     @Published var isSplashShown: Bool = false
     @Published var checkLoginState = false
+    let profileInfoViewModel = UserAccountViewModel()
 
     private var cancellables = Set<AnyCancellable>()
     private let loginUseCase: LoginUseCase
@@ -36,11 +37,20 @@ class AppViewModel: ObservableObject {
 
     func checkLoginStateUseCase() {
         loginUseCase.checkLoginState { [weak self] isLoggedIn in
-            self?.checkLoginState = isLoggedIn
-            self?.isLoggedIn = isLoggedIn
             if isLoggedIn {
-                self?.registDeviceTokenApi()
-                Log.debug("accessToken: \(KeychainHelper.loadAccessToken())")
+                self?.profileInfoViewModel.getUserProfileApi { success, userId in
+                    if success, let userId = userId {
+                        AnalyticsManager.shared.setUser("userId = \(userId)")
+                        AnalyticsManager.shared.trackEvent(AuthEvents.login, additionalParams: [
+                            AnalyticsConstants.Parameter.oauthType: OAuthRegistrationManager.shared.provider,
+                            AnalyticsConstants.Parameter.isRefresh: false,
+                        ])
+                        self?.checkLoginState = isLoggedIn
+                        self?.isLoggedIn = isLoggedIn
+                        self?.registDeviceTokenApi()
+                        Log.debug("[AppViewModel] accessToken: \(KeychainHelper.loadAccessToken())")
+                    }
+                }
             }
         }
     }

--- a/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
+++ b/pennyway-client-iOS/pennyway-client-iOS/ViewModel/AppViewModel.swift
@@ -1,5 +1,7 @@
 
+import AppTrackingTransparency
 import Combine
+import Firebase
 import SwiftUI
 
 // MARK: - AppViewModel
@@ -8,7 +10,6 @@ class AppViewModel: ObservableObject {
     @Published var isLoggedIn: Bool = false
     @Published var isSplashShown: Bool = false
     @Published var checkLoginState = false
-    let profileInfoViewModel = UserAccountViewModel()
 
     private var cancellables = Set<AnyCancellable>()
     private let loginUseCase: LoginUseCase
@@ -33,24 +34,16 @@ class AppViewModel: ObservableObject {
     func login() {
         registDeviceTokenApi()
         isLoggedIn = true
+        requestTrackingPermissionAndInitializeAnalytics()
     }
 
     func checkLoginStateUseCase() {
         loginUseCase.checkLoginState { [weak self] isLoggedIn in
             if isLoggedIn {
-                self?.profileInfoViewModel.getUserProfileApi { success, userId in
-                    if success, let userId = userId {
-                        AnalyticsManager.shared.setUser("userId = \(userId)")
-                        AnalyticsManager.shared.trackEvent(AuthEvents.login, additionalParams: [
-                            AnalyticsConstants.Parameter.oauthType: OAuthRegistrationManager.shared.provider,
-                            AnalyticsConstants.Parameter.isRefresh: false,
-                        ])
-                        self?.checkLoginState = isLoggedIn
-                        self?.isLoggedIn = isLoggedIn
-                        self?.registDeviceTokenApi()
-                        Log.debug("[AppViewModel] accessToken: \(KeychainHelper.loadAccessToken())")
-                    }
-                }
+                self?.checkLoginState = isLoggedIn
+                self?.isLoggedIn = isLoggedIn
+                self?.registDeviceTokenApi()
+                Log.debug("[AppViewModel] accessToken: \(KeychainHelper.loadAccessToken())")
             }
         }
     }
@@ -83,5 +76,30 @@ class AppViewModel: ObservableObject {
         } else {
             Log.fault("fcm Token 존재 x")
         }
+    }
+
+    /// 앱 추적 권한 요청 및 Firebase Analytics 초기화
+    private func requestTrackingPermissionAndInitializeAnalytics() {
+        let status = ATTrackingManager.trackingAuthorizationStatus
+
+        if status == .authorized {
+            initializeAnalytics() // 추적 허용된 경우 실행
+        } else if status == .notDetermined {
+            ATTrackingManager.requestTrackingAuthorization { newStatus in
+                if newStatus == .authorized {
+                    DispatchQueue.main.async {
+                        self.initializeAnalytics()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Firebase Analytics 초기화
+    private func initializeAnalytics() {
+        let firebaseAnalyticsService = FirebaseAnalyticsService()
+        AnalyticsManager.shared.addService(firebaseAnalyticsService)
+
+        Log.info("📊 Firebase Analytics Initialized")
     }
 }


### PR DESCRIPTION
## 작업 이유

- 사용자 추적 금지 요청 팝업 적용

<br/>

## 작업 사항

### 1️⃣ 사용자 추적 금지 요청 팝업 적용

추적 금지 요청은 로그인 후 나오도록 정하였다. 

추적 금지 요청 허용 => 구글 애널리틱스 적용
추적 금지 요청 허용하지 않음 => 구글 애널리틱스 적용 x

![image](https://github.com/user-attachments/assets/591845a2-7ce8-4653-ae7c-0f5b33d4a91a)

추적 금지 요청 상단 문구는 애플에서 제공해줘서 고정 문구이고, 하단의 문구만 변경할 수 있어서 임시로 "더 나은 맞춤 서비스와 콘텐츠 제공을 위해 사용되며, 서비스 이외의 목적으로는 사용되지 않습니다."이라고 정하였고 디자인팀의 답변을 받으면 바꿀 예정이다.

- 동작 과정

![Simulator Screen Recording - iPhone 15 Pro - 2025-02-06 at 22 13 44](https://github.com/user-attachments/assets/fdd536c9-a0a0-416a-a385-5f85f1c128f8)




<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

사용자 추적 금지 요청 팝업 적용했습니다~


<br/>

## 발견한 이슈
없음